### PR TITLE
fix: update OEE demo seeder to use downtime kind enum

### DIFF
--- a/backend/database/seeders/OeeAndDowntimeDemoSeeder.php
+++ b/backend/database/seeders/OeeAndDowntimeDemoSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\DowntimeKind;
 use App\Models\DowntimeReason;
 use App\Models\Line;
 use App\Models\OeeRecord;
@@ -44,11 +45,11 @@ class OeeAndDowntimeDemoSeeder extends Seeder
     private function seedDowntimeReasons(): array
     {
         $defs = [
-            ['code' => 'MAINT_PLANNED', 'name' => 'Planned maintenance',  'is_planned' => true],
-            ['code' => 'TOOL_CHANGE',   'name' => 'Tool / die change',    'is_planned' => true],
-            ['code' => 'MAT_SHORTAGE',  'name' => 'Material shortage',    'is_planned' => false],
-            ['code' => 'MACH_BREAK',    'name' => 'Machine breakdown',    'is_planned' => false],
-            ['code' => 'QUALITY',       'name' => 'Quality hold',         'is_planned' => false],
+            ['code' => 'MAINT_PLANNED', 'name' => 'Planned maintenance',  'kind' => DowntimeKind::Planned->value],
+            ['code' => 'TOOL_CHANGE',   'name' => 'Tool / die change',    'kind' => DowntimeKind::Changeover->value],
+            ['code' => 'MAT_SHORTAGE',  'name' => 'Material shortage',    'kind' => DowntimeKind::Unplanned->value],
+            ['code' => 'MACH_BREAK',    'name' => 'Machine breakdown',    'kind' => DowntimeKind::Unplanned->value],
+            ['code' => 'QUALITY',       'name' => 'Quality hold',         'kind' => DowntimeKind::Unplanned->value],
         ];
 
         $result = [];


### PR DESCRIPTION
## Summary

Updates `OeeAndDowntimeDemoSeeder` to seed downtime reasons with the `kind` column instead of the removed `is_planned` column.

Migration `2026_05_19_152131_replace_is_planned_with_kind_on_downtime_reasons` replaced `is_planned` with `kind` on `downtime_reasons`, but the demo seeder was never updated. Running `php artisan db:seed --class=DemoDataSeeder` therefore failed when `OeeAndDowntimeDemoSeeder` executed.

Mapping used:

| Code | `kind` |
|------|--------|
| `MAINT_PLANNED` | `planned` |
| `TOOL_CHANGE` | `changeover` |
| `MAT_SHORTAGE`, `MACH_BREAK`, `QUALITY` | `unplanned` |

This aligns the seeder with `DowntimeReason`, `DowntimeReasonsSeeder`, and `DowntimeKind`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Related issue

Closes #73 

## Testing

- [ ] Tested manually in browser
- [x] `php artisan test` passes
- [ ] Tested as Operator / Supervisor / Admin role (if UI change)

**Manual verification:**

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml exec backend php artisan db:seed --class=DemoDataSeeder --force
```

Confirmed `OeeAndDowntimeDemoSeeder` completes successfully and downtime reasons are created with the expected `kind` values.

## Checklist

- [x] No `.env` secrets committed
- [x] Migration added if schema changed
- [x] `$fillable` updated if new model columns added
- [x] No raw SQL with user input (use Eloquent / Query Builder)
- [x] CSRF protection in place for any new forms
- [x] `composer audit` clean
