### PR TITLE
feat: secure reference photos for process templates

### DIFF
--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
@@ -82,6 +82,7 @@ class ProcessTemplateManagementController extends Controller
             'steps' => fn($q) => $q->orderBy('step_number', 'asc'),
             'steps.workstation.line',
             'steps.processSegment',
+            'photos.uploadedBy',
         ]);
         $workstations    = Workstation::active()->with('line')->orderBy('name')->get();
         $processSegments = \App\Models\ProcessSegment::query()
@@ -114,6 +115,17 @@ class ProcessTemplateManagementController extends Controller
                         'id'   => $s->processSegment->id,
                         'code' => $s->processSegment->code,
                     ] : null,
+                ]),
+                'photos'     => $processTemplate->photos->map(fn($p) => [
+                    'id'            => $p->id,
+                    'url'           => route('process-templates.photos.show', [$processTemplate, $p]),
+                    'original_name' => $p->original_name,
+                    'caption'       => $p->caption,
+                    'width'         => $p->width,
+                    'height'        => $p->height,
+                    'file_size'     => $p->file_size_human ?? null,
+                    'uploaded_by'   => $p->uploadedBy?->name,
+                    'created_at'    => $p->created_at->format('Y-m-d H:i'),
                 ]),
             ],
             'workstations'    => $workstations->map(fn($w) => [

--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplatePhotoController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplatePhotoController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers\Web\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProcessTemplatePhotoRequest;
+use App\Models\ProcessTemplate;
+use App\Models\ProcessTemplatePhoto;
+use App\Models\ProductType;
+use App\Services\Media\ImageSanitizer;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+/**
+ * Reference photos for process templates (work instructions).
+ *
+ * Security model:
+ *  - Upload/delete: admin-only routes (role:Admin) + throttle.
+ *  - Every file is re-encoded from raw pixels (ImageSanitizer) — polyglot
+ *    payloads, embedded scripts and EXIF never reach the disk.
+ *  - Files live on the PRIVATE local disk under a server-generated random
+ *    name; the client filename is metadata only. Nothing is web-reachable
+ *    directly — viewing goes through the authenticated streaming endpoint.
+ *  - All photo routes are scoped to the template/product-type in the URL
+ *    (mismatch = 404), so IDs can't be swapped across entities (IDOR).
+ */
+class ProcessTemplatePhotoController extends Controller
+{
+    public function store(
+        StoreProcessTemplatePhotoRequest $request,
+        ProductType $productType,
+        ProcessTemplate $processTemplate,
+        ImageSanitizer $sanitizer,
+    ) {
+        $this->ensureBelongs($productType, $processTemplate);
+
+        if ($processTemplate->photos()->count() >= StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE) {
+            return back()->withErrors([
+                'photo' => 'Photo limit reached ('.StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE.' per template).',
+            ]);
+        }
+
+        try {
+            $clean = $sanitizer->sanitize($request->file('photo')->getRealPath());
+        } catch (InvalidArgumentException $e) {
+            return back()->withErrors(['photo' => $e->getMessage()]);
+        }
+
+        // Server-generated random name on the private disk — never the
+        // client filename, never a client-supplied extension.
+        $path = 'process-template-photos/'.$processTemplate->id.'/'.Str::random(40).'.'.$clean['extension'];
+        Storage::put($path, $clean['bytes']);
+
+        $processTemplate->photos()->create([
+            'original_name' => Str::limit($request->file('photo')->getClientOriginalName(), 255, ''),
+            'storage_path' => $path,
+            'mime_type' => $clean['mime'],
+            'file_size' => strlen($clean['bytes']),
+            'width' => $clean['width'],
+            'height' => $clean['height'],
+            'caption' => $request->validated('caption'),
+            'sort_order' => ($processTemplate->photos()->max('sort_order') ?? 0) + 1,
+            'uploaded_by_id' => $request->user()->id,
+        ]);
+
+        return back()->with('success', 'Photo uploaded.');
+    }
+
+    public function destroy(
+        ProductType $productType,
+        ProcessTemplate $processTemplate,
+        ProcessTemplatePhoto $photo,
+    ) {
+        $this->ensureBelongs($productType, $processTemplate, $photo);
+
+        $photo->delete(); // model event removes the file from disk
+
+        return back()->with('success', 'Photo deleted.');
+    }
+
+    /**
+     * Stream a photo to any authenticated user (operators need work
+     * instructions too — route lives outside the admin group). Never
+     * a public URL.
+     */
+    public function show(
+        ProcessTemplate $processTemplate,
+        ProcessTemplatePhoto $photo,
+    ) {
+        abort_unless($photo->process_template_id === $processTemplate->id, 404);
+
+        abort_unless(Storage::exists($photo->storage_path), 404);
+
+        // mime_type comes from our own re-encode — known-safe raster type.
+        return Storage::response($photo->storage_path, null, [
+            'Content-Type' => $photo->mime_type,
+            'Content-Disposition' => 'inline',
+            'X-Content-Type-Options' => 'nosniff',
+            'Cache-Control' => 'private, max-age=3600',
+        ]);
+    }
+
+    /**
+     * URL-scope guard: every segment must belong to its parent, or 404.
+     */
+    private function ensureBelongs(
+        ProductType $productType,
+        ProcessTemplate $processTemplate,
+        ?ProcessTemplatePhoto $photo = null,
+    ): void {
+        abort_unless($processTemplate->product_type_id === $productType->id, 404);
+
+        if ($photo) {
+            abort_unless($photo->process_template_id === $processTemplate->id, 404);
+        }
+    }
+}

--- a/backend/app/Http/Requests/StoreProcessTemplatePhotoRequest.php
+++ b/backend/app/Http/Requests/StoreProcessTemplatePhotoRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\File;
+
+class StoreProcessTemplatePhotoRequest extends FormRequest
+{
+    /** Hard cap on photos per template (DoS / storage abuse guard). */
+    public const MAX_PHOTOS_PER_TEMPLATE = 20;
+
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + role:Admin middleware
+    }
+
+    public function rules(): array
+    {
+        return [
+            // First validation layer (cheap). The authoritative content check
+            // is the GD re-encode in ImageSanitizer — this rule only filters
+            // the obvious junk early. SVG is intentionally NOT accepted.
+            'photo' => [
+                'required',
+                File::types(['jpg', 'jpeg', 'png', 'webp'])
+                    ->max(10 * 1024), // 10 MB
+            ],
+            'caption' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/backend/app/Models/ProcessTemplate.php
+++ b/backend/app/Models/ProcessTemplate.php
@@ -60,6 +60,14 @@ class ProcessTemplate extends Model
     }
 
     /**
+     * Reference photos (work instructions) for this template.
+     */
+    public function photos(): HasMany
+    {
+        return $this->hasMany(ProcessTemplatePhoto::class)->orderBy('sort_order')->orderBy('id');
+    }
+
+    /**
      * Generate a JSON snapshot of this template for work order storage.
      * This ensures work orders are immune to template changes.
      */

--- a/backend/app/Models/ProcessTemplatePhoto.php
+++ b/backend/app/Models/ProcessTemplatePhoto.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessTemplatePhoto extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'process_template_id',
+        'original_name',
+        'storage_path',
+        'mime_type',
+        'file_size',
+        'width',
+        'height',
+        'caption',
+        'sort_order',
+        'uploaded_by_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'file_size' => 'integer',
+            'width' => 'integer',
+            'height' => 'integer',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        // Keep disk and DB consistent — deleting the row removes the file.
+        static::deleted(function (ProcessTemplatePhoto $photo) {
+            Storage::delete($photo->storage_path);
+        });
+    }
+
+    public function processTemplate(): BelongsTo
+    {
+        return $this->belongsTo(ProcessTemplate::class);
+    }
+
+    public function uploadedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by_id');
+    }
+
+    /**
+     * Get a human-readable file size string.
+     */
+    public function getFileSizeHumanAttribute(): string
+    {
+        $bytes = $this->file_size ?? 0;
+
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        if ($bytes < 1_048_576) {
+            return round($bytes / 1024, 1).' KB';
+        }
+
+        return round($bytes / 1_048_576, 1).' MB';
+    }
+}

--- a/backend/app/Services/Media/ImageSanitizer.php
+++ b/backend/app/Services/Media/ImageSanitizer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\Media;
+
+use InvalidArgumentException;
+
+/**
+ * Security gate for user-uploaded images.
+ *
+ * Every accepted image is fully DECODED and RE-ENCODED from raw pixels via GD.
+ * This is the core defense: the stored file contains only pixel data produced
+ * by this server, so anything smuggled inside the original is destroyed —
+ * PHP/script payloads appended to a valid image (polyglot files), malicious
+ * EXIF/ICC chunks, and embedded metadata (incl. GPS) never reach the disk.
+ *
+ * Only raster formats are accepted. SVG is rejected by design (XML — can
+ * carry scripts), as is GIF (low value for work instructions, extra parser
+ * surface). The output format always matches the validated input format.
+ */
+class ImageSanitizer
+{
+    /** Formats we re-encode. Keys are the GD image types. */
+    private const SUPPORTED = [
+        IMAGETYPE_JPEG => ['mime' => 'image/jpeg', 'extension' => 'jpg'],
+        IMAGETYPE_PNG => ['mime' => 'image/png', 'extension' => 'png'],
+        IMAGETYPE_WEBP => ['mime' => 'image/webp', 'extension' => 'webp'],
+    ];
+
+    public const MAX_DIMENSION = 8000; // px — decompression-bomb guard
+
+    /**
+     * Decode + re-encode an uploaded image file.
+     *
+     * @param  string  $sourcePath  absolute path of the uploaded temp file
+     * @return array{bytes: string, mime: string, extension: string, width: int, height: int}
+     *
+     * @throws InvalidArgumentException when the file is not a clean raster image
+     */
+    public function sanitize(string $sourcePath): array
+    {
+        // Type detection from CONTENT (magic bytes), never from name/headers.
+        $info = @getimagesize($sourcePath);
+        if ($info === false || ! isset(self::SUPPORTED[$info[2]])) {
+            throw new InvalidArgumentException('File is not a supported image (JPEG, PNG, WebP).');
+        }
+
+        [$width, $height] = $info;
+        if ($width < 1 || $height < 1) {
+            throw new InvalidArgumentException('Image has invalid dimensions.');
+        }
+        if ($width > self::MAX_DIMENSION || $height > self::MAX_DIMENSION) {
+            throw new InvalidArgumentException(
+                'Image dimensions exceed the '.self::MAX_DIMENSION.'px limit.'
+            );
+        }
+
+        $format = self::SUPPORTED[$info[2]];
+
+        // Full decode — fails on truncated/corrupt files that spoof magic bytes.
+        $image = @imagecreatefromstring((string) file_get_contents($sourcePath));
+        if ($image === false) {
+            throw new InvalidArgumentException('Image could not be decoded.');
+        }
+
+        // PNG/WebP may carry alpha — preserve it through the re-encode.
+        imagesavealpha($image, true);
+
+        ob_start();
+        $encoded = match ($info[2]) {
+            IMAGETYPE_JPEG => imagejpeg($image, null, 90),
+            IMAGETYPE_PNG => imagepng($image, null, 6),
+            IMAGETYPE_WEBP => imagewebp($image, null, 90),
+        };
+        $bytes = ob_get_clean();
+        imagedestroy($image);
+
+        if (! $encoded || $bytes === false || $bytes === '') {
+            throw new InvalidArgumentException('Image could not be re-encoded.');
+        }
+
+        return [
+            'bytes' => $bytes,
+            'mime' => $format['mime'],
+            'extension' => $format['extension'],
+            'width' => $width,
+            'height' => $height,
+        ];
+    }
+}

--- a/backend/database/factories/ProcessTemplatePhotoFactory.php
+++ b/backend/database/factories/ProcessTemplatePhotoFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProcessTemplate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class ProcessTemplatePhotoFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'process_template_id' => ProcessTemplate::factory(),
+            'original_name' => fake()->word().'.jpg',
+            'storage_path' => 'process-template-photos/1/'.Str::random(40).'.jpg',
+            'mime_type' => 'image/jpeg',
+            'file_size' => fake()->numberBetween(10_000, 500_000),
+            'width' => 800,
+            'height' => 600,
+            'caption' => null,
+            'sort_order' => 1,
+            'uploaded_by_id' => null,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_06_06_120000_create_process_template_photos_table.php
+++ b/backend/database/migrations/2026_06_06_120000_create_process_template_photos_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('process_template_photos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('process_template_id')->constrained()->cascadeOnDelete();
+            // Client filename is metadata ONLY — never used on the filesystem.
+            $table->string('original_name', 255);
+            // Random hash name under a private disk path.
+            $table->string('storage_path', 255);
+            // Set from the server-side re-encode, never from the client.
+            $table->string('mime_type', 50);
+            $table->unsignedBigInteger('file_size');
+            $table->unsignedInteger('width');
+            $table->unsignedInteger('height');
+            $table->string('caption', 255)->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->foreignId('uploaded_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['process_template_id', 'sort_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('process_template_photos');
+    }
+};

--- a/backend/resources/js/Pages/admin/process-templates/Show.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Show.jsx
@@ -615,6 +615,9 @@ export default function ProcessTemplatesShow() {
                     </div>
                 )}
 
+                {/* Reference photos (work instructions) */}
+                <PhotosSection productType={productType} processTemplate={processTemplate} />
+
                 {/* Drag-sort save status toast */}
                 {saveStatus && (
                     <div
@@ -633,6 +636,154 @@ export default function ProcessTemplatesShow() {
                 )}
             </div>
         </>
+    );
+}
+
+/**
+ * Reference photos for the template. Upload accepts JPEG/PNG/WebP only;
+ * the server re-encodes every image (strips EXIF and any embedded payloads)
+ * and serves files through an authenticated endpoint — never a public URL.
+ */
+function PhotosSection({ productType, processTemplate }) {
+    const photos = processTemplate.photos ?? [];
+    const baseUrl = `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/photos`;
+
+    const form = useForm({ photo: null, caption: '' });
+    const fileInputRef = useRef(null);
+    const [lightbox, setLightbox] = useState(null); // photo object or null
+
+    const submit = (e) => {
+        e.preventDefault();
+        if (!form.data.photo) return;
+        form.post(baseUrl, {
+            preserveScroll: true,
+            forceFormData: true,
+            onSuccess: () => {
+                form.reset();
+                if (fileInputRef.current) fileInputRef.current.value = '';
+            },
+        });
+    };
+
+    const handleDelete = (photo) => {
+        if (!confirm('Delete this photo?')) return;
+        router.delete(`${baseUrl}/${photo.id}`, { preserveScroll: true });
+    };
+
+    return (
+        <div className="mt-10">
+            <div className="flex items-center gap-2 mb-4">
+                <h2 className="text-xl font-bold text-gray-800">Reference Photos</h2>
+                <span className="text-sm text-gray-500">({photos.length}/20)</span>
+            </div>
+
+            {/* Upload form */}
+            <form onSubmit={submit} className="card mb-4 flex flex-wrap items-end gap-3">
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Photo <span className="text-xs text-gray-400">(JPEG/PNG/WebP, max 10 MB)</span>
+                    </label>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp"
+                        onChange={(e) => form.setData('photo', e.target.files[0] ?? null)}
+                        className="block text-sm text-gray-600 file:mr-3 file:px-3 file:py-1.5 file:rounded-lg file:border-0 file:bg-blue-50 file:text-blue-700 file:text-sm file:font-medium hover:file:bg-blue-100"
+                    />
+                </div>
+                <div className="flex-1 min-w-[200px]">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Caption</label>
+                    <input
+                        type="text"
+                        value={form.data.caption}
+                        onChange={(e) => form.setData('caption', e.target.value)}
+                        maxLength={255}
+                        placeholder="Optional description"
+                        className="form-input w-full"
+                    />
+                </div>
+                <button
+                    type="submit"
+                    disabled={form.processing || !form.data.photo}
+                    className="btn-touch btn-primary disabled:opacity-50"
+                >
+                    {form.processing ? 'Uploading…' : 'Upload'}
+                </button>
+                {form.errors.photo && <p className="w-full text-sm text-red-600">{form.errors.photo}</p>}
+                {form.errors.caption && <p className="w-full text-sm text-red-600">{form.errors.caption}</p>}
+            </form>
+
+            {/* Photo grid */}
+            {photos.length > 0 ? (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+                    {photos.map((photo) => (
+                        <div key={photo.id} className="card p-2 group relative">
+                            <button
+                                type="button"
+                                onClick={() => setLightbox(photo)}
+                                className="block w-full"
+                                title={photo.original_name}
+                            >
+                                <img
+                                    src={photo.url}
+                                    alt={photo.caption || photo.original_name}
+                                    loading="lazy"
+                                    className="w-full h-32 object-cover rounded-lg bg-gray-100"
+                                />
+                            </button>
+                            <div className="mt-2 text-xs text-gray-600 truncate" title={photo.caption || ''}>
+                                {photo.caption || <span className="text-gray-400">No caption</span>}
+                            </div>
+                            <div className="text-[10px] text-gray-400">
+                                {photo.width}×{photo.height} • {photo.file_size}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => handleDelete(photo)}
+                                className="absolute top-3 right-3 bg-white/90 text-red-600 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity shadow"
+                                title="Delete photo"
+                            >
+                                <Icon d="M6 18L18 6M6 6l12 12" className="w-4 h-4" />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <div className="card text-center py-8 text-sm text-gray-500">
+                    No reference photos yet. Upload assembly/work-instruction images for operators.
+                </div>
+            )}
+
+            {/* Lightbox */}
+            {lightbox && (
+                <div
+                    className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-6"
+                    onClick={() => setLightbox(null)}
+                >
+                    <figure className="max-w-4xl max-h-full" onClick={(e) => e.stopPropagation()}>
+                        <img
+                            src={lightbox.url}
+                            alt={lightbox.caption || lightbox.original_name}
+                            className="max-w-full max-h-[80vh] rounded-lg shadow-2xl"
+                        />
+                        <figcaption className="text-white/90 text-sm mt-3 text-center">
+                            {lightbox.caption || lightbox.original_name}
+                            {lightbox.uploaded_by && (
+                                <span className="text-white/50"> — {lightbox.uploaded_by}, {lightbox.created_at}</span>
+                            )}
+                        </figcaption>
+                    </figure>
+                    <button
+                        type="button"
+                        onClick={() => setLightbox(null)}
+                        className="absolute top-5 right-5 text-white/80 hover:text-white"
+                        title="Close"
+                    >
+                        <Icon d="M6 18L18 6M6 6l12 12" className="w-8 h-8" />
+                    </button>
+                </div>
+            )}
+        </div>
     );
 }
 

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -145,6 +145,11 @@ Route::middleware('auth')->group(function () {
         return response()->json(['count' => $count]);
     })->name('maintenance.upcoming-count');
 
+    // Process template reference photos — streamed to any authenticated user
+    // (operators see work instructions); files are NEVER publicly reachable.
+    Route::get('/process-templates/{process_template}/photos/{photo}', [\App\Http\Controllers\Web\Admin\ProcessTemplatePhotoController::class, 'show'])
+        ->name('process-templates.photos.show');
+
     // Settings
     Route::prefix('settings')->name('settings.')->group(function () {
         Route::get('/', [\App\Http\Controllers\Web\SettingsController::class, 'index'])->name('index');
@@ -391,6 +396,11 @@ Route::middleware('auth')->group(function () {
             Route::post('/{process_template}/steps/reorder', [\App\Http\Controllers\Web\Admin\ProcessTemplateManagementController::class, 'reorderSteps'])->name('reorder-steps');
             Route::post('/{process_template}/steps/{step}/move-up', [\App\Http\Controllers\Web\Admin\ProcessTemplateManagementController::class, 'moveStepUp'])->name('move-step-up');
             Route::post('/{process_template}/steps/{step}/move-down', [\App\Http\Controllers\Web\Admin\ProcessTemplateManagementController::class, 'moveStepDown'])->name('move-step-down');
+
+            // Reference photos (work instructions) — uploads throttled (DoS guard)
+            Route::post('/{process_template}/photos', [\App\Http\Controllers\Web\Admin\ProcessTemplatePhotoController::class, 'store'])
+                ->middleware('throttle:30,1')->name('photos.store');
+            Route::delete('/{process_template}/photos/{photo}', [\App\Http\Controllers\Web\Admin\ProcessTemplatePhotoController::class, 'destroy'])->name('photos.destroy');
 
             // BOM Management (nested under process templates)
             Route::get('/{process_template}/bom', [BomManagementController::class, 'index'])->name('bom');

--- a/backend/tests/Feature/ProcessTemplatePhotoTest.php
+++ b/backend/tests/Feature/ProcessTemplatePhotoTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\StoreProcessTemplatePhotoRequest;
+use App\Models\ProcessTemplate;
+use App\Models\ProcessTemplatePhoto;
+use App\Models\ProductType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ProcessTemplatePhotoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $operator;
+
+    private ProductType $productType;
+
+    private ProcessTemplate $template;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Operator', 'guard_name' => 'web']);
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+
+        $this->operator = User::factory()->create();
+        $this->operator->assignRole('Operator');
+
+        $this->productType = ProductType::factory()->create();
+        $this->template = ProcessTemplate::factory()->create([
+            'product_type_id' => $this->productType->id,
+        ]);
+    }
+
+    private function uploadUrl(?ProcessTemplate $template = null, ?ProductType $productType = null): string
+    {
+        $template ??= $this->template;
+        $productType ??= $this->productType;
+
+        return "/admin/product-types/{$productType->id}/process-templates/{$template->id}/photos";
+    }
+
+    // ── Happy path ───────────────────────────────────────────────────────
+
+    public function test_admin_can_upload_photo(): void
+    {
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('instruction.jpg', 800, 600),
+            'caption' => 'Step 3 assembly detail',
+        ]);
+
+        $response->assertRedirect()->assertSessionHas('success');
+
+        $photo = ProcessTemplatePhoto::first();
+        $this->assertNotNull($photo);
+        $this->assertSame($this->template->id, $photo->process_template_id);
+        $this->assertSame('instruction.jpg', $photo->original_name);
+        $this->assertSame('Step 3 assembly detail', $photo->caption);
+        $this->assertSame('image/jpeg', $photo->mime_type);
+        $this->assertSame(800, $photo->width);
+        $this->assertSame($this->admin->id, $photo->uploaded_by_id);
+        Storage::assertExists($photo->storage_path);
+
+        // Server-generated random filename — never the client's name
+        $this->assertStringNotContainsString('instruction', $photo->storage_path);
+    }
+
+    public function test_authenticated_user_can_view_photo_with_safe_headers(): void
+    {
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.png', 100, 100),
+        ]);
+        $photo = ProcessTemplatePhoto::first();
+
+        $response = $this->actingAs($this->operator)
+            ->get("/process-templates/{$this->template->id}/photos/{$photo->id}");
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $this->assertStringContainsString('inline', (string) $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_admin_can_delete_photo_and_file_is_removed(): void
+    {
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.jpg'),
+        ]);
+        $photo = ProcessTemplatePhoto::first();
+        $path = $photo->storage_path;
+
+        $response = $this->actingAs($this->admin)
+            ->delete($this->uploadUrl()."/{$photo->id}");
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('process_template_photos', ['id' => $photo->id]);
+        Storage::assertMissing($path);
+    }
+
+    // ── Malicious upload rejection ───────────────────────────────────────
+
+    public function test_php_payload_appended_to_image_is_destroyed_on_disk(): void
+    {
+        // Polyglot: valid PNG + appended PHP webshell
+        $file = UploadedFile::fake()->image('innocent.png', 50, 50);
+        file_put_contents($file->getRealPath(), '<?php system($_GET["c"]); ?>', FILE_APPEND);
+
+        $this->actingAs($this->admin)
+            ->post($this->uploadUrl(), ['photo' => $file])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $stored = Storage::get(ProcessTemplatePhoto::first()->storage_path);
+        $this->assertStringNotContainsString('<?php', $stored);
+        $this->assertStringNotContainsString('system(', $stored);
+    }
+
+    public function test_rejects_php_file_disguised_as_jpg(): void
+    {
+        $file = UploadedFile::fake()->createWithContent('shell.jpg', '<?php echo "owned"; ?>');
+
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), ['photo' => $file]);
+
+        $response->assertSessionHasErrors('photo');
+        $this->assertDatabaseCount('process_template_photos', 0);
+    }
+
+    public function test_rejects_svg(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>';
+        $file = UploadedFile::fake()->createWithContent('xss.svg', $svg);
+
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), ['photo' => $file]);
+
+        $response->assertSessionHasErrors('photo');
+        $this->assertDatabaseCount('process_template_photos', 0);
+    }
+
+    public function test_rejects_oversized_file(): void
+    {
+        $file = UploadedFile::fake()->create('big.jpg', 11 * 1024, 'image/jpeg'); // 11 MB
+
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), ['photo' => $file]);
+
+        $response->assertSessionHasErrors('photo');
+    }
+
+    public function test_enforces_photo_limit_per_template(): void
+    {
+        ProcessTemplatePhoto::factory()
+            ->count(StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE)
+            ->create(['process_template_id' => $this->template->id]);
+
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('one-too-many.jpg'),
+        ]);
+
+        $response->assertSessionHasErrors('photo');
+        $this->assertDatabaseCount(
+            'process_template_photos',
+            StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE,
+        );
+    }
+
+    // ── Authorization ────────────────────────────────────────────────────
+
+    public function test_guest_cannot_upload_or_view(): void
+    {
+        $this->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.jpg'),
+        ])->assertRedirect('/login');
+
+        $photo = ProcessTemplatePhoto::factory()->create([
+            'process_template_id' => $this->template->id,
+        ]);
+
+        $this->get("/process-templates/{$this->template->id}/photos/{$photo->id}")
+            ->assertRedirect('/login');
+    }
+
+    public function test_operator_cannot_upload_or_delete(): void
+    {
+        $this->actingAs($this->operator)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.jpg'),
+        ])->assertForbidden();
+
+        $photo = ProcessTemplatePhoto::factory()->create([
+            'process_template_id' => $this->template->id,
+        ]);
+
+        $this->actingAs($this->operator)
+            ->delete($this->uploadUrl()."/{$photo->id}")
+            ->assertForbidden();
+    }
+
+    // ── IDOR / scope ─────────────────────────────────────────────────────
+
+    public function test_photo_cannot_be_accessed_through_foreign_template(): void
+    {
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.jpg'),
+        ]);
+        $photo = ProcessTemplatePhoto::first();
+
+        $otherTemplate = ProcessTemplate::factory()->create([
+            'product_type_id' => ProductType::factory()->create()->id,
+        ]);
+
+        // View through a template the photo does NOT belong to → 404
+        $this->actingAs($this->operator)
+            ->get("/process-templates/{$otherTemplate->id}/photos/{$photo->id}")
+            ->assertNotFound();
+
+        // Delete through a foreign template/product-type pair → 404
+        $this->actingAs($this->admin)
+            ->delete($this->uploadUrl($otherTemplate)."/{$photo->id}")
+            ->assertNotFound();
+    }
+
+    public function test_upload_rejected_for_mismatched_product_type(): void
+    {
+        $otherProductType = ProductType::factory()->create();
+
+        $this->actingAs($this->admin)
+            ->post($this->uploadUrl($this->template, $otherProductType), [
+                'photo' => UploadedFile::fake()->image('a.jpg'),
+            ])
+            ->assertNotFound();
+    }
+}

--- a/backend/tests/Unit/Services/ImageSanitizerTest.php
+++ b/backend/tests/Unit/Services/ImageSanitizerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\Media\ImageSanitizer;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ImageSanitizerTest extends TestCase
+{
+    private ImageSanitizer $sanitizer;
+
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sanitizer = new ImageSanitizer;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_sanitizes_valid_jpeg(): void
+    {
+        $result = $this->sanitizer->sanitize($this->makeImage('jpeg', 100, 50));
+
+        $this->assertSame('image/jpeg', $result['mime']);
+        $this->assertSame('jpg', $result['extension']);
+        $this->assertSame(100, $result['width']);
+        $this->assertSame(50, $result['height']);
+        // Output is itself a decodable image
+        $this->assertNotFalse(@imagecreatefromstring($result['bytes']));
+    }
+
+    public function test_sanitizes_valid_png_and_webp(): void
+    {
+        $this->assertSame('image/png', $this->sanitizer->sanitize($this->makeImage('png'))['mime']);
+        $this->assertSame('image/webp', $this->sanitizer->sanitize($this->makeImage('webp'))['mime']);
+    }
+
+    public function test_destroys_php_payload_appended_to_valid_image(): void
+    {
+        // Polyglot: a real PNG with a PHP webshell appended — still a valid
+        // image for most parsers, lethal if ever executed by a misconfigured
+        // server. The re-encode must strip the payload.
+        $path = $this->makeImage('png');
+        file_put_contents($path, '<?php system($_GET["cmd"]); ?>', FILE_APPEND);
+
+        $result = $this->sanitizer->sanitize($path);
+
+        $this->assertStringNotContainsString('<?php', $result['bytes']);
+        $this->assertStringNotContainsString('system(', $result['bytes']);
+    }
+
+    public function test_rejects_php_file_with_image_extension(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'img').'.jpg';
+        file_put_contents($path, '<?php echo "owned"; ?>');
+        $this->tempFiles[] = $path;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->sanitizer->sanitize($path);
+    }
+
+    public function test_rejects_svg(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'img').'.svg';
+        file_put_contents($path, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+        $this->tempFiles[] = $path;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->sanitizer->sanitize($path);
+    }
+
+    public function test_rejects_gif(): void
+    {
+        $image = imagecreatetruecolor(10, 10);
+        $path = tempnam(sys_get_temp_dir(), 'img');
+        imagegif($image, $path);
+        imagedestroy($image);
+        $this->tempFiles[] = $path;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->sanitizer->sanitize($path);
+    }
+
+    public function test_rejects_fake_magic_bytes_with_garbage_body(): void
+    {
+        // Real JPEG magic bytes followed by garbage — passes naive
+        // signature checks, must fail the full decode.
+        $path = tempnam(sys_get_temp_dir(), 'img');
+        file_put_contents($path, "\xFF\xD8\xFF\xE0".random_bytes(2048));
+        $this->tempFiles[] = $path;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->sanitizer->sanitize($path);
+    }
+
+    public function test_rejects_oversized_dimensions(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('dimensions exceed');
+
+        $this->sanitizer->sanitize($this->makeImage('png', ImageSanitizer::MAX_DIMENSION + 1, 10));
+    }
+
+    public function test_strips_exif_metadata(): void
+    {
+        // JPEG with an EXIF APP1 segment (camera/GPS metadata carrier).
+        $path = $this->makeImage('jpeg');
+        $jpeg = file_get_contents($path);
+        $exif = "\xFF\xE1".pack('n', 20)."Exif\x00\x00FAKEGPSDATA\x00";
+        // Inject APP1 right after SOI marker
+        file_put_contents($path, substr($jpeg, 0, 2).$exif.substr($jpeg, 2));
+
+        $result = $this->sanitizer->sanitize($path);
+
+        $this->assertStringNotContainsString('FAKEGPSDATA', $result['bytes']);
+    }
+
+    /**
+     * Create a real temp image and return its path.
+     */
+    private function makeImage(string $format, int $width = 60, int $height = 40): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        imagefilledrectangle($image, 0, 0, $width, $height, (int) imagecolorallocate($image, 200, 60, 60));
+
+        $path = tempnam(sys_get_temp_dir(), 'img');
+        match ($format) {
+            'jpeg' => imagejpeg($image, $path),
+            'png' => imagepng($image, $path),
+            'webp' => imagewebp($image, $path),
+        };
+        imagedestroy($image);
+
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary

Process templates can now hold **reference photos** (work instructions for operators). Admins upload/delete photos on the template page; any authenticated user can view them. Built with a defense-in-depth security model, as requested.

## Security model

| Threat | Mitigation |
|---|---|
| Polyglot files (valid image + embedded PHP/script payload) | Every upload is **fully decoded and re-encoded from raw pixels** via GD (`ImageSanitizer`) — only server-produced pixel data reaches the disk; payloads, malicious metadata chunks and EXIF (incl. GPS) are destroyed |
| SVG XSS / extra parser surface | SVG and GIF rejected by design — only JPEG/PNG/WebP raster formats |
| MIME spoofing | Type detected from magic bytes + full decode; client filename/headers never trusted (a JPEG header followed by garbage fails the decode) |
| Direct file access / webshell execution | Files live on the **private disk** under server-generated random names — nothing is web-reachable; viewing goes through an authenticated streaming endpoint with `X-Content-Type-Options: nosniff` |
| Path traversal | Storage name is `Str::random(40)` + validated extension; client filename is DB metadata only |
| IDOR | Scoped bindings — photo must belong to the template, template to the product type in the URL, otherwise 404 |
| DoS / storage abuse | 10 MB file limit, 8000px dimension cap (decompression bombs), 20 photos/template, `throttle:30,1` on upload |
| Privilege escalation | Upload/delete behind `role:Admin`; viewing requires authentication; uploads audited (`uploaded_by_id`) |
| Orphaned files | Disk file removed via model `deleted` event; FK cascade from template |

## Implementation

- `ImageSanitizer` service (GD re-encode, reusable for future uploads)
- `process_template_photos` table + `ProcessTemplatePhoto` model
- `ProcessTemplatePhotoController` (store/destroy admin, show streaming)
- `StoreProcessTemplatePhotoRequest` (first validation layer)
- UI: Photos section on the template page — upload with caption, thumbnail grid, lightbox preview, delete

## Tests

21 new tests, all passing:
- Sanitizer unit: polyglot payload destruction, disguised PHP rejection, SVG/GIF rejection, fake-magic-bytes rejection, EXIF stripping, dimension caps
- Feature: upload/view/delete happy paths with safe headers, file cleanup, photo limit, guest/operator authorization, IDOR scoping (foreign template/product-type → 404)

Full suite verified against the develop baseline — identical pre-existing failures only, no regressions.