### PR TITLE
feat: per-step process photos (one photo per production step)

### DIFF
--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
@@ -118,6 +118,7 @@ class ProcessTemplateManagementController extends Controller
                 ]),
                 'photos'     => $processTemplate->photos->map(fn($p) => [
                     'id'            => $p->id,
+                    'template_step_id' => $p->template_step_id,
                     'url'           => route('process-templates.photos.show', [$processTemplate, $p]),
                     'original_name' => $p->original_name,
                     'caption'       => $p->caption,

--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplatePhotoController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplatePhotoController.php
@@ -8,6 +8,7 @@ use App\Models\ProcessTemplate;
 use App\Models\ProcessTemplatePhoto;
 use App\Models\ProductType;
 use App\Services\Media\ImageSanitizer;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -35,7 +36,16 @@ class ProcessTemplatePhotoController extends Controller
     ) {
         $this->ensureBelongs($productType, $processTemplate);
 
-        if ($processTemplate->photos()->count() >= StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE) {
+        // A photo may target one specific step. Verify the step belongs to this
+        // template (anti-IDOR) before persisting the link.
+        $stepId = $request->validated('template_step_id');
+        if ($stepId) {
+            abort_unless(
+                $processTemplate->steps()->whereKey($stepId)->exists(),
+                404,
+            );
+        } elseif ($processTemplate->photos()->whereNull('template_step_id')->count() >= StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE) {
+            // The per-template cap applies only to general (non-step) photos.
             return back()->withErrors([
                 'photo' => 'Photo limit reached ('.StoreProcessTemplatePhotoRequest::MAX_PHOTOS_PER_TEMPLATE.' per template).',
             ]);
@@ -52,17 +62,27 @@ class ProcessTemplatePhotoController extends Controller
         $path = 'process-template-photos/'.$processTemplate->id.'/'.Str::random(40).'.'.$clean['extension'];
         Storage::put($path, $clean['bytes']);
 
-        $processTemplate->photos()->create([
-            'original_name' => Str::limit($request->file('photo')->getClientOriginalName(), 255, ''),
-            'storage_path' => $path,
-            'mime_type' => $clean['mime'],
-            'file_size' => strlen($clean['bytes']),
-            'width' => $clean['width'],
-            'height' => $clean['height'],
-            'caption' => $request->validated('caption'),
-            'sort_order' => ($processTemplate->photos()->max('sort_order') ?? 0) + 1,
-            'uploaded_by_id' => $request->user()->id,
-        ]);
+        DB::transaction(function () use ($processTemplate, $stepId, $path, $clean, $request) {
+            // One photo per step: a new step photo replaces the existing one
+            // (its disk file is removed by the model's deleted event).
+            if ($stepId) {
+                $processTemplate->photos()->where('template_step_id', $stepId)->get()
+                    ->each(fn (ProcessTemplatePhoto $p) => $p->delete());
+            }
+
+            $processTemplate->photos()->create([
+                'template_step_id' => $stepId,
+                'original_name' => Str::limit($request->file('photo')->getClientOriginalName(), 255, ''),
+                'storage_path' => $path,
+                'mime_type' => $clean['mime'],
+                'file_size' => strlen($clean['bytes']),
+                'width' => $clean['width'],
+                'height' => $clean['height'],
+                'caption' => $request->validated('caption'),
+                'sort_order' => ($processTemplate->photos()->max('sort_order') ?? 0) + 1,
+                'uploaded_by_id' => $request->user()->id,
+            ]);
+        });
 
         return back()->with('success', 'Photo uploaded.');
     }

--- a/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
+++ b/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
@@ -265,22 +265,36 @@ class WorkOrderController extends Controller
         // instructions reach in-flight orders; the snapshot itself stays frozen.
         // Served via the authenticated stream route, so any logged-in operator
         // may view them.
-        $processPhotos = collect();
+        $processPhotos = collect();   // general (non-step) work-instruction gallery
+        $stepPhotos = [];             // step_number => photo, shown inline per step
         $templateId = $workOrder->process_snapshot['template_id'] ?? null;
         if ($templateId) {
-            $processPhotos = \App\Models\ProcessTemplatePhoto::where('process_template_id', $templateId)
+            $photos = \App\Models\ProcessTemplatePhoto::where('process_template_id', $templateId)
+                ->with('templateStep:id,step_number')
                 ->orderBy('sort_order')
                 ->orderBy('id')
-                ->get()
-                ->map(fn ($p) => [
-                    'id' => $p->id,
-                    'url' => route('process-templates.photos.show', [$templateId, $p->id]),
-                    'caption' => $p->caption,
-                    'width' => $p->width,
-                    'height' => $p->height,
-                ]);
+                ->get();
+
+            $shape = fn ($p) => [
+                'id' => $p->id,
+                'url' => route('process-templates.photos.show', [$templateId, $p->id]),
+                'caption' => $p->caption,
+                'width' => $p->width,
+                'height' => $p->height,
+            ];
+
+            $processPhotos = $photos->whereNull('template_step_id')->map($shape)->values();
+
+            // A batch step links back to its template step only by step_number
+            // (the snapshot doesn't carry template_step_id), so key by that.
+            foreach ($photos->whereNotNull('template_step_id') as $p) {
+                $num = $p->templateStep?->step_number;
+                if ($num !== null) {
+                    $stepPhotos[$num] = $shape($p);
+                }
+            }
         }
 
-        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'scrapReasons', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates', 'processPhotos'));
+        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'scrapReasons', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates', 'processPhotos', 'stepPhotos'));
     }
 }

--- a/backend/app/Http/Requests/StoreProcessTemplatePhotoRequest.php
+++ b/backend/app/Http/Requests/StoreProcessTemplatePhotoRequest.php
@@ -27,6 +27,9 @@ class StoreProcessTemplatePhotoRequest extends FormRequest
                     ->max(10 * 1024), // 10 MB
             ],
             'caption' => ['nullable', 'string', 'max:255'],
+            // Optional: tie the photo to one production step. The controller
+            // additionally verifies the step belongs to this template (IDOR).
+            'template_step_id' => ['nullable', 'integer', 'exists:template_steps,id'],
         ];
     }
 }

--- a/backend/app/Models/ProcessTemplatePhoto.php
+++ b/backend/app/Models/ProcessTemplatePhoto.php
@@ -13,6 +13,7 @@ class ProcessTemplatePhoto extends Model
 
     protected $fillable = [
         'process_template_id',
+        'template_step_id',
         'original_name',
         'storage_path',
         'mime_type',
@@ -45,6 +46,11 @@ class ProcessTemplatePhoto extends Model
     public function processTemplate(): BelongsTo
     {
         return $this->belongsTo(ProcessTemplate::class);
+    }
+
+    public function templateStep(): BelongsTo
+    {
+        return $this->belongsTo(TemplateStep::class);
     }
 
     public function uploadedBy(): BelongsTo

--- a/backend/app/Models/TemplateStep.php
+++ b/backend/app/Models/TemplateStep.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class TemplateStep extends Model
 {
@@ -56,6 +57,14 @@ class TemplateStep extends Model
     public function processSegment(): BelongsTo
     {
         return $this->belongsTo(ProcessSegment::class);
+    }
+
+    /**
+     * Reference photo(s) attached to this specific step. Currently one per step.
+     */
+    public function photos(): HasMany
+    {
+        return $this->hasMany(ProcessTemplatePhoto::class);
     }
 
     /**

--- a/backend/database/migrations/2026_06_08_140000_add_template_step_id_to_process_template_photos_table.php
+++ b/backend/database/migrations/2026_06_08_140000_add_template_step_id_to_process_template_photos_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('process_template_photos', function (Blueprint $table) {
+            // A photo can be tied to one specific production step (one photo per
+            // step). NULL = a general template-level photo (the existing
+            // gallery). nullOnDelete so removing a step doesn't delete the photo
+            // row out from under the model's disk-cleanup event.
+            $table->foreignId('template_step_id')->nullable()->after('process_template_id')
+                ->constrained('template_steps')->nullOnDelete();
+
+            $table->index('template_step_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('process_template_photos', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('template_step_id');
+        });
+    }
+};

--- a/backend/resources/js/Pages/admin/process-templates/Show.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Show.jsx
@@ -255,8 +255,82 @@ function EditStepForm({ step, productType, processTemplate, processSegments, wor
 /* ------------------------------------------------------------------ */
 /* Single step row (view + edit toggle)                                  */
 /* ------------------------------------------------------------------ */
+/* ------------------------------------------------------------------ */
+/* Per-step photo (one image per step) — upload / replace / delete       */
+/* ------------------------------------------------------------------ */
+function StepPhoto({ step, photo, baseUrl }) {
+    const form = useForm({ photo: null, template_step_id: step.id });
+    const inputRef = useRef(null);
+    const [zoom, setZoom] = useState(false);
+
+    const pick = () => inputRef.current?.click();
+
+    const onFile = (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        form.setData('photo', file);
+        // upload immediately (replace-on-upload, one per step)
+        form.transform((d) => ({ photo: file, template_step_id: step.id })).post(baseUrl, {
+            preserveScroll: true,
+            forceFormData: true,
+            onFinish: () => {
+                if (inputRef.current) inputRef.current.value = '';
+            },
+        });
+    };
+
+    const remove = () => {
+        if (confirm('Delete this step photo?')) {
+            router.delete(`${baseUrl}/${photo.id}`, { preserveScroll: true });
+        }
+    };
+
+    return (
+        <div className="mt-3 flex items-center gap-3">
+            {photo ? (
+                <>
+                    <button type="button" onClick={() => setZoom(true)} title={photo.caption || photo.original_name}>
+                        <img
+                            src={photo.url}
+                            alt={photo.caption || 'Step photo'}
+                            className="w-20 h-20 object-cover rounded-lg border border-gray-200 bg-gray-100"
+                        />
+                    </button>
+                    <div className="flex flex-col gap-1">
+                        <button type="button" onClick={pick} disabled={form.processing} className="text-xs text-blue-600 hover:underline text-left">
+                            {form.processing ? 'Uploading…' : 'Replace photo'}
+                        </button>
+                        <button type="button" onClick={remove} className="text-xs text-red-600 hover:underline text-left">
+                            Remove
+                        </button>
+                    </div>
+                </>
+            ) : (
+                <button
+                    type="button"
+                    onClick={pick}
+                    disabled={form.processing}
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-gray-300 text-sm text-gray-500 hover:border-blue-400 hover:text-blue-600 disabled:opacity-50"
+                >
+                    <Icon d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z M15 13a3 3 0 11-6 0 3 3 0 016 0z" className="w-4 h-4" />
+                    {form.processing ? 'Uploading…' : 'Add step photo'}
+                </button>
+            )}
+            {form.errors.photo && <span className="text-xs text-red-600">{form.errors.photo}</span>}
+
+            <input ref={inputRef} type="file" accept="image/jpeg,image/png,image/webp" className="hidden" onChange={onFile} />
+
+            {zoom && photo && (
+                <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-6" onClick={() => setZoom(false)}>
+                    <img src={photo.url} alt={photo.caption || ''} className="max-w-full max-h-[85vh] rounded-lg shadow-2xl" onClick={(e) => e.stopPropagation()} />
+                </div>
+            )}
+        </div>
+    );
+}
+
 function StepCard({
-    step, isFirst, isLast, editingId, onEditStart, onEditCancel,
+    step, photo, photosBaseUrl, isFirst, isLast, editingId, onEditStart, onEditCancel,
     productType, processTemplate, processSegments, workstations,
     onMoveUp, onMoveDown, onDelete,
     dragHandleProps,
@@ -378,6 +452,8 @@ function StepCard({
                                     <p className="text-sm text-gray-700 whitespace-pre-wrap">{step.instruction}</p>
                                 </div>
                             )}
+
+                            <StepPhoto step={step} photo={photo} baseUrl={photosBaseUrl} />
                         </div>
                     </div>
                 </div>
@@ -402,6 +478,12 @@ export default function ProcessTemplatesShow() {
     const { productType, processTemplate, workstations = [], processSegments = [] } = usePage().props;
 
     const steps = processTemplate.steps ?? [];
+    const allPhotos = processTemplate.photos ?? [];
+    const photoByStep = {};
+    allPhotos.forEach((p) => {
+        if (p.template_step_id) photoByStep[p.template_step_id] = p;
+    });
+    const photosBaseUrl = `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/photos`;
     const [showAddForm, setShowAddForm] = useState(false);
     const [editingId, setEditingId] = useState(null);
     const [saveStatus, setSaveStatus] = useState(null); // 'saving' | 'saved' | 'error'
@@ -579,6 +661,8 @@ export default function ProcessTemplatesShow() {
                             <div key={step.id} data-step-id={step.id}>
                                 <StepCard
                                     step={step}
+                                    photo={photoByStep[step.id] ?? null}
+                                    photosBaseUrl={photosBaseUrl}
                                     isFirst={idx === 0}
                                     isLast={idx === steps.length - 1}
                                     editingId={editingId}
@@ -645,7 +729,8 @@ export default function ProcessTemplatesShow() {
  * and serves files through an authenticated endpoint — never a public URL.
  */
 function PhotosSection({ productType, processTemplate }) {
-    const photos = processTemplate.photos ?? [];
+    // Only general (non-step) photos here; per-step photos live on each StepCard.
+    const photos = (processTemplate.photos ?? []).filter((p) => !p.template_step_id);
     const baseUrl = `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/photos`;
 
     const form = useForm({ photo: null, caption: '' });
@@ -673,7 +758,7 @@ function PhotosSection({ productType, processTemplate }) {
     return (
         <div className="mt-10">
             <div className="flex items-center gap-2 mb-4">
-                <h2 className="text-xl font-bold text-gray-800">Reference Photos</h2>
+                <h2 className="text-xl font-bold text-gray-800">General Reference Photos</h2>
                 <span className="text-sm text-gray-500">({photos.length}/20)</span>
             </div>
 

--- a/backend/resources/js/Pages/admin/process-templates/Show.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Show.jsx
@@ -268,12 +268,13 @@ function StepPhoto({ step, photo, baseUrl }) {
     const onFile = (e) => {
         const file = e.target.files?.[0];
         if (!file) return;
-        form.setData('photo', file);
         // upload immediately (replace-on-upload, one per step)
-        form.transform((d) => ({ photo: file, template_step_id: step.id })).post(baseUrl, {
+        form.transform(() => ({ photo: file, template_step_id: step.id }));
+        form.post(baseUrl, {
             preserveScroll: true,
             forceFormData: true,
             onFinish: () => {
+                form.transform((d) => d);
                 if (inputRef.current) inputRef.current.value = '';
             },
         });

--- a/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
+++ b/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
@@ -570,7 +570,7 @@ function ProductionControls({ batch }) {
 // Single Batch card
 // ---------------------------------------------------------------------------
 
-function BatchCard({ batch, defaultOpen, labelTemplates = [] }) {
+function BatchCard({ batch, defaultOpen, labelTemplates = [], stepPhotos = {} }) {
     const [expanded, setExpanded] = useState(defaultOpen);
     const showControls = batch.status === 'IN_PROGRESS' || batch.status === 'DONE';
 
@@ -642,7 +642,7 @@ function BatchCard({ batch, defaultOpen, labelTemplates = [] }) {
                     </div>
 
                     {/* Steps */}
-                    <BatchStepList steps={batch.steps ?? []} labelTemplates={labelTemplates} />
+                    <BatchStepList steps={batch.steps ?? []} labelTemplates={labelTemplates} stepPhotos={stepPhotos} />
 
                     {/* Production controls */}
                     {showControls && <ProductionControls batch={batch} />}
@@ -656,8 +656,9 @@ function BatchCard({ batch, defaultOpen, labelTemplates = [] }) {
 // Batch Steps list (replaces the Livewire component)
 // ---------------------------------------------------------------------------
 
-function BatchStepList({ steps, labelTemplates = [] }) {
+function BatchStepList({ steps, labelTemplates = [], stepPhotos = {} }) {
     const [inflightStepId, setInflightStepId] = useState(null);
+    const [photoZoom, setPhotoZoom] = useState(null);
 
     if (!steps || steps.length === 0) return null;
 
@@ -679,11 +680,27 @@ function BatchStepList({ steps, labelTemplates = [] }) {
             <div className="space-y-2">
                 {steps.map((step) => {
                     const isInflight = inflightStepId === step.id;
+                    const photo = stepPhotos[step.step_number];
                     return (
                         <div key={step.id} className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
                             <span className="w-7 h-7 flex-shrink-0 flex items-center justify-center rounded-full text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
                                 {step.step_number}
                             </span>
+                            {photo && (
+                                <button
+                                    type="button"
+                                    onClick={() => setPhotoZoom(photo)}
+                                    className="flex-shrink-0"
+                                    title={photo.caption || 'Step photo'}
+                                >
+                                    <img
+                                        src={photo.url}
+                                        alt={photo.caption || 'Step photo'}
+                                        loading="lazy"
+                                        className="w-12 h-12 object-cover rounded-md border border-gray-200 dark:border-gray-700 bg-gray-100"
+                                    />
+                                </button>
+                            )}
                             <span className="flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">
                                 {step.name}
                             </span>
@@ -747,6 +764,17 @@ function BatchStepList({ steps, labelTemplates = [] }) {
                     );
                 })}
             </div>
+
+            {photoZoom && (
+                <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-6" onClick={() => setPhotoZoom(null)}>
+                    <figure className="max-w-3xl max-h-full m-0" onClick={(e) => e.stopPropagation()}>
+                        <img src={photoZoom.url} alt={photoZoom.caption || 'Step photo'} className="max-w-full max-h-[80vh] rounded-lg shadow-2xl" />
+                        {photoZoom.caption && (
+                            <figcaption className="text-white/90 text-sm mt-3 text-center">{photoZoom.caption}</figcaption>
+                        )}
+                    </figure>
+                </div>
+            )}
         </div>
     );
 }
@@ -1112,7 +1140,7 @@ function ReportScrapModal({ workOrder, scrapReasons, onClose }) {
 // ---------------------------------------------------------------------------
 
 export default function WorkOrderDetail() {
-    const { workOrder, issueTypes = [], scrapReasons = [], workstations = [], defaultWorkstationId, line, labelTemplates = [], processPhotos = [] } = usePage().props;
+    const { workOrder, issueTypes = [], scrapReasons = [], workstations = [], defaultWorkstationId, line, labelTemplates = [], processPhotos = [], stepPhotos = {} } = usePage().props;
 
     const [createBatchOpen, setCreateBatchOpen] = useState(false);
     const [reportIssueOpen, setReportIssueOpen] = useState(false);
@@ -1269,6 +1297,7 @@ export default function WorkOrderDetail() {
                                             batch={batch}
                                             defaultOpen={idx === 0}
                                             labelTemplates={labelTemplates}
+                                            stepPhotos={stepPhotos}
                                         />
                                     ))}
                                 </div>

--- a/backend/tests/Feature/PerStepProcessPhotoTest.php
+++ b/backend/tests/Feature/PerStepProcessPhotoTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ProcessTemplate;
+use App\Models\ProcessTemplatePhoto;
+use App\Models\ProductType;
+use App\Models\TemplateStep;
+use App\Models\User;
+use App\Models\WorkOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PerStepProcessPhotoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $operator;
+
+    private ProductType $productType;
+
+    private ProcessTemplate $template;
+
+    private TemplateStep $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Operator', 'guard_name' => 'web']);
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+
+        $this->operator = User::factory()->create(['account_type' => 'operator']);
+        $this->operator->assignRole('Operator');
+
+        $this->productType = ProductType::factory()->create();
+        $this->template = ProcessTemplate::factory()->create(['product_type_id' => $this->productType->id]);
+        $this->step = TemplateStep::factory()->create(['process_template_id' => $this->template->id, 'step_number' => 1]);
+    }
+
+    private function uploadUrl(): string
+    {
+        return "/admin/product-types/{$this->productType->id}/process-templates/{$this->template->id}/photos";
+    }
+
+    public function test_admin_can_attach_a_photo_to_a_step(): void
+    {
+        $response = $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('step.jpg', 100, 100),
+            'template_step_id' => $this->step->id,
+        ]);
+
+        $response->assertRedirect()->assertSessionHas('success');
+
+        $photo = ProcessTemplatePhoto::first();
+        $this->assertSame($this->step->id, $photo->template_step_id);
+        $this->assertSame($this->template->id, $photo->process_template_id);
+        Storage::assertExists($photo->storage_path);
+    }
+
+    public function test_uploading_a_second_step_photo_replaces_the_first(): void
+    {
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('a.jpg'),
+            'template_step_id' => $this->step->id,
+        ]);
+        $first = ProcessTemplatePhoto::first();
+
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('b.jpg'),
+            'template_step_id' => $this->step->id,
+        ]);
+
+        // Exactly one photo for the step; the old row and its file are gone.
+        $this->assertSame(1, ProcessTemplatePhoto::where('template_step_id', $this->step->id)->count());
+        $this->assertDatabaseMissing('process_template_photos', ['id' => $first->id]);
+        Storage::assertMissing($first->storage_path);
+    }
+
+    public function test_step_must_belong_to_the_template(): void
+    {
+        $otherStep = TemplateStep::factory()->create([
+            'process_template_id' => ProcessTemplate::factory()->create()->id,
+        ]);
+
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('x.jpg'),
+            'template_step_id' => $otherStep->id,
+        ])->assertNotFound();
+
+        $this->assertDatabaseCount('process_template_photos', 0);
+    }
+
+    public function test_step_photos_do_not_count_against_the_general_template_cap(): void
+    {
+        // Fill the general cap with non-step photos.
+        ProcessTemplatePhoto::factory()
+            ->count(20)
+            ->create(['process_template_id' => $this->template->id, 'template_step_id' => null]);
+
+        // A step photo still goes through despite the general cap being full.
+        $this->actingAs($this->admin)->post($this->uploadUrl(), [
+            'photo' => UploadedFile::fake()->image('step.jpg'),
+            'template_step_id' => $this->step->id,
+        ])->assertSessionHas('success');
+
+        $this->assertSame(1, ProcessTemplatePhoto::whereNotNull('template_step_id')->count());
+    }
+
+    public function test_operator_sees_step_photo_keyed_by_step_number(): void
+    {
+        // Photo on template step #1.
+        ProcessTemplatePhoto::factory()->create([
+            'process_template_id' => $this->template->id,
+            'template_step_id' => $this->step->id,
+        ]);
+        // A general photo (no step) should land in processPhotos, not stepPhotos.
+        ProcessTemplatePhoto::factory()->create([
+            'process_template_id' => $this->template->id,
+            'template_step_id' => null,
+        ]);
+
+        // Work order whose snapshot points at this template.
+        $wo = WorkOrder::factory()->create([
+            'line_id' => \App\Models\Line::factory()->create()->id,
+            'product_type_id' => $this->productType->id,
+            'process_snapshot' => [
+                'template_id' => $this->template->id,
+                'template_name' => $this->template->name,
+                'template_version' => 1,
+                'steps' => [],
+                'bom' => [],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->operator)
+            ->withSession(['selected_line_id' => $wo->line_id])
+            ->get("/operator/work-order/{$wo->id}");
+
+        $response->assertOk();
+        $props = $response->getOriginalContent()->getData()['page']['props'];
+
+        $this->assertArrayHasKey(1, $props['stepPhotos']); // keyed by step_number
+        $this->assertCount(1, $props['processPhotos']);    // the general one only
+    }
+}


### PR DESCRIPTION
## Summary
Photos can now be attached to a **specific production step**, not only to the whole template. Each step gets one photo; operators see it inline next to that step.

## Backend
- New nullable `process_template_photos.template_step_id` (FK → `template_steps`, `nullOnDelete`); `TemplateStep::photos()`, `ProcessTemplatePhoto::templateStep()`.
- Upload (`StoreProcessTemplatePhotoRequest` + controller) accepts `template_step_id`; verifies the step belongs to the template (anti-IDOR); **one photo per step** — a new upload replaces the previous (old disk file removed, in a transaction).
- The 20-per-template cap now applies only to **general** (non-step) photos.
- Operator `show()`: a batch step maps to its template step **only by `step_number`** (the snapshot carries no `template_step_id`), so the controller emits a `step_number → photo` map plus the existing general `processPhotos` gallery.

## Frontend
- **Admin** (`Show.jsx`): each `StepCard` has its own add/replace/remove photo control (thumbnail + zoom). The template-wide gallery is now "General Reference Photos" (non-step only).
- **Operator** (`WorkOrderDetail.jsx`): each step row shows its photo inline, tap to enlarge.

## Security (reused, unchanged)
ImageSanitizer GD re-encode (polyglot/EXIF stripped), private disk + random name, authenticated stream endpoint with `nosniff`, IDOR-scoped routes.

## Tests
5 new (attach to step, replace-on-reupload, step-belongs-to-template guard, step photos bypass the general cap, operator sees step photo by step_number). Existing template-photo + operator-visibility tests still green. Full suite: baseline failures only, no regressions.