### PR TITLE
feat: show process work-instruction photos to operators

### DIFF
--- a/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
+++ b/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
@@ -100,6 +100,7 @@ class WorkOrderController extends Controller
                         return true;
                     }
                 }
+
                 return false;
             })->values();
         }
@@ -172,7 +173,7 @@ class WorkOrderController extends Controller
     public function check(Request $request)
     {
         $lineId = $request->session()->get('selected_line_id');
-        if (!$lineId) {
+        if (! $lineId) {
             return response()->json(['active' => 0, 'workstation' => 0]);
         }
 
@@ -197,6 +198,7 @@ class WorkOrderController extends Controller
                             return true;
                         }
                     }
+
                     return false;
                 })->count();
         }
@@ -253,6 +255,27 @@ class WorkOrderController extends Controller
             ->orderBy('name')
             ->get(['id', 'name', 'type', 'size', 'barcode_format', 'is_default']);
 
-        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates'));
+        // Reference photos (work instructions) for the process this order was
+        // built from. Loaded live by the snapshot's template id so updated
+        // instructions reach in-flight orders; the snapshot itself stays frozen.
+        // Served via the authenticated stream route, so any logged-in operator
+        // may view them.
+        $processPhotos = collect();
+        $templateId = $workOrder->process_snapshot['template_id'] ?? null;
+        if ($templateId) {
+            $processPhotos = \App\Models\ProcessTemplatePhoto::where('process_template_id', $templateId)
+                ->orderBy('sort_order')
+                ->orderBy('id')
+                ->get()
+                ->map(fn ($p) => [
+                    'id' => $p->id,
+                    'url' => route('process-templates.photos.show', [$templateId, $p->id]),
+                    'caption' => $p->caption,
+                    'width' => $p->width,
+                    'height' => $p->height,
+                ]);
+        }
+
+        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates', 'processPhotos'));
     }
 }

--- a/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
+++ b/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
@@ -148,6 +148,86 @@ function BomSection({ workOrder }) {
 }
 
 // ---------------------------------------------------------------------------
+// Process reference photos (work instructions) — read-only for operators.
+// Images stream from an authenticated endpoint; tap to enlarge.
+// ---------------------------------------------------------------------------
+
+function ProcessPhotosSection({ photos = [] }) {
+    const [open, setOpen] = useState(true);
+    const [lightbox, setLightbox] = useState(null);
+    if (!photos || photos.length === 0) return null;
+
+    return (
+        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm p-6">
+            <button
+                type="button"
+                className="flex justify-between items-center w-full text-left"
+                onClick={() => setOpen((v) => !v)}
+            >
+                <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">Work Instructions</h2>
+                <div className="flex items-center gap-2">
+                    <span className="text-sm text-gray-500">{photos.length} photos</span>
+                    <ChevronIcon open={open} />
+                </div>
+            </button>
+
+            {open && (
+                <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                    {photos.map((photo) => (
+                        <figure key={photo.id} className="m-0">
+                            <button
+                                type="button"
+                                onClick={() => setLightbox(photo)}
+                                className="block w-full"
+                                title={photo.caption || ''}
+                            >
+                                <img
+                                    src={photo.url}
+                                    alt={photo.caption || 'Work instruction'}
+                                    loading="lazy"
+                                    className="w-full h-32 object-cover rounded-lg bg-gray-100 dark:bg-slate-700"
+                                />
+                            </button>
+                            {photo.caption && (
+                                <figcaption className="mt-1 text-xs text-gray-600 dark:text-gray-300 truncate">
+                                    {photo.caption}
+                                </figcaption>
+                            )}
+                        </figure>
+                    ))}
+                </div>
+            )}
+
+            {lightbox && (
+                <div
+                    className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-6"
+                    onClick={() => setLightbox(null)}
+                >
+                    <figure className="max-w-4xl max-h-full m-0" onClick={(e) => e.stopPropagation()}>
+                        <img
+                            src={lightbox.url}
+                            alt={lightbox.caption || 'Work instruction'}
+                            className="max-w-full max-h-[80vh] rounded-lg shadow-2xl"
+                        />
+                        {lightbox.caption && (
+                            <figcaption className="text-white/90 text-sm mt-3 text-center">{lightbox.caption}</figcaption>
+                        )}
+                    </figure>
+                    <button
+                        type="button"
+                        onClick={() => setLightbox(null)}
+                        className="absolute top-5 right-5 text-white/80 hover:text-white text-3xl leading-none"
+                        title="Close"
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Quality Check form (3 fixed samples per Blade)
 // ---------------------------------------------------------------------------
 
@@ -925,7 +1005,7 @@ function ReportIssueModal({ workOrder, issueTypes, onClose }) {
 // ---------------------------------------------------------------------------
 
 export default function WorkOrderDetail() {
-    const { workOrder, issueTypes = [], workstations = [], defaultWorkstationId, line, labelTemplates = [] } = usePage().props;
+    const { workOrder, issueTypes = [], workstations = [], defaultWorkstationId, line, labelTemplates = [], processPhotos = [] } = usePage().props;
 
     const [createBatchOpen, setCreateBatchOpen] = useState(false);
     const [reportIssueOpen, setReportIssueOpen] = useState(false);
@@ -1045,6 +1125,9 @@ export default function WorkOrderDetail() {
 
                         {/* Recipe / BOM */}
                         <BomSection workOrder={workOrder} />
+
+                        {/* Process reference photos (work instructions) */}
+                        <ProcessPhotosSection photos={processPhotos} />
 
                         {/* Batches */}
                         <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm p-6">

--- a/backend/tests/Feature/OperatorProcessPhotosTest.php
+++ b/backend/tests/Feature/OperatorProcessPhotosTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ProcessTemplate;
+use App\Models\ProcessTemplatePhoto;
+use App\Models\User;
+use App\Models\WorkOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Operators at a workstation must see the work-instruction photos of the
+ * process their order was built from — surfaced on the work-order detail page
+ * (the photos themselves live on the process template, PR #56).
+ */
+class OperatorProcessPhotosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $operator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Operator', 'guard_name' => 'web']);
+        Role::create(['name' => 'Supervisor', 'guard_name' => 'web']);
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+
+        $this->operator = User::factory()->create(['account_type' => 'operator']);
+        $this->operator->assignRole('Operator');
+    }
+
+    private function templateIdOf(WorkOrder $wo): int
+    {
+        return $wo->process_snapshot['template_id'];
+    }
+
+    /** The detail page requires the order's line selected in session. */
+    private function showOrder(WorkOrder $wo)
+    {
+        return $this->actingAs($this->operator)
+            ->withSession(['selected_line_id' => $wo->line_id])
+            ->get("/operator/work-order/{$wo->id}");
+    }
+
+    public function test_operator_sees_photos_of_their_orders_process(): void
+    {
+        $wo = WorkOrder::factory()->create();
+        $templateId = $this->templateIdOf($wo);
+
+        $photos = ProcessTemplatePhoto::factory()->count(3)->create([
+            'process_template_id' => $templateId,
+        ]);
+
+        $response = $this->showOrder($wo);
+
+        $response->assertOk();
+        $props = $response->getOriginalContent()->getData()['page']['props'];
+
+        $this->assertCount(3, $props['processPhotos']);
+        $ids = array_column($props['processPhotos'], 'id');
+        $this->assertEqualsCanonicalizing($photos->pluck('id')->all(), $ids);
+
+        // Each entry exposes a stream URL, never a storage path.
+        foreach ($props['processPhotos'] as $p) {
+            $this->assertStringContainsString("/process-templates/{$templateId}/photos/{$p['id']}", $p['url']);
+            $this->assertArrayNotHasKey('storage_path', $p);
+        }
+    }
+
+    public function test_photos_of_other_processes_are_not_shown(): void
+    {
+        $wo = WorkOrder::factory()->create();
+
+        // Photos belonging to an unrelated template must not leak in.
+        $otherTemplate = ProcessTemplate::factory()->create();
+        ProcessTemplatePhoto::factory()->count(2)->create([
+            'process_template_id' => $otherTemplate->id,
+        ]);
+
+        $response = $this->showOrder($wo);
+
+        $response->assertOk();
+        $this->assertCount(0, $response->getOriginalContent()->getData()['page']['props']['processPhotos']);
+    }
+
+    public function test_no_photos_yields_empty_list(): void
+    {
+        $wo = WorkOrder::factory()->create();
+
+        $response = $this->showOrder($wo);
+
+        $response->assertOk();
+        $this->assertSame([], $response->getOriginalContent()->getData()['page']['props']['processPhotos']);
+    }
+
+    public function test_photos_respect_sort_order(): void
+    {
+        $wo = WorkOrder::factory()->create();
+        $templateId = $this->templateIdOf($wo);
+
+        $second = ProcessTemplatePhoto::factory()->create(['process_template_id' => $templateId, 'sort_order' => 2]);
+        $first = ProcessTemplatePhoto::factory()->create(['process_template_id' => $templateId, 'sort_order' => 1]);
+
+        $response = $this->showOrder($wo);
+
+        $ids = array_column($response->getOriginalContent()->getData()['page']['props']['processPhotos'], 'id');
+        $this->assertSame([$first->id, $second->id], $ids);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #56. The reference photos attached to a process template were only visible to admins. This surfaces them to **operators at the workstation** — where work instructions are actually needed — on the work-order detail page.

## What operators see
A collapsible **Work Instructions** gallery (thumbnail grid + tap-to-enlarge lightbox, read-only) on `operator/WorkOrderDetail`, right after the Recipe/BOM section.

## Implementation
- `WorkOrderController::show()` loads photos **live by the snapshot's `template_id`** — the frozen process snapshot stays immune to template edits, but updated/added work instructions still reach in-flight orders. Only `id`, `url`, `caption`, `width`, `height` are passed (no storage paths).
- Images stream through the **existing authenticated route** from #56 (`process-templates.photos.show`), which is available to any logged-in user — so operators can view, while upload/delete stay admin-only.
- Read-only UI; mirrors the admin gallery component.

## Tests (4, all passing)
- Operator sees the photos of their order's process
- Photos from an unrelated template are not shown (no leakage)
- No photos → empty list
- Sort order respected

Full suite: 76 pre-existing baseline failures only, no regressions; +4 new passing.