### PR TITLE
feat: version + publish lifecycle for inspection plans

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/InspectionPlanController.php
+++ b/backend/app/Http/Controllers/Api/V1/InspectionPlanController.php
@@ -4,11 +4,14 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Models\InspectionPlan;
+use App\Services\Quality\InspectionPlanVersionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class InspectionPlanController extends Controller
 {
+    public function __construct(private InspectionPlanVersionService $versions) {}
+
     public function index(Request $request): JsonResponse
     {
         $request->validate([
@@ -41,22 +44,51 @@ class InspectionPlanController extends Controller
     {
         $validated = $this->validatedPayload($request);
 
-        $plan = InspectionPlan::create($validated);
+        $plan = InspectionPlan::create([
+            ...$validated,
+            'version' => 1,
+            'published_at' => null,
+            'root_id' => null,
+            'is_active' => false,
+        ]);
 
         return response()->json(['message' => __('Inspection plan created'), 'data' => $plan], 201);
     }
 
+    /**
+     * Draft → update in place. Published → create the next draft version.
+     */
     public function update(Request $request, InspectionPlan $inspectionPlan): JsonResponse
     {
         $validated = $this->validatedPayload($request, $inspectionPlan->id);
 
-        $inspectionPlan->update($validated);
+        if ($inspectionPlan->isDraft()) {
+            $inspectionPlan->update($validated);
 
-        return response()->json(['message' => __('Inspection plan updated'), 'data' => $inspectionPlan->fresh()]);
+            return response()->json(['message' => __('Inspection plan updated'), 'data' => $inspectionPlan->fresh()]);
+        }
+
+        $newVersion = $this->versions->createNewVersion($inspectionPlan, $validated);
+
+        return response()->json([
+            'message' => __('Created version :v as a draft from the published plan.', ['v' => $newVersion->version]),
+            'data' => $newVersion,
+        ], 201);
+    }
+
+    public function publish(InspectionPlan $inspectionPlan): JsonResponse
+    {
+        $this->versions->publish($inspectionPlan);
+
+        return response()->json(['message' => __('Inspection plan published'), 'data' => $inspectionPlan->fresh()]);
     }
 
     public function destroy(InspectionPlan $inspectionPlan): JsonResponse
     {
+        if ($inspectionPlan->isPublished() && $inspectionPlan->inspections()->exists()) {
+            return response()->json(['message' => __('Cannot delete a published version that has recorded inspections.')], 422);
+        }
+
         $inspectionPlan->delete();
 
         return response()->json(['message' => __('Inspection plan deleted')]);
@@ -76,7 +108,6 @@ class InspectionPlanController extends Controller
             'criteria.*.unit' => 'nullable|string|max:30',
             'criteria.*.spec_min' => 'nullable|numeric',
             'criteria.*.spec_max' => 'nullable|numeric',
-            'is_active' => 'nullable|boolean',
         ]);
 
         // Exactly-one rule: either tie to a material, a material_type, or be generic.

--- a/backend/app/Http/Controllers/Web/Admin/InspectionPlanController.php
+++ b/backend/app/Http/Controllers/Web/Admin/InspectionPlanController.php
@@ -3,14 +3,17 @@
 namespace App\Http\Controllers\Web\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\InspectionPlanRequest;
 use App\Models\InspectionPlan;
 use App\Models\Material;
 use App\Models\MaterialType;
-use Illuminate\Http\Request;
+use App\Services\Quality\InspectionPlanVersionService;
 use Inertia\Inertia;
 
 class InspectionPlanController extends Controller
 {
+    public function __construct(private InspectionPlanVersionService $versions) {}
+
     public function index()
     {
         return Inertia::render('admin/inspection-plans/Index', [
@@ -32,82 +35,95 @@ class InspectionPlanController extends Controller
         return Inertia::render('admin/inspection-plans/Create', $this->formData());
     }
 
-    public function store(Request $request)
+    /**
+     * Create a brand-new plan as version 1 — a draft until published.
+     */
+    public function store(InspectionPlanRequest $request)
     {
-        $validated = $this->validated($request);
-        InspectionPlan::create($validated);
+        InspectionPlan::create([
+            ...$request->payload(),
+            'version' => 1,
+            'published_at' => null,
+            'root_id' => null,
+            'is_active' => false,
+        ]);
 
-        return redirect()->route('admin.inspection-plans.index')->with('success', __('Inspection plan created.'));
+        return redirect()->route('admin.inspection-plans.index')
+            ->with('success', __('Inspection plan created as a draft. Publish it to use it for inspections.'));
     }
 
     public function edit(InspectionPlan $inspectionPlan)
     {
-        // Derive scope from which target FK is set (scope isn't a stored column).
-        $scope = $inspectionPlan->material_id ? 'material' : ($inspectionPlan->material_type_id ? 'material_type' : 'generic');
+        $scope = $inspectionPlan->material_id ? 'material'
+            : ($inspectionPlan->material_type_id ? 'material_type' : 'generic');
+
+        $history = $inspectionPlan->versionGroup()
+            ->get(['id', 'version', 'published_at', 'is_active', 'updated_at'])
+            ->map(fn ($v) => [
+                'id' => $v->id,
+                'version' => $v->version,
+                'is_draft' => $v->published_at === null,
+                'is_active' => (bool) $v->is_active,
+                'published_at' => $v->published_at?->toIso8601String(),
+                'updated_at' => $v->updated_at?->toIso8601String(),
+            ]);
 
         return Inertia::render('admin/inspection-plans/Edit', array_merge($this->formData(), [
             'plan' => [
-                ...$inspectionPlan->only('id', 'name', 'description', 'material_id', 'material_type_id', 'criteria', 'is_active'),
+                ...$inspectionPlan->only('id', 'name', 'description', 'material_id', 'material_type_id', 'criteria', 'is_active', 'version'),
                 'scope' => $scope,
+                'is_draft' => $inspectionPlan->isDraft(),
+                'published_at' => $inspectionPlan->published_at?->toIso8601String(),
             ],
+            'history' => $history,
         ]));
     }
 
-    public function update(Request $request, InspectionPlan $inspectionPlan)
+    /**
+     * Draft → edit in place. Published → spawn the next draft version
+     * (the published version stays immutable for reproducibility).
+     */
+    public function update(InspectionPlanRequest $request, InspectionPlan $inspectionPlan)
     {
-        $inspectionPlan->update($this->validated($request));
+        if ($inspectionPlan->isDraft()) {
+            $inspectionPlan->update($request->payload());
 
-        return redirect()->route('admin.inspection-plans.index')->with('success', __('Inspection plan updated.'));
+            return redirect()->route('admin.inspection-plans.index')
+                ->with('success', __('Draft updated.'));
+        }
+
+        $newVersion = $this->versions->createNewVersion($inspectionPlan, $request->payload());
+
+        return redirect()->route('admin.inspection-plans.edit', $newVersion)
+            ->with('success', __('Created version :v as a draft from the published plan.', ['v' => $newVersion->version]));
+    }
+
+    /**
+     * Publish a draft — makes it the live version and retires the previous one.
+     */
+    public function publish(InspectionPlan $inspectionPlan)
+    {
+        if ($inspectionPlan->isPublished()) {
+            return back()->with('error', __('This version is already published.'));
+        }
+
+        $this->versions->publish($inspectionPlan);
+
+        return redirect()->route('admin.inspection-plans.index')
+            ->with('success', __('Inspection plan version :v published.', ['v' => $inspectionPlan->version]));
     }
 
     public function destroy(InspectionPlan $inspectionPlan)
     {
-        $inspectionPlan->delete();
-
-        return redirect()->route('admin.inspection-plans.index')->with('success', __('Inspection plan deleted.'));
-    }
-
-    private function validated(Request $request): array
-    {
-        $validated = $request->validate([
-            'name' => 'required|string|max:150',
-            'description' => 'nullable|string',
-            'scope' => 'required|string|in:material,material_type,generic',
-            'material_id' => 'nullable|integer|exists:materials,id',
-            'material_type_id' => 'nullable|integer|exists:material_types,id',
-            'criteria' => 'required|array|min:1',
-            'criteria.*.name' => 'required|string|max:150',
-            'criteria.*.type' => 'required|string|in:visual,measurement,functional,pass_fail',
-            'criteria.*.required' => 'nullable|boolean',
-            'criteria.*.unit' => 'nullable|string|max:30',
-            'criteria.*.spec_min' => 'nullable|numeric',
-            'criteria.*.spec_max' => 'nullable|numeric',
-            'is_active' => 'nullable|boolean',
-        ]);
-
-        // Enforce scope coherence based on the radio choice.
-        $scope = $validated['scope'];
-        if ($scope === 'material') {
-            abort_unless($validated['material_id'] ?? null, 422, 'Pick a material when scope = material.');
-            $validated['material_type_id'] = null;
-        } elseif ($scope === 'material_type') {
-            abort_unless($validated['material_type_id'] ?? null, 422, 'Pick a material type when scope = material_type.');
-            $validated['material_id'] = null;
-        } else {
-            $validated['material_id'] = null;
-            $validated['material_type_id'] = null;
+        // Published versions that have been used by inspections must stay for
+        // historical reproducibility.
+        if ($inspectionPlan->isPublished() && $inspectionPlan->inspections()->exists()) {
+            return back()->with('error', __('Cannot delete a published version that has recorded inspections.'));
         }
 
-        unset($validated['scope']);
-        $validated['is_active'] = $validated['is_active'] ?? false;
+        $inspectionPlan->delete();
 
-        // Normalize criteria booleans (HTML form sends nothing when unchecked).
-        $validated['criteria'] = array_map(function ($c) {
-            $c['required'] = isset($c['required']) ? (bool) $c['required'] : false;
-
-            return $c;
-        }, $validated['criteria']);
-
-        return $validated;
+        return redirect()->route('admin.inspection-plans.index')
+            ->with('success', __('Inspection plan deleted.'));
     }
 }

--- a/backend/app/Http/Controllers/Web/InspectionController.php
+++ b/backend/app/Http/Controllers/Web/InspectionController.php
@@ -58,7 +58,7 @@ class InspectionController extends Controller
     {
         return Inertia::render('inspections/Create', [
             'materials' => Material::orderBy('name')->get(['id', 'code', 'name']),
-            'plans' => InspectionPlan::active()->orderBy('name')->with(['material:id,name', 'materialType:id,name'])->get(),
+            'plans' => InspectionPlan::active()->published()->orderBy('name')->with(['material:id,name', 'materialType:id,name'])->get(),
         ]);
     }
 

--- a/backend/app/Http/Requests/InspectionPlanRequest.php
+++ b/backend/app/Http/Requests/InspectionPlanRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validation for the admin inspection-plan form. `scope` is a form-only control
+ * that decides which target FK is persisted (material / material_type / generic).
+ */
+class InspectionPlanRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // route is behind auth + role:Admin
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:150'],
+            'description' => ['nullable', 'string'],
+            'scope' => ['required', 'string', 'in:material,material_type,generic'],
+            'material_id' => ['nullable', 'integer', 'exists:materials,id'],
+            'material_type_id' => ['nullable', 'integer', 'exists:material_types,id'],
+            'criteria' => ['required', 'array', 'min:1'],
+            'criteria.*.name' => ['required', 'string', 'max:150'],
+            'criteria.*.type' => ['required', 'string', 'in:visual,measurement,functional,pass_fail'],
+            'criteria.*.required' => ['nullable', 'boolean'],
+            'criteria.*.unit' => ['nullable', 'string', 'max:30'],
+            'criteria.*.spec_min' => ['nullable', 'numeric'],
+            'criteria.*.spec_max' => ['nullable', 'numeric'],
+            'is_active' => ['nullable', 'boolean'],
+        ];
+    }
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $scope = $this->input('scope');
+            if ($scope === 'material' && ! $this->filled('material_id')) {
+                $validator->errors()->add('material_id', __('Pick a material when scope is "material".'));
+            }
+            if ($scope === 'material_type' && ! $this->filled('material_type_id')) {
+                $validator->errors()->add('material_type_id', __('Pick a material type when scope is "material type".'));
+            }
+
+            foreach ($this->input('criteria', []) as $i => $c) {
+                if (($c['type'] ?? null) === 'measurement'
+                    && isset($c['spec_min'], $c['spec_max'])
+                    && $c['spec_min'] !== '' && $c['spec_max'] !== ''
+                    && (float) $c['spec_min'] > (float) $c['spec_max']) {
+                    $validator->errors()->add("criteria.$i.spec_min", __('Min cannot exceed max.'));
+                }
+            }
+        });
+    }
+
+    /**
+     * Normalized, persistable payload (scope resolved to FKs, criteria booleans
+     * coerced). Does NOT decide draft/publish state — the controller does.
+     */
+    public function payload(): array
+    {
+        $data = $this->validated();
+        $scope = $data['scope'];
+
+        if ($scope === 'material') {
+            $data['material_type_id'] = null;
+        } elseif ($scope === 'material_type') {
+            $data['material_id'] = null;
+        } else {
+            $data['material_id'] = null;
+            $data['material_type_id'] = null;
+        }
+        unset($data['scope']);
+
+        $data['criteria'] = array_map(function ($c) {
+            $c['required'] = ! empty($c['required']);
+
+            return $c;
+        }, $data['criteria']);
+
+        // is_active is owned by the publish lifecycle, never by the edit form.
+        unset($data['is_active']);
+
+        return $data;
+    }
+}

--- a/backend/app/Models/Inspection.php
+++ b/backend/app/Models/Inspection.php
@@ -14,17 +14,27 @@ class Inspection extends Model
     use HasTenant;
 
     public const STATUS_PENDING = 'pending';
+
     public const STATUS_PASS = 'pass';
+
     public const STATUS_FAIL = 'fail';
+
     public const STATUS_CONDITIONAL = 'conditional_pass';
 
     public const DISPOSITION_PENDING = 'pending';
+
     public const DISPOSITION_ACCEPT = 'accept';
+
     public const DISPOSITION_ACCEPT_WITH_DEVIATION = 'accept_with_deviation';
+
     public const DISPOSITION_REWORK = 'rework';
+
     public const DISPOSITION_SCRAP = 'scrap';
+
     public const DISPOSITION_RETURN_TO_SUPPLIER = 'return_to_supplier';
+
     public const DISPOSITION_QUARANTINE = 'quarantine';
+
     public const DISPOSITION_REJECT = 'reject';
 
     public const DISPOSITIONS = [
@@ -40,6 +50,7 @@ class Inspection extends Model
 
     protected $fillable = [
         'inspection_plan_id',
+        'plan_version',
         'material_id',
         'lot_number',
         'supplier_lot_ref',

--- a/backend/app/Models/InspectionPlan.php
+++ b/backend/app/Models/InspectionPlan.php
@@ -6,6 +6,7 @@ use App\Models\Concerns\HasTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class InspectionPlan extends Model
 {
@@ -19,6 +20,9 @@ class InspectionPlan extends Model
         'material_type_id',
         'criteria',
         'is_active',
+        'version',
+        'published_at',
+        'root_id',
         'tenant_id',
     ];
 
@@ -27,6 +31,8 @@ class InspectionPlan extends Model
         return [
             'criteria' => 'array',
             'is_active' => 'boolean',
+            'version' => 'integer',
+            'published_at' => 'datetime',
         ];
     }
 
@@ -40,14 +46,72 @@ class InspectionPlan extends Model
         return $this->belongsTo(MaterialType::class);
     }
 
+    /** The root of this plan's version group (itself when it is the root). */
+    public function root(): BelongsTo
+    {
+        return $this->belongsTo(InspectionPlan::class, 'root_id');
+    }
+
+    /** All versions belonging to the same group, including this one. */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(InspectionPlan::class, 'root_id', 'root_id');
+    }
+
+    /** Inspections performed against this exact plan version. */
+    public function inspections(): HasMany
+    {
+        return $this->hasMany(Inspection::class);
+    }
+
+    // ── Version-group helpers ────────────────────────────────────────────
+
+    /** Id that identifies this plan's version group. */
+    public function rootId(): int
+    {
+        return $this->root_id ?? $this->id;
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->published_at === null;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->published_at !== null;
+    }
+
+    /** Every version row in this plan's group (root + children), newest first. */
+    public function versionGroup()
+    {
+        $rootId = $this->rootId();
+
+        return static::where('id', $rootId)
+            ->orWhere('root_id', $rootId)
+            ->orderByDesc('version');
+    }
+
+    // ── Scopes ───────────────────────────────────────────────────────────
+
     public function scopeActive($query)
     {
         return $query->where('is_active', true);
     }
 
+    public function scopePublished($query)
+    {
+        return $query->whereNotNull('published_at');
+    }
+
+    /**
+     * Plans usable for an inspection of the given material — the live,
+     * published version (is_active + published) matching the material, its
+     * type, or a generic plan. Drafts are never offered.
+     */
     public function scopeApplicableTo($query, Material $material)
     {
-        return $query->active()->where(function ($q) use ($material) {
+        return $query->active()->published()->where(function ($q) use ($material) {
             $q->where('material_id', $material->id)
                 ->orWhere('material_type_id', $material->material_type_id)
                 ->orWhere(function ($q2) {

--- a/backend/app/Services/Quality/InboundInspectionService.php
+++ b/backend/app/Services/Quality/InboundInspectionService.php
@@ -31,6 +31,9 @@ class InboundInspectionService
         return DB::transaction(function () use ($material, $lotNumber, $quantity, $plan, $inspector, $supplierLotRef) {
             $inspection = Inspection::create([
                 'inspection_plan_id' => $plan?->id,
+                // Pin the exact plan version used so the inspection stays
+                // reproducible even after the plan is revised.
+                'plan_version' => $plan?->version,
                 'material_id' => $material->id,
                 'lot_number' => $lotNumber,
                 'supplier_lot_ref' => $supplierLotRef,
@@ -85,7 +88,7 @@ class InboundInspectionService
     public function complete(Inspection $inspection, ?string $notes = null): Inspection
     {
         if (! $inspection->isPending()) {
-            throw new RuntimeException('Inspection #' . $inspection->id . ' is already completed (status: ' . $inspection->status . ').');
+            throw new RuntimeException('Inspection #'.$inspection->id.' is already completed (status: '.$inspection->status.').');
         }
 
         $inspection->loadMissing('results', 'material', 'inspector');
@@ -205,7 +208,7 @@ class InboundInspectionService
 
         $failed = $inspection->results->filter(fn ($r) => $r->is_passed === false);
         $description = "Inbound inspection failed for material '{$inspection->material->name}' lot '{$inspection->lot_number}'.\n\nFailed criteria:\n"
-            . $failed->map(function ($r) {
+            .$failed->map(function ($r) {
                 $value = $r->value_numeric ?? ($r->value_boolean !== null ? ($r->value_boolean ? 'pass' : 'fail') : ($r->value_text ?? '—'));
                 $spec = $r->spec_min !== null && $r->spec_max !== null
                     ? " (spec: {$r->spec_min}–{$r->spec_max} {$r->unit})"

--- a/backend/app/Services/Quality/InspectionPlanVersionService.php
+++ b/backend/app/Services/Quality/InspectionPlanVersionService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Quality;
+
+use App\Models\InspectionPlan;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Versioning rules for inspection plans.
+ *
+ * A plan is a DRAFT until published (published_at = null) and can be edited in
+ * place. Once PUBLISHED it is immutable; editing it produces a new draft
+ * version in the same version group. Publishing a version makes it the single
+ * live version (is_active) and retires the previous live one — so inspections
+ * always run against the latest published version, while old versions stay
+ * intact for historical reproducibility.
+ */
+class InspectionPlanVersionService
+{
+    /**
+     * Create the next draft version from a published plan, copying its fields
+     * and criteria. Returns the new draft.
+     */
+    public function createNewVersion(InspectionPlan $plan, array $attributes): InspectionPlan
+    {
+        return DB::transaction(function () use ($plan, $attributes) {
+            $rootId = $plan->rootId();
+            $nextVersion = (int) InspectionPlan::query()
+                ->where(fn ($q) => $q->where('id', $rootId)->orWhere('root_id', $rootId))
+                ->max('version') + 1;
+
+            return InspectionPlan::create([
+                ...$attributes,
+                'version' => $nextVersion,
+                'root_id' => $rootId,
+                'published_at' => null, // draft
+                'is_active' => false,
+                'tenant_id' => $plan->tenant_id,
+            ]);
+        });
+    }
+
+    /**
+     * Publish a draft: stamp published_at, make it the live version, and retire
+     * every other version in the group. No-op if already published.
+     */
+    public function publish(InspectionPlan $plan): InspectionPlan
+    {
+        if ($plan->isPublished()) {
+            return $plan;
+        }
+
+        return DB::transaction(function () use ($plan) {
+            $rootId = $plan->rootId();
+
+            InspectionPlan::query()
+                ->where(fn ($q) => $q->where('id', $rootId)->orWhere('root_id', $rootId))
+                ->where('id', '!=', $plan->id)
+                ->update(['is_active' => false]);
+
+            $plan->update([
+                'published_at' => now(),
+                'is_active' => true,
+            ]);
+
+            return $plan->fresh();
+        });
+    }
+}

--- a/backend/app/Sync/ShapeRegistry.php
+++ b/backend/app/Sync/ShapeRegistry.php
@@ -155,7 +155,7 @@ class ShapeRegistry
         ],
         'inspection_plans' => [
             'table' => 'inspection_plans',
-            'columns' => ['id', 'name', 'description', 'material_id', 'material_type_id', 'is_active', 'created_at', 'updated_at'],
+            'columns' => ['id', 'name', 'description', 'material_id', 'material_type_id', 'is_active', 'version', 'published_at', 'root_id', 'created_at', 'updated_at'],
         ],
         'label_templates' => [
             'table' => 'label_templates',

--- a/backend/database/factories/InspectionPlanFactory.php
+++ b/backend/database/factories/InspectionPlanFactory.php
@@ -13,7 +13,7 @@ class InspectionPlanFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->words(3, true) . ' Inspection',
+            'name' => fake()->words(3, true).' Inspection',
             'description' => fake()->sentence(),
             'material_id' => Material::factory(),
             'material_type_id' => null,
@@ -22,6 +22,18 @@ class InspectionPlanFactory extends Factory
                 ['name' => 'Diameter', 'type' => 'measurement', 'unit' => 'mm', 'spec_min' => 9.8, 'spec_max' => 10.2, 'required' => true],
             ],
             'is_active' => true,
+            'version' => 1,
+            'published_at' => now(),
+            'root_id' => null,
         ];
+    }
+
+    /** A draft version (editable in place, not selectable for inspections). */
+    public function draft(): static
+    {
+        return $this->state(fn () => [
+            'is_active' => false,
+            'published_at' => null,
+        ]);
     }
 }

--- a/backend/database/migrations/2026_06_08_100000_add_versioning_to_inspection_plans_table.php
+++ b/backend/database/migrations/2026_06_08_100000_add_versioning_to_inspection_plans_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('inspection_plans', function (Blueprint $table) {
+            // Version number within a version group. The first version is 1.
+            $table->unsignedInteger('version')->default(1)->after('description');
+            // NULL = draft (editable in place); set = published & immutable.
+            $table->timestamp('published_at')->nullable()->after('version');
+            // Version group: the first version is the root (root_id = NULL);
+            // every later version points back to it. Lets us number versions
+            // and list a plan's history regardless of name/scope changes.
+            $table->foreignId('root_id')->nullable()->after('published_at')
+                ->constrained('inspection_plans')->nullOnDelete();
+
+            $table->index(['root_id', 'version']);
+        });
+
+        // Existing plans were already usable, so treat them as published at
+        // their creation time (keeps them selectable for inspections; their
+        // is_active flag still distinguishes live vs. retired).
+        DB::table('inspection_plans')->whereNull('published_at')->update([
+            'published_at' => DB::raw('created_at'),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('inspection_plans', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('root_id');
+            $table->dropColumn(['version', 'published_at']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_06_08_100001_add_plan_version_to_inspections_table.php
+++ b/backend/database/migrations/2026_06_08_100001_add_plan_version_to_inspections_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('inspections', function (Blueprint $table) {
+            // The plan version this inspection was performed against. The FK
+            // already points at the exact plan-version row; this denormalized
+            // number makes the version visible/auditable without a join and
+            // survives even if the plan row is later removed.
+            $table->unsignedInteger('plan_version')->nullable()->after('inspection_plan_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('inspections', function (Blueprint $table) {
+            $table->dropColumn('plan_version');
+        });
+    }
+};

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -3016,5 +3016,18 @@
     "No operator was recorded for this order.": "No operator was recorded for this order.",
     "started": "started",
     "released": "released",
-    "confirmed": "confirmed"
+    "confirmed": "confirmed",
+    "Archived": "Archived",
+    "Delete inspection plan \":name\"?": "Delete inspection plan \":name\"?",
+    "Draft": "Draft",
+    "Last edited :t": "Last edited :t",
+    "New Plan": "New Plan",
+    "Publish": "Publish",
+    "Publish this version? It becomes the live plan used for new inspections.": "Publish this version? It becomes the live plan used for new inspections.",
+    "Published": "Published",
+    "Published :t": "Published :t",
+    "Save as new version": "Save as new version",
+    "This is a draft — editable in place and not yet used for inspections.": "This is a draft — editable in place and not yet used for inspections.",
+    "This version is published and immutable. Saving creates a new draft version — the published version stays unchanged so past inspections remain reproducible.": "This version is published and immutable. Saving creates a new draft version — the published version stays unchanged so past inspections remain reproducible.",
+    "Version history": "Version history"
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -3016,5 +3016,18 @@
     "No operator was recorded for this order.": "Dla tego zlecenia nie zarejestrowano operatora.",
     "started": "rozpoczął",
     "released": "wydał",
-    "confirmed": "potwierdził"
+    "confirmed": "potwierdził",
+    "Archived": "Zarchiwizowany",
+    "Delete inspection plan \":name\"?": "Usunąć plan inspekcji „:name\"?",
+    "Draft": "Szkic",
+    "Last edited :t": "Ostatnia edycja :t",
+    "New Plan": "Nowy plan",
+    "Publish": "Opublikuj",
+    "Publish this version? It becomes the live plan used for new inspections.": "Opublikować tę wersję? Stanie się aktywnym planem dla nowych inspekcji.",
+    "Published": "Opublikowany",
+    "Published :t": "Opublikowano :t",
+    "Save as new version": "Zapisz jako nową wersję",
+    "This is a draft — editable in place and not yet used for inspections.": "To szkic — edytowalny w miejscu i jeszcze nieużywany do inspekcji.",
+    "This version is published and immutable. Saving creates a new draft version — the published version stays unchanged so past inspections remain reproducible.": "Ta wersja jest opublikowana i niezmienna. Zapis utworzy nową wersję-szkic — opublikowana wersja pozostaje bez zmian, aby przeszłe inspekcje były odtwarzalne.",
+    "Version history": "Historia wersji"
 }

--- a/backend/resources/js/Pages/admin/inspection-plans/Edit.jsx
+++ b/backend/resources/js/Pages/admin/inspection-plans/Edit.jsx
@@ -1,9 +1,21 @@
-import { Head, useForm, usePage } from '@inertiajs/react';
+import { Head, router, useForm, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import InspectionPlanForm from './Form';
+import { __, formatDateTime } from '../../../lib/i18n';
+
+function VersionBadge({ v }) {
+    const cls = v.is_draft
+        ? 'bg-amber-100 text-amber-800'
+        : v.is_active
+        ? 'bg-green-100 text-green-800'
+        : 'bg-gray-100 text-gray-500';
+    const label = v.is_draft ? __('Draft') : v.is_active ? __('Published') : __('Archived');
+    return <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${cls}`}>{label}</span>;
+}
 
 export default function InspectionPlanEdit() {
-    const { plan, materials = [], materialTypes = [] } = usePage().props;
+    const { plan, materials = [], materialTypes = [], history = [] } = usePage().props;
+
     const form = useForm({
         name: plan.name ?? '',
         description: plan.description ?? '',
@@ -11,15 +23,79 @@ export default function InspectionPlanEdit() {
         material_id: plan.material_id != null ? String(plan.material_id) : '',
         material_type_id: plan.material_type_id != null ? String(plan.material_type_id) : '',
         criteria: plan.criteria ?? [],
-        is_active: !!plan.is_active,
     });
-    const submit = (e) => { e.preventDefault(); form.put(`/admin/inspection-plans/${plan.id}`); };
+
+    const submit = (e) => {
+        e.preventDefault();
+        form.put(`/admin/inspection-plans/${plan.id}`);
+    };
+
+    const publish = () => {
+        if (confirm(__('Publish this version? It becomes the live plan used for new inspections.'))) {
+            router.post(`/admin/inspection-plans/${plan.id}/publish`);
+        }
+    };
 
     return (
         <div className="max-w-7xl mx-auto">
-            <Head title={`Edit ${plan.name}`} />
-            <h1 className="text-3xl font-bold text-gray-800 mb-6">Edit Inspection Plan</h1>
-            <InspectionPlanForm form={form} materials={materials} materialTypes={materialTypes} submitLabel="Save Changes" onSubmit={submit} />
+            <Head title={`${__('Edit')} ${plan.name}`} />
+
+            <div className="flex items-center gap-3 mb-2">
+                <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">{__('Edit Inspection Plan')}</h1>
+                <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">v{plan.version}</span>
+                <VersionBadge v={{ is_draft: plan.is_draft, is_active: plan.is_active }} />
+            </div>
+
+            {/* Lifecycle banner */}
+            {plan.is_draft ? (
+                <div className="mb-5 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 flex items-center justify-between gap-4">
+                    <p className="text-sm text-amber-800">
+                        {__('This is a draft — editable in place and not yet used for inspections.')}
+                    </p>
+                    <button type="button" onClick={publish} className="btn-touch btn-primary whitespace-nowrap">
+                        {__('Publish')}
+                    </button>
+                </div>
+            ) : (
+                <div className="mb-5 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3">
+                    <p className="text-sm text-blue-800">
+                        {__('This version is published and immutable. Saving creates a new draft version — the published version stays unchanged so past inspections remain reproducible.')}
+                    </p>
+                </div>
+            )}
+
+            <InspectionPlanForm
+                form={form}
+                materials={materials}
+                materialTypes={materialTypes}
+                submitLabel={plan.is_draft ? __('Save Changes') : __('Save as new version')}
+                onSubmit={submit}
+            />
+
+            {/* Version history */}
+            {history.length > 1 && (
+                <div className="mt-8 max-w-4xl">
+                    <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-3">{__('Version history')}</h2>
+                    <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm divide-y divide-gray-100 dark:divide-slate-700">
+                        {history.map((v) => (
+                            <div key={v.id} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+                                <span className="font-mono text-gray-500 w-10">v{v.version}</span>
+                                <VersionBadge v={v} />
+                                <span className="text-gray-500 flex-1">
+                                    {v.is_draft
+                                        ? __('Last edited :t', { t: formatDateTime(v.updated_at) })
+                                        : __('Published :t', { t: formatDateTime(v.published_at) })}
+                                </span>
+                                {v.id !== plan.id && (
+                                    <a href={`/admin/inspection-plans/${v.id}/edit`} className="text-blue-600 hover:underline">
+                                        {__('Open')}
+                                    </a>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/backend/resources/js/Pages/admin/inspection-plans/Form.jsx
+++ b/backend/resources/js/Pages/admin/inspection-plans/Form.jsx
@@ -83,11 +83,6 @@ export default function InspectionPlanForm({ form, materials, materialTypes, sub
                 {errors.criteria && <p className="mt-1 text-xs text-red-600">{errors.criteria}</p>}
             </div>
 
-            <label className="flex items-center gap-2 text-sm text-gray-700">
-                <input type="checkbox" checked={!!data.is_active} onChange={(e) => setData('is_active', e.target.checked)} />
-                Active
-            </label>
-
             <div className="flex items-center gap-3 pt-2">
                 <button type="submit" disabled={processing} className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50">
                     {processing ? 'Saving…' : submitLabel}

--- a/backend/resources/js/Pages/admin/inspection-plans/Index.jsx
+++ b/backend/resources/js/Pages/admin/inspection-plans/Index.jsx
@@ -1,49 +1,97 @@
 import { Head, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
-import ResourceTable, { ActiveBadge } from '../../../components/ResourceTable';
+import ResourceTable from '../../../components/ResourceTable';
+import { __ } from '../../../lib/i18n';
 
 function asArray(v) {
     if (Array.isArray(v)) return v;
-    if (typeof v === 'string' && v) { try { const p = JSON.parse(v); return Array.isArray(p) ? p : []; } catch { return []; } }
+    if (typeof v === 'string' && v) {
+        try {
+            const p = JSON.parse(v);
+            return Array.isArray(p) ? p : [];
+        } catch {
+            return [];
+        }
+    }
     return [];
+}
+
+function planStatus(r) {
+    if (!r.published_at) return { label: __('Draft'), cls: 'bg-amber-100 text-amber-800' };
+    if (r.is_active) return { label: __('Published'), cls: 'bg-green-100 text-green-800' };
+    return { label: __('Archived'), cls: 'bg-gray-100 text-gray-500' };
 }
 
 export default function InspectionPlansIndex() {
     const { materialNames = {}, materialTypeNames = {} } = usePage().props;
 
     const columns = [
-        { key: 'name', label: 'Name', className: 'font-medium text-gray-800' },
+        { key: 'name', label: __('Name'), className: 'font-medium text-gray-800' },
         {
-            key: 'scope', label: 'Scope', className: 'text-gray-600',
-            render: (r) => r.material_id ? `Material: ${materialNames[r.material_id] ?? '?'}`
-                : r.material_type_id ? `Type: ${materialTypeNames[r.material_type_id] ?? '?'}`
-                    : 'Generic',
+            key: 'version',
+            label: __('Version'),
+            className: 'text-gray-600 font-mono',
+            render: (r) => `v${r.version ?? 1}`,
         },
-        { key: 'criteria', label: 'Criteria', render: (r) => asArray(r.criteria).length },
-        { key: 'is_active', label: 'Status', render: (r) => <ActiveBadge active={r.is_active} /> },
+        {
+            key: 'scope',
+            label: __('Scope'),
+            className: 'text-gray-600',
+            render: (r) =>
+                r.material_id
+                    ? `${__('Material')}: ${materialNames[r.material_id] ?? '?'}`
+                    : r.material_type_id
+                    ? `${__('Type')}: ${materialTypeNames[r.material_type_id] ?? '?'}`
+                    : __('Generic'),
+        },
+        { key: 'criteria', label: __('Criteria'), render: (r) => asArray(r.criteria).length },
+        {
+            key: 'status',
+            label: __('Status'),
+            render: (r) => {
+                const s = planStatus(r);
+                return <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.cls}`}>{s.label}</span>;
+            },
+        },
     ];
 
-    const actions = (r) => [
-        { label: 'Edit', href: `/admin/inspection-plans/${r.id}/edit` },
-        {
-            label: 'Delete',
+    const actions = (r) => {
+        const items = [{ label: __('Edit'), href: `/admin/inspection-plans/${r.id}/edit` }];
+        if (!r.published_at) {
+            items.push({
+                label: __('Publish'),
+                className: 'text-green-700 hover:underline',
+                onClick: () => {
+                    if (confirm(__('Publish this version? It becomes the live plan used for new inspections.'))) {
+                        router.post(`/admin/inspection-plans/${r.id}/publish`, {}, { preserveScroll: true });
+                    }
+                },
+            });
+        }
+        items.push({
+            label: __('Delete'),
             className: 'text-red-600 hover:underline',
-            onClick: () => { if (confirm(`Delete inspection plan "${r.name}"?`)) router.delete(`/admin/inspection-plans/${r.id}`, { preserveScroll: true }); },
-        },
-    ];
+            onClick: () => {
+                if (confirm(__('Delete inspection plan ":name"?', { name: r.name }))) {
+                    router.delete(`/admin/inspection-plans/${r.id}`, { preserveScroll: true });
+                }
+            },
+        });
+        return items;
+    };
 
     return (
         <>
-            <Head title="Inspection Plans" />
+            <Head title={__('Inspection Plans')} />
             <ResourceTable
                 shape="inspection_plans"
-                title="Inspection Plans"
+                title={__('Inspection Plans')}
                 createHref="/admin/inspection-plans/create"
-                createLabel="+ New Plan"
+                createLabel={`+ ${__('New Plan')}`}
                 columns={columns}
                 orderBy="name"
                 actions={actions}
-                emptyText="No inspection plans yet."
+                emptyText={__('No inspection plans yet.')}
             />
         </>
     );

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -432,6 +432,7 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
         // Inspection plans — admin mutations
         Route::post('/inspection-plans', [InspectionPlanController::class, 'store']);
         Route::patch('/inspection-plans/{inspectionPlan}', [InspectionPlanController::class, 'update']);
+        Route::post('/inspection-plans/{inspectionPlan}/publish', [InspectionPlanController::class, 'publish']);
         Route::delete('/inspection-plans/{inspectionPlan}', [InspectionPlanController::class, 'destroy']);
 
         // BOM Items — admin mutations

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -536,7 +536,8 @@ Route::middleware('auth')->group(function () {
         Route::post('/production-anomalies/{productionAnomaly}/process', [ProductionAnomalyController::class, 'process'])->name('production-anomalies.process');
         Route::delete('/production-anomalies/{productionAnomaly}', [ProductionAnomalyController::class, 'destroy'])->name('production-anomalies.destroy');
 
-        // Inspection Plans (admin CRUD)
+        // Inspection Plans (admin CRUD + version publish)
+        Route::post('inspection-plans/{inspection_plan}/publish', [\App\Http\Controllers\Web\Admin\InspectionPlanController::class, 'publish'])->name('inspection-plans.publish');
         Route::resource('inspection-plans', \App\Http\Controllers\Web\Admin\InspectionPlanController::class)->except(['show']);
 
         // ── Gate 6: Costing ───────────────────────────────────────────────────

--- a/backend/tests/Feature/InspectionPlanVersioningTest.php
+++ b/backend/tests/Feature/InspectionPlanVersioningTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InspectionPlan;
+use App\Models\Material;
+use App\Models\User;
+use App\Services\Quality\InboundInspectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class InspectionPlanVersioningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $inspector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Operator', 'guard_name' => 'web']);
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+
+        $this->inspector = User::factory()->create();
+        $this->inspector->assignRole('Operator');
+    }
+
+    private function planPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Bolt QC',
+            'description' => 'x',
+            'scope' => 'generic',
+            'criteria' => [
+                ['name' => 'Visual', 'type' => 'pass_fail', 'required' => true],
+            ],
+        ], $overrides);
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────────
+
+    public function test_new_plan_is_created_as_draft(): void
+    {
+        $this->actingAs($this->admin)->post('/admin/inspection-plans', $this->planPayload())
+            ->assertRedirect();
+
+        $plan = InspectionPlan::firstWhere('name', 'Bolt QC');
+        $this->assertNotNull($plan);
+        $this->assertSame(1, $plan->version);
+        $this->assertNull($plan->published_at);
+        $this->assertFalse($plan->is_active);
+        $this->assertNull($plan->root_id);
+    }
+
+    public function test_editing_a_draft_updates_in_place(): void
+    {
+        $plan = InspectionPlan::factory()->draft()->create(['name' => 'Draft P']);
+
+        $this->actingAs($this->admin)->put("/admin/inspection-plans/{$plan->id}", $this->planPayload([
+            'name' => 'Draft P edited',
+        ]))->assertRedirect();
+
+        $this->assertSame(1, InspectionPlan::count()); // no new version
+        $this->assertSame('Draft P edited', $plan->fresh()->name);
+        $this->assertSame(1, $plan->fresh()->version);
+    }
+
+    public function test_publishing_makes_it_live(): void
+    {
+        $plan = InspectionPlan::factory()->draft()->create();
+
+        $this->actingAs($this->admin)->post("/admin/inspection-plans/{$plan->id}/publish")
+            ->assertRedirect();
+
+        $plan->refresh();
+        $this->assertNotNull($plan->published_at);
+        $this->assertTrue($plan->is_active);
+    }
+
+    public function test_editing_a_published_plan_creates_a_new_draft_version(): void
+    {
+        $v1 = InspectionPlan::factory()->create(['name' => 'Spec', 'version' => 1]); // published
+
+        $this->actingAs($this->admin)->put("/admin/inspection-plans/{$v1->id}", $this->planPayload([
+            'name' => 'Spec v2',
+        ]))->assertRedirect();
+
+        $this->assertSame(2, InspectionPlan::count());
+
+        // v1 untouched
+        $v1->refresh();
+        $this->assertSame('Spec', $v1->name);
+        $this->assertNotNull($v1->published_at);
+
+        // v2 is a draft in the same group
+        $v2 = InspectionPlan::where('id', '!=', $v1->id)->first();
+        $this->assertSame(2, $v2->version);
+        $this->assertSame($v1->id, $v2->root_id);
+        $this->assertNull($v2->published_at);
+        $this->assertFalse($v2->is_active);
+        $this->assertSame('Spec v2', $v2->name);
+    }
+
+    public function test_publishing_v2_retires_v1(): void
+    {
+        $v1 = InspectionPlan::factory()->create(['version' => 1]); // published & active
+        $v2 = InspectionPlan::factory()->draft()->create(['version' => 2, 'root_id' => $v1->id]);
+
+        $this->actingAs($this->admin)->post("/admin/inspection-plans/{$v2->id}/publish");
+
+        $this->assertFalse($v1->fresh()->is_active);   // archived
+        $this->assertTrue($v2->fresh()->is_active);    // live
+        $this->assertNotNull($v2->fresh()->published_at);
+    }
+
+    // ── Inspections pin the version ──────────────────────────────────────
+
+    public function test_inspection_records_the_plan_version_and_snapshots_criteria(): void
+    {
+        $material = Material::factory()->create();
+        $plan = InspectionPlan::factory()->create([
+            'version' => 3,
+            'material_id' => $material->id,
+            'criteria' => [
+                ['name' => 'Length', 'type' => 'measurement', 'unit' => 'mm', 'spec_min' => 1, 'spec_max' => 2, 'required' => true],
+            ],
+        ]);
+
+        $inspection = app(InboundInspectionService::class)->start(
+            $material, 'LOT1', 10, $plan, $this->inspector,
+        );
+
+        $this->assertSame(3, $inspection->plan_version);
+        $this->assertSame($plan->id, $inspection->inspection_plan_id);
+
+        // Criteria snapshotted into results (reproducible even if plan changes).
+        $this->assertCount(1, $inspection->results);
+        $this->assertSame('Length', $inspection->results->first()->criterion_name);
+    }
+
+    public function test_only_published_active_versions_are_offered_for_inspection(): void
+    {
+        $material = Material::factory()->create();
+        InspectionPlan::factory()->create(['name' => 'Live', 'material_id' => $material->id]);          // published+active
+        InspectionPlan::factory()->draft()->create(['name' => 'Draft', 'material_id' => $material->id]); // draft
+        $archived = InspectionPlan::factory()->create(['name' => 'Old', 'material_id' => $material->id, 'is_active' => false]);
+
+        $applicable = InspectionPlan::applicableTo($material)->pluck('name')->all();
+
+        $this->assertContains('Live', $applicable);
+        $this->assertNotContains('Draft', $applicable);
+        $this->assertNotContains('Old', $applicable);
+    }
+
+    // ── Deletion guard ───────────────────────────────────────────────────
+
+    public function test_cannot_delete_published_version_with_inspections(): void
+    {
+        $material = Material::factory()->create();
+        $plan = InspectionPlan::factory()->create(['material_id' => $material->id]);
+        app(InboundInspectionService::class)->start($material, 'LOT', 1, $plan, $this->inspector);
+
+        $this->actingAs($this->admin)->delete("/admin/inspection-plans/{$plan->id}")
+            ->assertSessionHas('error');
+
+        $this->assertDatabaseHas('inspection_plans', ['id' => $plan->id]);
+    }
+
+    public function test_draft_can_be_deleted(): void
+    {
+        $plan = InspectionPlan::factory()->draft()->create();
+
+        $this->actingAs($this->admin)->delete("/admin/inspection-plans/{$plan->id}")
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('inspection_plans', ['id' => $plan->id]);
+    }
+
+    // ── Authorization ────────────────────────────────────────────────────
+
+    public function test_guest_cannot_publish(): void
+    {
+        $plan = InspectionPlan::factory()->draft()->create();
+        $this->post("/admin/inspection-plans/{$plan->id}/publish")->assertRedirect('/login');
+    }
+
+    public function test_operator_cannot_publish(): void
+    {
+        $plan = InspectionPlan::factory()->draft()->create();
+        $this->actingAs($this->inspector)->post("/admin/inspection-plans/{$plan->id}/publish")->assertForbidden();
+    }
+}

--- a/backend/tests/Feature/Web/InspectionWebTest.php
+++ b/backend/tests/Feature/Web/InspectionWebTest.php
@@ -125,12 +125,12 @@ class InspectionWebTest extends TestCase
 
     public function test_create_plan_with_invalid_scope_rejected(): void
     {
-        // scope=material but no material_id
+        // scope=material but no material_id → form-request validation error
         $response = $this->actingAs($this->admin)->post(route('admin.inspection-plans.store'), [
             'name' => 'Bad plan',
             'scope' => 'material',
             'criteria' => [['name' => 'A', 'type' => 'pass_fail']],
         ]);
-        $response->assertStatus(422);
+        $response->assertSessionHasErrors('material_id');
     }
 }


### PR DESCRIPTION
## Summary

Inspection plans are now versioned with a draft→publish lifecycle, and inspections pin the exact plan version used — so historical inspections stay reproducible even after a plan is revised.

## Lifecycle
- **New plan** = version 1 **Draft** (`published_at` null, editable in place, not usable for inspections)
- **Publish** → becomes the single live version (`is_active`), retiring the previous one. Only published+active versions are offered when starting an inspection.
- **Editing a published plan** does NOT mutate it — it spawns the next **Draft** version in the same version group (`root_id` self-reference). The published version stays immutable.

## Reproducibility (three layers)
- `inspections.plan_version` pins the exact version number used
- the existing FK `inspection_plan_id` points at that exact version row
- criteria are still snapshot-copied into `inspection_results` at inspection start

## Data model
- `inspection_plans`: `version`, `published_at`, `root_id` (self-FK version group). Existing rows backfilled `published_at = created_at` so they stay selectable.
- `inspections`: `plan_version`
- ShapeRegistry columns updated for the admin list

## Backend
- `InspectionPlanVersionService` (createNewVersion / publish) shared by web + API
- Web + API `update()` branch: draft → in-place, published → new version; `publish` endpoint
- Web validation moved from inline `abort(422)` to a Form Request (CLAUDE.md rule 3)
- `is_active` is now owned by the publish lifecycle, removed from the edit form
- Deleting a published version that has inspections is blocked

## Frontend
- Index: **Version** column + **Draft / Published / Archived** status + Publish action
- Edit: version + status badges, a banner explaining published-edit creates a new version, a Publish button for drafts, and a version-history list

## Tests
11 feature tests (lifecycle, version spawn from published, publish retires prior, inspection pins version + snapshots criteria, only-published-applicable, delete guard, authz). Full suite: pre-existing baseline failures only, no regressions. i18n en/pl parity.

## Verified manually
Created plan → Draft; published → live; edited published → v2 draft (v1 untouched in DB); version history shows v1+v2; published v2 → v1 archived, v2 live. All badges/banners/flashes correct.

## Note
Two legacy seed plans store criteria as a string array (`["a","b"]`) instead of the current object format (`[{name,type,…}]`); the edit form can't render those rows. Pre-existing data issue, unrelated to versioning.