### PR TITLE
fix(i18n): locale + timezone aware date/time formatting, single-source language whitelist

### DIFF
--- a/backend/app/Http/Controllers/Web/SettingsController.php
+++ b/backend/app/Http/Controllers/Web/SettingsController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -119,7 +120,8 @@ class SettingsController extends Controller
             'scanner_mode' => json_decode($rows['scanner_mode']->value ?? '"hid"', true) ?? 'hid',
         ];
 
-        $availableLocales = ['en' => 'English', 'pl' => 'Polski'];
+        // Same source as the validation rule and the language switcher.
+        $availableLocales = config('app.available_locales', ['en' => 'English']);
 
         // Append CORS fields not in the standard settings map (they may exist in DB)
         $corsRow = DB::table('system_settings')->where('key', 'cors_allowed_methods')->first();
@@ -283,7 +285,8 @@ class SettingsController extends Controller
             'workstation_routing_enabled' => 'nullable|boolean',
             'workflow_mode' => 'required|in:status,board_status',
             'pin_login_enabled' => 'nullable|boolean',
-            'language' => 'nullable|in:en,pl,tr',
+            // Single source of truth — the language switcher's configured locales.
+            'language' => ['nullable', Rule::in(array_keys(config('app.available_locales', [])))],
             'schedule_view_mode' => 'required|in:weekly,daily,monthly',
             'schedule_shifts_per_day' => 'required|integer|in:1,2,3,4',
             'schedule_horizon_weeks' => 'required|integer|min:1|max:52',
@@ -358,7 +361,7 @@ class SettingsController extends Controller
 
         foreach ($tables as $table) {
             try {
-                $export[$table] = DB::table($table)->get()->map(fn($r) => (array) $r)->toArray();
+                $export[$table] = DB::table($table)->get()->map(fn ($r) => (array) $r)->toArray();
             } catch (\Exception $e) {
                 // table may not exist yet
             }
@@ -369,7 +372,7 @@ class SettingsController extends Controller
         foreach ($optionalTables as $table) {
             try {
                 if (Schema::hasTable($table)) {
-                    $export[$table] = DB::table($table)->get()->map(fn($r) => (array) $r)->toArray();
+                    $export[$table] = DB::table($table)->get()->map(fn ($r) => (array) $r)->toArray();
                 }
             } catch (\Exception $e) {
                 // table may not exist yet
@@ -377,7 +380,7 @@ class SettingsController extends Controller
         }
 
         return response()->json($export, 200, [
-            'Content-Disposition' => 'attachment; filename="openmes-config-' . date('Y-m-d') . '.json"',
+            'Content-Disposition' => 'attachment; filename="openmes-config-'.date('Y-m-d').'.json"',
         ]);
     }
 
@@ -399,7 +402,7 @@ class SettingsController extends Controller
             }
 
             // Backward compat: old format with just 'settings' key
-            if (isset($data['settings']) && !isset($data['system_settings'])) {
+            if (isset($data['settings']) && ! isset($data['system_settings'])) {
                 $data['system_settings'] = $data['settings'];
             }
 
@@ -428,28 +431,45 @@ class SettingsController extends Controller
             DB::beginTransaction();
 
             foreach ($data as $tableName => $rows) {
-                if (!in_array($tableName, $allowedTables, true)) continue;
-                if (!is_array($rows)) continue;
-                if (!Schema::hasTable($tableName)) continue;
+                if (! in_array($tableName, $allowedTables, true)) {
+                    continue;
+                }
+                if (! is_array($rows)) {
+                    continue;
+                }
+                if (! Schema::hasTable($tableName)) {
+                    continue;
+                }
 
                 if ($tableName === 'system_settings') {
                     // Special handling: key-value update, not replace
                     $existingKeys = DB::table('system_settings')->pluck('key')->toArray();
 
                     foreach ($rows as $key => $value) {
-                        if (in_array(strtolower($key), $forbiddenSettings, true)) continue;
-                        if (!is_string($value) && !is_numeric($value)) continue;
-                        if (strlen((string) $value) > 1000) continue;
-                        if (!in_array($key, $existingKeys, true)) continue;
+                        if (in_array(strtolower($key), $forbiddenSettings, true)) {
+                            continue;
+                        }
+                        if (! is_string($value) && ! is_numeric($value)) {
+                            continue;
+                        }
+                        if (strlen((string) $value) > 1000) {
+                            continue;
+                        }
+                        if (! in_array($key, $existingKeys, true)) {
+                            continue;
+                        }
 
                         DB::table('system_settings')->where('key', $key)->update(['value' => (string) $value]);
                         $imported++;
                     }
+
                     continue;
                 }
 
                 // For all other tables: upsert by unique key (code or name)
-                if (empty($rows)) continue;
+                if (empty($rows)) {
+                    continue;
+                }
 
                 // Determine unique key for upsert
                 $uniqueKey = match ($tableName) {
@@ -463,7 +483,9 @@ class SettingsController extends Controller
                 };
 
                 foreach ($rows as $row) {
-                    if (!is_array($row)) continue;
+                    if (! is_array($row)) {
+                        continue;
+                    }
 
                     $originalId = $row['id'] ?? null;
 
@@ -472,9 +494,11 @@ class SettingsController extends Controller
                         unset($row[$col]);
                     }
                     // Remove null values for columns that might not accept null
-                    $row = array_filter($row, fn($v) => $v !== null);
+                    $row = array_filter($row, fn ($v) => $v !== null);
 
-                    if (empty($row)) continue;
+                    if (empty($row)) {
+                        continue;
+                    }
 
                     try {
                         DB::statement('SAVEPOINT row_insert');
@@ -490,6 +514,7 @@ class SettingsController extends Controller
                         $imported++;
                     } catch (\Exception $e) {
                         DB::statement('ROLLBACK TO SAVEPOINT row_insert');
+
                         continue;
                     }
                 }
@@ -502,6 +527,7 @@ class SettingsController extends Controller
         } catch (\Exception $e) {
             DB::rollBack();
             report($e);
+
             return back()->with('error', __('Failed to import settings. Please check the file and try again.'));
         }
     }

--- a/backend/app/Http/Middleware/HandleInertiaRequests.php
+++ b/backend/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,9 @@ class HandleInertiaRequests extends Middleware
             // loads the matching lang/<locale>.json chunk itself (see lib/i18n).
             'locale' => fn () => app()->getLocale(),
             'locales' => fn () => config('app.available_locales'),
+            // Plant timezone — the frontend formats all dates/times in this zone
+            // (config/app.php → APP_TIMEZONE) instead of the viewer's browser zone.
+            'timezone' => fn () => config('app.timezone'),
             'flash' => [
                 'success' => fn () => $request->session()->get('success'),
                 'error' => fn () => $request->session()->get('error'),

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -65,7 +65,10 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    // Default UTC keeps stored timestamps unambiguous; override per deployment
+    // (e.g. APP_TIMEZONE=Europe/Warsaw) so server-side date/time reflects the
+    // local plant. The frontend formats in this zone too — shared via Inertia.
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/resources/js/Pages/admin/Dashboard.jsx
+++ b/backend/resources/js/Pages/admin/Dashboard.jsx
@@ -4,6 +4,7 @@ import { useDashboardShapes, DASHBOARD_SHAPES } from '../../lib/useDashboardShap
 import { useShapeConfigs } from '../../lib/useShapeConfigs';
 import { useHotShapes } from '../../components/LiveShapesProvider';
 import AppLayout from '../../layouts/AppLayout';
+import { formatDateTime } from '../../lib/i18n';
 
 const WO_TERMINAL = ['DONE', 'CANCELLED', 'REJECTED'];
 
@@ -157,7 +158,7 @@ function Header({ selectedLineId, onLineChange, lines }) {
             <div>
                 <h1 className="text-3xl font-bold text-gray-800">Admin Dashboard</h1>
                 <p className="text-gray-500 mt-1 text-sm">
-                    {new Date().toLocaleString()}{' '}
+                    {formatDateTime(new Date())}{' '}
                     {selectedLine ? (
                         <>— <span className="font-medium text-blue-600">{selectedLine.name}</span></>
                     ) : (

--- a/backend/resources/js/Pages/admin/alerts/Index.jsx
+++ b/backend/resources/js/Pages/admin/alerts/Index.jsx
@@ -6,6 +6,7 @@ import { useShapeConfigs } from '../../../lib/useShapeConfigs';
 import { useSyncedShape } from '../../../lib/useSyncedShape';
 import { electricCollection } from '../../../lib/electricCollection';
 import { useLiveShapeBudget } from '../../../lib/liveShapeBudget';
+import { formatDate } from '../../../lib/i18n';
 
 /**
  * Admin Alerts — the one screen that exceeded the connection budget (it joins
@@ -301,7 +302,7 @@ function EmptyCard({ text }) {
 function fmtDate(d) {
     if (!d) return '';
     const dt = new Date(d);
-    return Number.isNaN(dt.getTime()) ? '' : dt.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' });
+    return Number.isNaN(dt.getTime()) ? '' : formatDate(dt, { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
 function timeAgo(d) {

--- a/backend/resources/js/Pages/admin/connectivity/Index.jsx
+++ b/backend/resources/js/Pages/admin/connectivity/Index.jsx
@@ -1,7 +1,7 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import { StatusDot } from './ui';
-import { __ } from '../../../lib/i18n';
+import { __, formatNumber } from '../../../lib/i18n';
 
 const PROTOCOL_LABELS = {
     mqtt:   'MQTT',
@@ -99,7 +99,7 @@ export default function ConnectivityIndex() {
 
                                     <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
                                         <span>{count ?? 0} {countLabel}</span>
-                                        {conn.protocol === 'mqtt' && <span>{Number(conn.messages_received).toLocaleString()} {__('msg')}</span>}
+                                        {conn.protocol === 'mqtt' && <span>{formatNumber(Number(conn.messages_received))} {__('msg')}</span>}
                                     </div>
 
                                     {conn.last_connected_at && (

--- a/backend/resources/js/Pages/admin/connectivity/mqtt/Index.jsx
+++ b/backend/resources/js/Pages/admin/connectivity/mqtt/Index.jsx
@@ -1,5 +1,6 @@
 import { Head, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../../layouts/AppLayout';
+import { formatNumber } from '../../../../lib/i18n';
 
 const STATUS_DOT = {
     green:  'bg-green-500',
@@ -94,7 +95,7 @@ export default function MqttIndex() {
                                             </td>
                                             <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{conn.topics_count}</td>
                                             <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
-                                                {Number(conn.messages_received).toLocaleString()}
+                                                {formatNumber(Number(conn.messages_received))}
                                             </td>
                                             <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
                                                 {conn.last_connected_at ?? '—'}

--- a/backend/resources/js/Pages/admin/connectivity/mqtt/Show.jsx
+++ b/backend/resources/js/Pages/admin/connectivity/mqtt/Show.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Head, router, usePage, useForm } from '@inertiajs/react';
 import AppLayout from '../../../../layouts/AppLayout';
+import { formatNumber, formatTime } from '../../../../lib/i18n';
 
 const STATUS_DOT = {
     green:  'bg-green-500',
@@ -96,7 +97,7 @@ export default function MqttShow() {
                 {/* Stats */}
                 <div className="grid grid-cols-3 gap-4">
                     <StatCard value={connection.topics.length} label="Topics" />
-                    <StatCard value={Number(connection.messages_received).toLocaleString()} label="Messages received" />
+                    <StatCard value={formatNumber(Number(connection.messages_received))} label="Messages received" />
                     <StatCard value={connection.status} label={connection.last_connected_at ?? 'Never'} capitalize />
                 </div>
 
@@ -614,7 +615,7 @@ function LiveMessageLog({ initialMessages, initialLastId, messagesUrl }) {
 
     const formatTime = (iso) => {
         if (!iso) return '';
-        try { return new Date(iso).toLocaleTimeString('pl-PL', { hour12: false }); } catch { return iso; }
+        try { return formatTime(new Date(iso), { hour12: false }); } catch { return iso; }
     };
 
     const statusDot = (status) => {

--- a/backend/resources/js/Pages/admin/machine-monitor/Index.jsx
+++ b/backend/resources/js/Pages/admin/machine-monitor/Index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Head, Link, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
-import { __ } from '../../../lib/i18n';
+import { __, formatNumber } from '../../../lib/i18n';
 
 /**
  * Live machine monitor — a tile grid of workstation states, polled from the
@@ -140,8 +140,8 @@ function Tile({ t, now }) {
 
             <div className="grid grid-cols-3 gap-2 text-center mt-4">
                 <Metric label={__('Availability')} value={t.availability != null ? `${t.availability}%` : '—'} />
-                <Metric label={__('Good')} value={Number(t.good ?? 0).toLocaleString()} tone="text-green-600 dark:text-green-400" />
-                <Metric label={__('Reject')} value={Number(t.reject ?? 0).toLocaleString()} tone="text-red-500 dark:text-red-400" />
+                <Metric label={__('Good')} value={formatNumber(Number(t.good ?? 0))} tone="text-green-600 dark:text-green-400" />
+                <Metric label={__('Reject')} value={formatNumber(Number(t.reject ?? 0))} tone="text-red-500 dark:text-red-400" />
             </div>
 
             {t.quality != null && (

--- a/backend/resources/js/Pages/admin/oee/Index.jsx
+++ b/backend/resources/js/Pages/admin/oee/Index.jsx
@@ -1,6 +1,7 @@
 import { Head, router, usePage } from '@inertiajs/react';
 import { useState } from 'react';
 import AppLayout from '../../../layouts/AppLayout';
+import { formatNumber } from '../../../lib/i18n';
 
 const LINE_PALETTE = ['#2563eb', '#db2777', '#0891b2', '#16a34a', '#ea580c', '#7c3aed'];
 
@@ -117,8 +118,8 @@ export default function OeeIndex() {
                                         <MetricMini label="Quality" value={fmt1(s.avg_quality)} />
                                     </div>
                                     <div className="w-full mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 flex justify-around text-xs text-gray-500">
-                                        <span>Produced: {Number(s.total_produced).toLocaleString()}</span>
-                                        <span>Scrap: {Number(s.total_scrap).toLocaleString()}</span>
+                                        <span>Produced: {formatNumber(Number(s.total_produced))}</span>
+                                        <span>Scrap: {formatNumber(Number(s.total_scrap))}</span>
                                         <span>Downtime: {s.total_downtime}min</span>
                                     </div>
                                 </a>
@@ -245,8 +246,8 @@ export default function OeeIndex() {
                                                 <td className="px-3 py-2 text-right">{r.performance_pct != null ? Number(r.performance_pct).toFixed(1) + '%' : '—'}</td>
                                                 <td className="px-3 py-2 text-right">{r.quality_pct != null ? Number(r.quality_pct).toFixed(1) + '%' : '—'}</td>
                                                 <td className={`px-3 py-2 text-right font-bold ${band.text}`}>{r.oee_pct != null ? Number(r.oee_pct).toFixed(1) + '%' : '—'}</td>
-                                                <td className="px-3 py-2 text-right font-mono">{Number(r.total_produced).toLocaleString()}</td>
-                                                <td className="px-3 py-2 text-right font-mono text-red-600">{r.scrap_qty > 0 ? Number(r.scrap_qty).toLocaleString() : '—'}</td>
+                                                <td className="px-3 py-2 text-right font-mono">{formatNumber(Number(r.total_produced))}</td>
+                                                <td className="px-3 py-2 text-right font-mono text-red-600">{r.scrap_qty > 0 ? formatNumber(Number(r.scrap_qty)) : '—'}</td>
                                                 <td className="px-3 py-2 text-right font-mono">{r.downtime_minutes}min</td>
                                             </tr>
                                         );

--- a/backend/resources/js/Pages/admin/oee/Show.jsx
+++ b/backend/resources/js/Pages/admin/oee/Show.jsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
+import { formatNumber } from '../../../lib/i18n';
 
 const KIND_BG = { blue: 'bg-blue-400', amber: 'bg-amber-400', red: 'bg-red-400' };
 const KIND_TEXT = { blue: 'text-blue-700', amber: 'text-amber-700', red: 'text-red-700' };
@@ -137,8 +138,8 @@ export default function OeeShow() {
                                                 <td className={`px-3 py-2 text-right font-bold ${oeeClass}`}>
                                                     {r.oee_pct != null ? Number(r.oee_pct).toFixed(1) + '%' : '—'}
                                                 </td>
-                                                <td className="px-3 py-2 text-right font-mono">{Number(r.total_produced).toLocaleString()}</td>
-                                                <td className="px-3 py-2 text-right font-mono">{r.scrap_qty > 0 ? Number(r.scrap_qty).toLocaleString() : '—'}</td>
+                                                <td className="px-3 py-2 text-right font-mono">{formatNumber(Number(r.total_produced))}</td>
+                                                <td className="px-3 py-2 text-right font-mono">{r.scrap_qty > 0 ? formatNumber(Number(r.scrap_qty)) : '—'}</td>
                                             </tr>
                                         );
                                     })}

--- a/backend/resources/js/Pages/admin/production-anomalies/Index.jsx
+++ b/backend/resources/js/Pages/admin/production-anomalies/Index.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
+import { formatNumber } from '../../../lib/i18n';
 
 const STATUS_STYLES = {
     pending:   'bg-yellow-100 text-yellow-800',
@@ -16,7 +17,7 @@ function deviation(planned, actual) {
 }
 
 function fmt(n, decimals = 2) {
-    return Number(n).toLocaleString(undefined, {
+    return formatNumber(Number(n), {
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals,
     });

--- a/backend/resources/js/Pages/admin/schedule/Index.jsx
+++ b/backend/resources/js/Pages/admin/schedule/Index.jsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
+import { formatDate, formatNumber } from '../../../lib/i18n';
 
 const STATUS_COLORS = {
     BLOCKED:     'bg-red-100 text-red-700',
@@ -54,8 +55,8 @@ export default function ScheduleIndex() {
 
     const navigate = (params) => router.get('/admin/schedule/list', params, { preserveState: false });
 
-    const weekStartFmt = weekStart ? new Date(weekStart).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }) : '';
-    const weekEndFmt = weekEnd ? new Date(weekEnd).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '';
+    const weekStartFmt = weekStart ? formatDate(new Date(weekStart), { day: 'numeric', month: 'short' }) : '';
+    const weekEndFmt = weekEnd ? formatDate(new Date(weekEnd), { day: 'numeric', month: 'short', year: 'numeric' }) : '';
 
     // Group workOrders by line for the by-line view
     const ordersByLine = {};
@@ -212,13 +213,13 @@ function OrderTable({ orders }) {
                                 <td className="px-4 py-3 text-sm hidden sm:table-cell">
                                     {wo.due_date ? (
                                         <span className={isOverdue ? 'text-red-600 font-semibold' : 'text-gray-600'}>
-                                            {new Date(wo.due_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
+                                            {formatDate(new Date(wo.due_date), { day: 'numeric', month: 'short' })}
                                             {isOverdue && ' ⚠'}
                                         </span>
                                     ) : <span className="text-gray-400">—</span>}
                                 </td>
                                 <td className="px-4 py-3 text-sm text-gray-600 hidden md:table-cell">
-                                    {wo.planned_qty != null ? Number(wo.planned_qty).toLocaleString() : '—'}
+                                    {wo.planned_qty != null ? formatNumber(Number(wo.planned_qty)) : '—'}
                                 </td>
                                 <td className="px-4 py-3">
                                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[wo.status] ?? 'bg-gray-100 text-gray-600'}`}>

--- a/backend/resources/js/Pages/admin/schedule/Planner.jsx
+++ b/backend/resources/js/Pages/admin/schedule/Planner.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import LiveRefresh from '../../../components/LiveRefresh';
+import { formatDate, formatNumber } from '../../../lib/i18n';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -345,8 +346,8 @@ export default function Planner() {
 
     // ─────────────────────────────────────────────────────────────────────────
 
-    const rangeStartFmt = rangeStart ? new Date(rangeStart).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit' }) : '';
-    const rangeEndFmt = rangeEnd ? new Date(rangeEnd).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' }) : '';
+    const rangeStartFmt = rangeStart ? formatDate(new Date(rangeStart), { day: '2-digit', month: '2-digit' }) : '';
+    const rangeEndFmt = rangeEnd ? formatDate(new Date(rangeEnd), { day: '2-digit', month: '2-digit', year: 'numeric' }) : '';
 
     return (
         <>
@@ -741,8 +742,8 @@ function WeeklyView({ data, shiftsPerDay, showWeekends, maintenanceEvents, dragO
                     cur.setDate(ws.getDate() + d);
                     dayHeaders.push({
                         date: cur.toISOString().slice(0, 10),
-                        dayLabel: cur.toLocaleDateString('en-GB', { weekday: 'short' }),
-                        dayNum: cur.toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit' }),
+                        dayLabel: formatDate(cur, { weekday: 'short' }),
+                        dayNum: formatDate(cur, { day: '2-digit', month: '2-digit' }),
                         isToday: cur.toISOString().slice(0, 10) === today,
                         isWeekend: cur.getDay() === 0 || cur.getDay() === 6,
                     });
@@ -763,7 +764,7 @@ function WeeklyView({ data, shiftsPerDay, showWeekends, maintenanceEvents, dragO
                                 <div className="flex items-center gap-3">
                                     <span className="text-lg font-black text-gray-800 dark:text-gray-100">wk. {period.number}</span>
                                     <span className="text-sm text-gray-500">
-                                        {new Date(period.start).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit' })}&ndash;{new Date(period.end).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit' })}
+                                        {formatDate(new Date(period.start), { day: '2-digit', month: '2-digit' })}&ndash;{formatDate(new Date(period.end), { day: '2-digit', month: '2-digit' })}
                                     </span>
                                     <div className="flex gap-0.5">
                                         {Array.from({ length: shiftsPerDay }, (_, i) => i + 1).map((s) => (
@@ -973,8 +974,8 @@ function DailyView({ data, lines, maintenanceEvents, onUnassign }) {
                             const isWeekend = (() => { const d = new Date(day.date); return d.getDay() === 0 || d.getDay() === 6; })();
                             return (
                                 <th key={day.date} className={`p-1.5 text-center border-r border-gray-100 dark:border-gray-700 ${isToday ? 'bg-blue-100 dark:bg-blue-900/40' : ''} ${isWeekend ? 'bg-gray-50 dark:bg-gray-800/60' : ''}`}>
-                                    <div className="text-[10px] text-gray-400 uppercase">{new Date(day.date).toLocaleDateString('en-GB', { weekday: 'short' })}</div>
-                                    <div className={`text-xs font-bold ${isToday ? 'text-blue-700' : 'text-gray-700 dark:text-gray-200'}`}>{new Date(day.date).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit' })}</div>
+                                    <div className="text-[10px] text-gray-400 uppercase">{formatDate(new Date(day.date), { weekday: 'short' })}</div>
+                                    <div className={`text-xs font-bold ${isToday ? 'text-blue-700' : 'text-gray-700 dark:text-gray-200'}`}>{formatDate(new Date(day.date), { day: '2-digit', month: '2-digit' })}</div>
                                     {isToday && <div className="h-0.5 bg-blue-500 rounded-full mt-0.5 mx-auto w-8" />}
                                 </th>
                             );
@@ -1497,7 +1498,7 @@ function BacklogPanel({ backlogOrders, backlogItems, allLines,
                                             </span>
                                         </div>
                                         <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[10px] text-gray-600 dark:text-gray-400">
-                                            <div>Qty: <strong className="text-gray-800 dark:text-gray-200">{Number(item.qty).toLocaleString()}</strong></div>
+                                            <div>Qty: <strong className="text-gray-800 dark:text-gray-200">{formatNumber(Number(item.qty))}</strong></div>
                                             <div>Due: <strong className={item.due_date !== '-' && new Date(item.due_date) < new Date() ? 'text-red-600' : 'text-gray-800 dark:text-gray-200'}>{item.due_date}</strong></div>
                                             <div>Line: <strong className="text-gray-800 dark:text-gray-200">{item.line_id ? allLines.find(l => l.id == item.line_id)?.name ?? 'unassigned' : 'unassigned'}</strong></div>
                                             <div>Priority: <strong className={pl.color}>{item.priority ?? '-'}</strong></div>
@@ -1520,7 +1521,7 @@ function BacklogPanel({ backlogOrders, backlogItems, allLines,
                 <div className="grid grid-cols-3 gap-2 text-center mb-2.5">
                     <div>
                         <div className="text-[10px] text-gray-400">total pcs</div>
-                        <div className="text-sm font-bold text-gray-800 dark:text-gray-100">{totalPcs.toLocaleString()}</div>
+                        <div className="text-sm font-bold text-gray-800 dark:text-gray-100">{formatNumber(totalPcs)}</div>
                     </div>
                     <div>
                         <div className="text-[10px] text-gray-400">orders</div>

--- a/backend/resources/js/Pages/admin/schedule/employees/Create.jsx
+++ b/backend/resources/js/Pages/admin/schedule/employees/Create.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Head, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../../layouts/AppLayout';
+import { formatDate } from '../../../../lib/i18n';
 
 function toMin(t) {
     if (!t) return 0;
@@ -45,7 +46,7 @@ export default function EmployeeCreate() {
             <div className="max-w-2xl mx-auto">
                 <div className="mb-4">
                     <div className="font-mono text-[11px] tracking-wider font-bold uppercase text-amber-600 dark:text-amber-400">
-                        {worker?.name} · {dateObj.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'long', year: 'numeric' })}
+                        {worker?.name} · {formatDate(dateObj, { weekday: 'short', day: 'numeric', month: 'long', year: 'numeric' })}
                     </div>
                     <h1 className="text-2xl md:text-3xl font-bold text-gray-800 dark:text-gray-100 mt-0.5">Add activity</h1>
                 </div>

--- a/backend/resources/js/Pages/admin/schedule/employees/Day.jsx
+++ b/backend/resources/js/Pages/admin/schedule/employees/Day.jsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../../layouts/AppLayout';
+import { formatDate } from '../../../../lib/i18n';
 
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -81,10 +82,10 @@ export function EmployeeTabs({ view, date, selectedWorkerId, selectedWorker, wor
                 </div>
                 <h1 className="text-2xl md:text-3xl font-bold text-gray-800 dark:text-gray-100 mt-0.5">
                     {view === 'team'
-                        ? `Team day · ${new Date(date).toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })}`
+                        ? `Team day · ${formatDate(new Date(date), { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })}`
                         : view === 'month'
-                            ? `Month overview · ${new Date(date).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })}`
-                            : <>{selectedWorker?.name ?? 'Day plan'} <span className="text-gray-400 dark:text-gray-500 font-normal text-lg">· {new Date(date).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })}</span></>
+                            ? `Month overview · ${formatDate(new Date(date), { month: 'long', year: 'numeric' })}`
+                            : <>{selectedWorker?.name ?? 'Day plan'} <span className="text-gray-400 dark:text-gray-500 font-normal text-lg">· {formatDate(new Date(date), { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })}</span></>
                     }
                 </h1>
             </div>
@@ -221,7 +222,7 @@ export default function EmployeeDay() {
                             return (
                                 <button key={d} onClick={() => navTo({ view: 'day', date: d, worker_id: selectedWorkerId })}
                                         className={`flex-shrink-0 px-3 py-2 rounded-lg font-mono text-[11px] font-bold tracking-wider uppercase border ${on ? 'bg-amber-500 border-amber-500 text-amber-950' : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100 dark:bg-zinc-800 dark:border-zinc-700 dark:text-gray-300'}`}>
-                                    {new Date(d).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric' })}
+                                    {formatDate(new Date(d), { weekday: 'short', day: 'numeric' })}
                                 </button>
                             );
                         })}
@@ -232,7 +233,7 @@ export default function EmployeeDay() {
                         <div className="flex flex-wrap justify-between items-start gap-3">
                             <div>
                                 <div className="font-mono text-[10px] tracking-wider font-bold uppercase text-amber-600 dark:text-amber-400">
-                                    {dateObj.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })} · A-shift
+                                    {formatDate(dateObj, { weekday: 'short', day: 'numeric', month: 'short' })} · A-shift
                                 </div>
                                 <div className="text-lg md:text-xl font-bold text-gray-800 dark:text-gray-100 mt-1">
                                     {fmtMins(totalWork + totalBreaks + (sums.maint ?? 0) + (sums.meeting ?? 0) + (sums.training ?? 0) + (sums.travel ?? 0))} planned

--- a/backend/resources/js/Pages/admin/schedule/employees/Month.jsx
+++ b/backend/resources/js/Pages/admin/schedule/employees/Month.jsx
@@ -1,6 +1,7 @@
 import { Head, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../../layouts/AppLayout';
 import { Tacho, EmployeeTabs } from './Day';
+import { formatDate } from '../../../../lib/i18n';
 
 function toMin(t) {
     if (!t) return 0;
@@ -171,7 +172,7 @@ export default function EmployeeMonth() {
                 <aside className="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700 rounded-2xl p-4 flex flex-col gap-3">
                     <div>
                         <div className="font-mono text-[10.5px] tracking-wider font-bold uppercase text-amber-600 dark:text-amber-400">
-                            Selected · {date ? new Date(date).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' }) : ''}
+                            Selected · {date ? formatDate(new Date(date), { weekday: 'short', day: 'numeric', month: 'short' }) : ''}
                         </div>
                         <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100 mt-1">{selectedDayActivities.length} activities</h2>
                         {selectedWorker && (

--- a/backend/resources/js/Pages/admin/traceability/Index.jsx
+++ b/backend/resources/js/Pages/admin/traceability/Index.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
-import { __ } from '../../../lib/i18n';
+import { __, formatNumber } from '../../../lib/i18n';
 
 /**
  * Traceability / genealogy console. Resolves a finished LOT, material lot,
@@ -161,7 +161,7 @@ function BatchResult({ data }) {
                                             <span className="w-1 h-1 rounded-full bg-gray-400" />
                                             <span className="font-mono">{c.lot_number}</span>
                                             <span className="text-gray-400 dark:text-gray-500">{c.material}</span>
-                                            <span className="text-gray-500 dark:text-gray-400">— {c.quantity.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                                            <span className="text-gray-500 dark:text-gray-400">— {formatNumber(c.quantity, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
                                         </li>
                                     ))}
                                 </ul>
@@ -220,7 +220,7 @@ function MaterialLotResult({ forward, backward }) {
                             ))}
                         </ul>
                         <p className="text-xs text-gray-400 dark:text-gray-500 mt-3">
-                            {__('Total consumed')}: {Number(forward.total_consumed).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            {__('Total consumed')}: {formatNumber(Number(forward.total_consumed), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                         </p>
                     </>
                 )}

--- a/backend/resources/js/Pages/admin/work-orders/Show.jsx
+++ b/backend/resources/js/Pages/admin/work-orders/Show.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import { WO_STATUS_STYLES } from './fields';
+import { formatDate, formatNumber } from '../../../lib/i18n';
 
 const TERMINAL = ['DONE', 'REJECTED', 'CANCELLED'];
 
@@ -23,14 +24,14 @@ const ISSUE_STATUS_STYLES = {
 };
 
 function fmtQty(n) {
-    return Number(n ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    return formatNumber(Number(n ?? 0), { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function fmtDate(d) {
     if (!d) return null;
     const dt = new Date(d);
     if (Number.isNaN(dt.getTime())) return d;
-    return dt.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' });
+    return formatDate(dt, { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
 function timeAgo(d) {

--- a/backend/resources/js/Pages/inspections/Index.jsx
+++ b/backend/resources/js/Pages/inspections/Index.jsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../layouts/AppLayout';
+import { formatNumber } from '../../lib/i18n';
 
 const DISPOSITION_LABELS = {
     pending: 'Pending',
@@ -49,7 +50,7 @@ function dispositionBadge(disposition) {
 
 function fmtNum(n) {
     if (n == null) return '—';
-    return Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    return formatNumber(Number(n), { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 export default function InspectionsIndex() {

--- a/backend/resources/js/Pages/inspections/Show.jsx
+++ b/backend/resources/js/Pages/inspections/Show.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import AppLayout from '../../layouts/AppLayout';
+import { formatDateTime, formatNumber } from '../../lib/i18n';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,7 +42,7 @@ function dispositionColorClass(disposition) {
 
 function fmtDateTime(str) {
     if (!str) return '—';
-    return new Date(str).toLocaleString(undefined, {
+    return formatDateTime(new Date(str), {
         year: 'numeric', month: '2-digit', day: '2-digit',
         hour: '2-digit', minute: '2-digit',
     });
@@ -49,7 +50,7 @@ function fmtDateTime(str) {
 
 function fmtNum(n, decimals = 2) {
     if (n == null) return '—';
-    return Number(n).toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+    return formatNumber(Number(n), { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/resources/js/Pages/operator/Queue.jsx
+++ b/backend/resources/js/Pages/operator/Queue.jsx
@@ -2,13 +2,14 @@ import { useState, useEffect } from 'react';
 import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import OperatorLayout from '../../layouts/OperatorLayout';
 import LineSync from '../../components/LineSync';
+import { formatDate, formatNumber, formatTime } from '../../lib/i18n';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function fmtQty(v, decimals = 0) {
     const n = parseFloat(v);
     if (isNaN(n)) return '0';
-    return n.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+    return formatNumber(n, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
 }
 
 function fmtDate(dateStr, format = 'short') {
@@ -16,10 +17,10 @@ function fmtDate(dateStr, format = 'short') {
     const d = new Date(dateStr);
     if (isNaN(d)) return '—';
     if (format === 'short') {
-        return d.toLocaleDateString(undefined, { day: '2-digit', month: 'short' });
+        return formatDate(d, { day: '2-digit', month: 'short' });
     }
-    return d.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' })
-        + ', ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    return formatDate(d, { day: '2-digit', month: 'short', year: 'numeric' })
+        + ', ' + formatTime(d, { hour: '2-digit', minute: '2-digit' });
 }
 
 function hexToRgba(hex, alpha) {

--- a/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
+++ b/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
@@ -3,6 +3,7 @@ import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import OperatorLayout from '../../layouts/OperatorLayout';
 import LineSync from '../../components/LineSync';
 import LabelPrintMenu from '../../components/LabelPrintMenu';
+import { formatDate, formatDateTime, formatNumber } from '../../lib/i18n';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -10,7 +11,7 @@ import LabelPrintMenu from '../../components/LabelPrintMenu';
 
 function fmtQty(n, decimals = 2) {
     if (n == null) return '—';
-    return Number(n).toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+    return formatNumber(Number(n), { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
 }
 
 function statusBadge(status) {
@@ -386,7 +387,7 @@ function ConfirmParametersRow({ batch }) {
             </button>
             {lastConfirm && (
                 <span className="text-xs text-green-600">
-                    Last: {new Date(lastConfirm.confirmed_at).toLocaleString(undefined, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                    Last: {formatDateTime(new Date(lastConfirm.confirmed_at), { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
                 </span>
             )}
         </div>
@@ -1028,7 +1029,7 @@ export default function WorkOrderDetail() {
                                     <div>
                                         <p className="text-sm text-gray-500">Due Date</p>
                                         <p className={`font-medium ${dueDatePast ? 'text-red-600' : 'text-gray-800 dark:text-gray-100'}`}>
-                                            {new Date(dueDateStr).toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' })}
+                                            {formatDate(new Date(dueDateStr), { day: '2-digit', month: 'short', year: 'numeric' })}
                                         </p>
                                     </div>
                                 )}
@@ -1154,7 +1155,7 @@ export default function WorkOrderDetail() {
                                             )}
                                             <p className="text-xs text-gray-400 mt-1">
                                                 {issue.reported_at
-                                                    ? new Date(issue.reported_at).toLocaleString()
+                                                    ? formatDateTime(new Date(issue.reported_at))
                                                     : ''}
                                                 {issue.reported_by ? ` by ${issue.reported_by.name}` : ''}
                                             </p>

--- a/backend/resources/js/Pages/operator/Workstation.jsx
+++ b/backend/resources/js/Pages/operator/Workstation.jsx
@@ -3,11 +3,12 @@ import { Head, Link, router, usePage } from '@inertiajs/react';
 import OperatorLayout from '../../layouts/OperatorLayout';
 import LineSync from '../../components/LineSync';
 import LabelPrintMenu from '../../components/LabelPrintMenu';
+import { formatDate, formatNumber } from '../../lib/i18n';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function fmt(n) {
-    return Number(n ?? 0).toLocaleString('en-US', { maximumFractionDigits: 0 });
+    return formatNumber(Number(n ?? 0), { maximumFractionDigits: 0 });
 }
 
 function weekLabel(wk) {
@@ -34,7 +35,7 @@ function getCellValue(wo, col) {
     if (col.key === 'due_date') {
         if (!wo.due_date) return '—';
         const d = new Date(wo.due_date);
-        return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+        return formatDate(d, { day: '2-digit', month: 'short' });
     }
     if (col.key === 'week_number') {
         return wo.week_number ? weekLabel(wo.week_number) : '—';

--- a/backend/resources/js/Pages/packaging/Admin.jsx
+++ b/backend/resources/js/Pages/packaging/Admin.jsx
@@ -1,5 +1,6 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import AppLayout from '../../layouts/AppLayout';
+import { formatNumber } from '../../lib/i18n';
 
 function ProgressBar({ pct, done }) {
     const color = done ? 'bg-green-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-indigo-500';
@@ -78,19 +79,19 @@ export default function Admin() {
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
                     <div className="card text-center">
                         <p className="text-3xl font-extrabold text-indigo-600 dark:text-indigo-400">
-                            {(stats.today_packed ?? 0).toLocaleString()}
+                            {formatNumber((stats.today_packed ?? 0))}
                         </p>
                         <p className="text-xs text-gray-500 mt-1">Spakowano (zmiana)</p>
                     </div>
                     <div className="card text-center">
                         <p className="text-3xl font-extrabold text-gray-700 dark:text-gray-200">
-                            {plan.toLocaleString()}
+                            {formatNumber(plan)}
                         </p>
                         <p className="text-xs text-gray-500 mt-1">Plan łącznie</p>
                     </div>
                     <div className="card text-center">
                         <p className={`text-3xl font-extrabold ${(stats.backlog ?? 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-                            {(stats.backlog ?? 0).toLocaleString()}
+                            {formatNumber((stats.backlog ?? 0))}
                         </p>
                         <p className="text-xs text-gray-500 mt-1">Backlog</p>
                     </div>

--- a/backend/resources/js/Pages/packaging/Station.jsx
+++ b/backend/resources/js/Pages/packaging/Station.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Head, usePage } from '@inertiajs/react';
 import AppLayout from '../../layouts/AppLayout';
+import { formatTime } from '../../lib/i18n';
 
 function ProgressBar({ pct, done }) {
     const color = done ? 'bg-green-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-indigo-500';
@@ -112,20 +113,20 @@ export default function Station() {
                     packed_qty: packedQty,
                     planned_qty: plannedQty,
                     progress: pct,
-                    scanned_at: new Date().toLocaleTimeString('pl-PL'),
+                    scanned_at: formatTime(new Date()),
                 });
                 setFlash('success');
                 await Promise.all([fetchItems(), fetchStats()]);
                 setHistory((prev) => [
-                    { id: Date.now(), ean, product_name: wo.product, scanned_at: new Date().toLocaleTimeString('pl-PL') },
+                    { id: Date.now(), ean, product_name: wo.product, scanned_at: formatTime(new Date()) },
                     ...prev,
                 ].slice(0, 100));
             } else {
-                setLastScan({ success: false, ean, error: data.message, scanned_at: new Date().toLocaleTimeString('pl-PL') });
+                setLastScan({ success: false, ean, error: data.message, scanned_at: formatTime(new Date()) });
                 setFlash('error');
             }
         } catch {
-            setLastScan({ success: false, ean, error: 'Błąd połączenia', scanned_at: new Date().toLocaleTimeString('pl-PL') });
+            setLastScan({ success: false, ean, error: 'Błąd połączenia', scanned_at: formatTime(new Date()) });
             setFlash('error');
         }
 

--- a/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
+++ b/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import { WO_STATUS_STYLES } from '../../admin/work-orders/fields';
+import { formatDate, formatNumber } from '../../../lib/i18n';
 
 const TERMINAL = ['DONE', 'REJECTED', 'CANCELLED'];
 
@@ -23,21 +24,21 @@ const ISSUE_STATUS_STYLES = {
 };
 
 function fmtQty(n) {
-    return Number(n ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    return formatNumber(Number(n ?? 0), { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function fmtDate(d) {
     if (!d) return null;
     const dt = new Date(d);
     if (Number.isNaN(dt.getTime())) return d;
-    return dt.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' });
+    return formatDate(dt, { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
 function fmtDateTime(d) {
     if (!d) return null;
     const dt = new Date(d);
     if (Number.isNaN(dt.getTime())) return d;
-    return dt.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+    return formatDate(dt, { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
 function timeAgo(d) {

--- a/backend/resources/js/app.jsx
+++ b/backend/resources/js/app.jsx
@@ -1,6 +1,6 @@
 import { createInertiaApp } from '@inertiajs/react';
 import { createRoot } from 'react-dom/client';
-import { loadLocale } from './lib/i18n';
+import { loadLocale, setTimezone } from './lib/i18n';
 
 createInertiaApp({
     resolve: (name) => {
@@ -15,6 +15,8 @@ createInertiaApp({
         // Load the active locale's translation chunk before the first render so
         // __() is ready and there's no flash of untranslated/wrong-language text.
         await loadLocale(props.initialPage.props.locale ?? 'en');
+        // Plant timezone for the date/time format helpers (lib/i18n).
+        setTimezone(props.initialPage.props.timezone);
         createRoot(el).render(<App {...props} />);
     },
     progress: { color: '#1e40af' },

--- a/backend/resources/js/lib/i18n.js
+++ b/backend/resources/js/lib/i18n.js
@@ -20,6 +20,9 @@ const localeFiles = import.meta.glob('../../../lang/*.json');
 
 let messages = {};
 let activeLocale = 'en';
+// Plant timezone, set from the Inertia `timezone` prop at bootstrap. Undefined
+// means "use the browser's zone" (Intl default) until configured.
+let activeTimezone;
 
 /** Load (and activate) a locale's messages. Call once before the first render. */
 export async function loadLocale(locale) {
@@ -31,6 +34,68 @@ export async function loadLocale(locale) {
 
 export function locale() {
     return activeLocale;
+}
+
+/** Set the plant timezone used by the format* helpers (from the `timezone` prop). */
+export function setTimezone(tz) {
+    activeTimezone = tz || undefined;
+}
+
+// Map app locale codes to BCP-47 tags for Intl. English uses en-GB (day-first,
+// 24h) to match this app's European convention. Unmapped codes fall through to
+// the code itself, so adding a locale to config/app.php just works.
+const BCP47 = {
+    en: 'en-GB',
+    pl: 'pl-PL',
+    tr: 'tr-TR',
+};
+
+function localeTag() {
+    return BCP47[activeLocale] ?? activeLocale;
+}
+
+function toDate(value) {
+    return value instanceof Date ? value : new Date(value);
+}
+
+/**
+ * Locale- and timezone-aware formatting. These replace scattered hardcoded
+ * toLocaleDateString('en-GB' | 'pl-PL', …) calls so date/time follows the
+ * user's chosen UI language and the plant timezone (APP_TIMEZONE), not the
+ * viewer's browser settings.
+ *
+ *   formatDate(value, opts?)      → date only
+ *   formatTime(value, opts?)      → time only
+ *   formatDateTime(value, opts?)  → date + time
+ *   formatNumber(value, opts?)    → number (no timezone)
+ *
+ * `opts` is a standard Intl.DateTimeFormat / NumberFormat options object.
+ * Invalid/empty input returns '' so callers don't render "Invalid Date".
+ */
+export function formatDate(value, opts = { day: '2-digit', month: '2-digit', year: 'numeric' }) {
+    if (value == null || value === '') return '';
+    const d = toDate(value);
+    if (isNaN(d)) return '';
+    return d.toLocaleDateString(localeTag(), { timeZone: activeTimezone, ...opts });
+}
+
+export function formatTime(value, opts = { hour: '2-digit', minute: '2-digit' }) {
+    if (value == null || value === '') return '';
+    const d = toDate(value);
+    if (isNaN(d)) return '';
+    return d.toLocaleTimeString(localeTag(), { timeZone: activeTimezone, ...opts });
+}
+
+export function formatDateTime(value, opts = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }) {
+    if (value == null || value === '') return '';
+    const d = toDate(value);
+    if (isNaN(d)) return '';
+    return d.toLocaleString(localeTag(), { timeZone: activeTimezone, ...opts });
+}
+
+export function formatNumber(value, opts = {}) {
+    if (value == null || value === '' || isNaN(value)) return '';
+    return Number(value).toLocaleString(localeTag(), opts);
 }
 
 function capitalize(s) {

--- a/backend/tests/Feature/Web/SystemSettingsLanguageTest.php
+++ b/backend/tests/Feature/Web/SystemSettingsLanguageTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The language whitelist is derived from config('app.available_locales')
+ * (single source of truth) — adding a locale there must make it valid
+ * without touching the controller, and removing it must reject it.
+ */
+class SystemSettingsLanguageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'production_period' => 'none',
+            'workflow_mode' => 'status',
+            'schedule_view_mode' => 'weekly',
+            'schedule_shifts_per_day' => 1,
+            'schedule_horizon_weeks' => 6,
+            'realtime_mode' => 'polling',
+            'production_tracking_mode' => 'per_operation',
+            'production_qty_edit_policy' => 'none',
+            'scanner_mode' => 'hid',
+        ], $overrides);
+    }
+
+    public function test_configured_locale_is_accepted(): void
+    {
+        foreach (array_keys(config('app.available_locales')) as $locale) {
+            $response = $this->actingAs($this->admin)
+                ->post('/settings/system', $this->payload(['language' => $locale]));
+
+            $response->assertSessionHasNoErrors();
+        }
+    }
+
+    public function test_unconfigured_locale_is_rejected(): void
+    {
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload(['language' => 'xx']))
+            ->assertSessionHasErrors('language');
+    }
+
+    public function test_newly_configured_locale_is_accepted_without_controller_change(): void
+    {
+        // Simulate adding a language in config/app.php.
+        config(['app.available_locales' => config('app.available_locales') + ['nl' => 'Nederlands']]);
+
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload(['language' => 'nl']))
+            ->assertSessionHasNoErrors();
+    }
+
+    public function test_language_whitelist_matches_switcher_options(): void
+    {
+        // The dropdown shown on the settings page must use the same source.
+        $response = $this->actingAs($this->admin)->get('/settings/system');
+
+        $response->assertOk();
+        $locales = $response->getOriginalContent()->getData()['page']['props']['availableLocales'] ?? null;
+        $this->assertSame(config('app.available_locales'), $locales);
+    }
+}


### PR DESCRIPTION
Addresses contributor feedback on language/locale handling.

## Problems fixed

**1. Language whitelist hardcoded in 3 places**
Adding a language required editing the validation rule (`in:en,pl,tr`), the settings dropdown (`['en'=>'English','pl'=>'Polski']` — also silently missing Turkish), and the lang JSON. The validation rule and the dropdown now derive from `config('app.available_locales')`, so adding a locale is a one-line config change. This is exactly what the contributor hit (`language invalid` after adding `nl` in only one spot).

**2. Timezone fixed to UTC**
`config/app.php` now reads `APP_TIMEZONE` (default UTC). The active zone is shared to the frontend via Inertia and used for all date/time rendering — so the clock/dates reflect the plant, not UTC. (This also fixes the LOT `[hour]` token being UTC-based.)

**3. Date/time/number formatting scattered & locale-hardcoded**
24 page files formatted dates with hardcoded locales — `'pl-PL'` (the "clock in Polish"), `'en-GB'`, `'en-US'`, and browser-default (which gave the contributor `mm/dd/yyyy`). Added `formatDate` / `formatTime` / `formatDateTime` / `formatNumber` to `lib/i18n` that format in the user's chosen UI language (en→en-GB, pl→pl-PL, tr→tr-TR) and the plant timezone. All **62 call sites** converted.

## Verified manually (localhost, APP_TIMEZONE=Europe/Warsaw)
- Settings language dropdown now lists English / Polski / **Türkçe** (was missing before)
- Dashboard timestamp renders `06/06/2026, 13:44` (en-GB, 24h, Warsaw) instead of the browser's `6/6/2026, 1:44:30 PM` (en-US, 12h)
- Backend `now()` shifted UTC→Warsaw correctly

## Tests
- `SystemSettingsLanguageTest` (4): configured locales accepted, unconfigured rejected, a newly-config'd locale works without controller edits, dropdown matches the whitelist source
- Full suite: 76 pre-existing baseline failures only (react-poc `viewData` leftovers) — no regressions; +4 new passing

## Not included (separate, by design)
- Per-user language in profile (a feature: needs a `users.locale` column) — left for a roadmap issue
- Native datepicker display format follows the browser/OS locale; changing it needs a custom datepicker component