### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.14.5...develop
+[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.15.1...develop
+[0.15.1]: https://github.com/Mes-Open/OpenMes/compare/v0.15.0...v0.15.1
+[0.15.0]: https://github.com/Mes-Open/OpenMes/compare/v0.14.5...v0.15.0
 [0.14.5]: https://github.com/Mes-Open/OpenMes/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/Mes-Open/OpenMes/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/Mes-Open/OpenMes/compare/v0.14.2...v0.14.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Stale caches surviving a Docker upgrade**: `bootstrap/cache` is a persisted volume, so after `git pull` + rebuild the previous release's compiled **route cache** could keep serving old middleware (e.g. the pre-0.15 `role:Admin` `/admin` group instead of `tab.access`), surfacing as a bogus **403 "user does not have the right roles"** — even for the admin. The entrypoint now wipes the route cache alongside the config/package caches before rebuilding, and resets the Spatie permission cache after seeding so the freshly-seeded roles/permissions are authoritative on every boot.
+
 ---
 
 ## [0.15.0] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [0.15.1] - 2026-06-15
+
 ### Fixed
 - **Sidecar containers raced the database migrations**: the `reverb` (and `queue`/`mqtt`/`modbus`) containers share the app image and ran the full entrypoint, so on a fresh `docker compose up` every sidecar ran `migrate`/`db:seed` concurrently with the backend — flooding the logs with `duplicate key "pg_type_typname_nsp_index"`, `relation … already exists` and `column "deleted_at" … already exists`, and crash-looping reverb. The entrypoint now runs migrations/seeders/admin-creation/scheduler **only on the primary (Octane) container**; sidecars log "skipping migrations/seeders" and start straight away.
 - **Creating a division without a factory returned a 500**: `divisions.factory_id` is `NOT NULL`, but the controller validated it as `nullable`, so submitting the form without a factory (e.g. on a fresh install with none created yet) hit a Postgres NOT NULL violation. It's now `required`, returning a normal 422. Regression test added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- **Sidecar containers raced the database migrations**: the `reverb` (and `queue`/`mqtt`/`modbus`) containers share the app image and ran the full entrypoint, so on a fresh `docker compose up` every sidecar ran `migrate`/`db:seed` concurrently with the backend — flooding the logs with `duplicate key "pg_type_typname_nsp_index"`, `relation … already exists` and `column "deleted_at" … already exists`, and crash-looping reverb. The entrypoint now runs migrations/seeders/admin-creation/scheduler **only on the primary (Octane) container**; sidecars log "skipping migrations/seeders" and start straight away.
+- **Creating a division without a factory returned a 500**: `divisions.factory_id` is `NOT NULL`, but the controller validated it as `nullable`, so submitting the form without a factory (e.g. on a fresh install with none created yet) hit a Postgres NOT NULL violation. It's now `required`, returning a normal 422. Regression test added.
 - **Stale caches surviving a Docker upgrade**: `bootstrap/cache` is a persisted volume, so after `git pull` + rebuild the previous release's compiled **route cache** could keep serving old middleware (e.g. the pre-0.15 `role:Admin` `/admin` group instead of `tab.access`), surfacing as a bogus **403 "user does not have the right roles"** — even for the admin. The entrypoint now wipes the route cache alongside the config/package caches before rebuilding, and resets the Spatie permission cache after seeding so the freshly-seeded roles/permissions are authoritative on every boot.
 
 ---

--- a/backend/app/Http/Controllers/Web/Admin/DivisionController.php
+++ b/backend/app/Http/Controllers/Web/Admin/DivisionController.php
@@ -43,7 +43,10 @@ class DivisionController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'factory_id' => 'nullable|exists:factories,id',
+            // divisions.factory_id is NOT NULL (a division always belongs to a
+            // factory) — must be required, or the insert 500s on a fresh install
+            // with no factory selected.
+            'factory_id' => 'required|exists:factories,id',
             'code' => 'required|string|max:50|unique:divisions',
             'name' => 'required|string|max:255',
             'description' => 'nullable|string|max:2000',
@@ -77,7 +80,7 @@ class DivisionController extends Controller
     public function update(Request $request, Division $division)
     {
         $validated = $request->validate([
-            'factory_id' => 'nullable|exists:factories,id',
+            'factory_id' => 'required|exists:factories,id',
             'code' => 'required|string|max:50|unique:divisions,code,'.$division->id,
             'name' => 'required|string|max:255',
             'description' => 'nullable|string|max:2000',

--- a/backend/app/Http/Controllers/Web/Admin/DivisionController.php
+++ b/backend/app/Http/Controllers/Web/Admin/DivisionController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Web\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreDivisionRequest;
+use App\Http\Requests\UpdateDivisionRequest;
 use App\Models\Division;
 use App\Models\Factory;
 use Illuminate\Http\Request;
@@ -40,19 +42,9 @@ class DivisionController extends Controller
     /**
      * Store a newly created division.
      */
-    public function store(Request $request)
+    public function store(StoreDivisionRequest $request)
     {
-        $validated = $request->validate([
-            // divisions.factory_id is NOT NULL (a division always belongs to a
-            // factory) — must be required, or the insert 500s on a fresh install
-            // with no factory selected.
-            'factory_id' => 'required|exists:factories,id',
-            'code' => 'required|string|max:50|unique:divisions',
-            'name' => 'required|string|max:255',
-            'description' => 'nullable|string|max:2000',
-            'is_active' => 'boolean',
-        ]);
-
+        $validated = $request->validated();
         $validated['is_active'] = $request->boolean('is_active', true);
 
         Division::create($validated);
@@ -77,16 +69,9 @@ class DivisionController extends Controller
     /**
      * Update the specified division.
      */
-    public function update(Request $request, Division $division)
+    public function update(UpdateDivisionRequest $request, Division $division)
     {
-        $validated = $request->validate([
-            'factory_id' => 'required|exists:factories,id',
-            'code' => 'required|string|max:50|unique:divisions,code,'.$division->id,
-            'name' => 'required|string|max:255',
-            'description' => 'nullable|string|max:2000',
-            'is_active' => 'boolean',
-        ]);
-
+        $validated = $request->validated();
         $validated['is_active'] = $request->boolean('is_active');
 
         $division->update($validated);

--- a/backend/app/Http/Requests/StoreDivisionRequest.php
+++ b/backend/app/Http/Requests/StoreDivisionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDivisionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + the admin tab-access middleware.
+    }
+
+    public function rules(): array
+    {
+        return [
+            // divisions.factory_id is NOT NULL (a division always belongs to a
+            // factory) — must be required, or the insert 500s on a fresh install
+            // with no factory selected.
+            'factory_id' => ['required', 'exists:factories,id'],
+            'code' => ['required', 'string', 'max:50', 'unique:divisions,code'],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:2000'],
+            'is_active' => ['boolean'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UpdateDivisionRequest.php
+++ b/backend/app/Http/Requests/UpdateDivisionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateDivisionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + the admin tab-access middleware.
+    }
+
+    public function rules(): array
+    {
+        $divisionId = $this->route('division')->id;
+
+        return [
+            'factory_id' => ['required', 'exists:factories,id'],
+            'code' => ['required', 'string', 'max:50', Rule::unique('divisions', 'code')->ignore($divisionId)],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:2000'],
+            'is_active' => ['boolean'],
+        ];
+    }
+}

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.15.0',
+    'current' => 'v0.15.1',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -34,7 +34,13 @@ if ! grep -q "APP_KEY=base64:" .env; then
 fi
 
 # ── Clear stale bootstrap cache ─────────────────────────────────────────────
-rm -f bootstrap/cache/packages.php bootstrap/cache/services.php bootstrap/cache/config.php
+# bootstrap/cache is a persisted volume, so on an upgrade (git pull + rebuild)
+# the OLD compiled config/route caches survive into the NEW image. Wipe them by
+# file (no DB/artisan needed yet) before anything reads them — including the
+# route cache, so a stale route map can't keep serving the previous release's
+# middleware (e.g. the old role:Admin /admin group instead of tab.access).
+rm -f bootstrap/cache/packages.php bootstrap/cache/services.php \
+      bootstrap/cache/config.php bootstrap/cache/routes-v7.php bootstrap/cache/route.php
 php artisan package:discover --ansi 2>/dev/null || true
 
 # ── Migrations ───────────────────────────────────────────────────────────────
@@ -46,6 +52,12 @@ echo "[OpenMES] Running seeders..."
 php artisan db:seed --class=RolesAndPermissionsSeeder --force
 php artisan db:seed --class=IssueTypesSeeder --force
 php artisan db:seed --class=LineStatusSeeder --force
+
+# Reset the Spatie permission cache so the freshly-seeded roles/permissions are
+# authoritative. Without this an upgrade can keep serving a stale cached map
+# (the cache store lives in the persisted DB), which surfaces as bogus 403
+# "user does not have the right roles" even for the admin.
+php artisan permission:cache-reset 2>/dev/null || true
 
 # ── Default admin (only if no users exist) ───────────────────────────────────
 ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -71,9 +71,13 @@ if [ "$IS_PRIMARY" = "1" ]; then
     php artisan permission:cache-reset 2>/dev/null || true
 
     # ── Default admin (only if no users exist) ───────────────────────────────
-    ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
-    ADMIN_EMAIL="${ADMIN_EMAIL:-admin@openmmes.local}"
-    ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin1234!}"
+    # Export so the tinker subprocess can read them with getenv() — values are
+    # NOT interpolated into the PHP string (a password with quotes/backslashes
+    # would otherwise break the --execute snippet), and the password is never
+    # echoed to the logs.
+    export ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+    export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@openmmes.local}"
+    export ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin1234!}"
 
     USER_COUNT=$(php artisan tinker --execute="echo \App\Models\User::count();" 2>/dev/null | tail -n1 | tr -d '[:space:]')
 
@@ -82,9 +86,9 @@ if [ "$IS_PRIMARY" = "1" ]; then
         php artisan tinker --execute="
             \$u = \App\Models\User::create([
                 'name'                  => 'Administrator',
-                'username'              => '${ADMIN_USERNAME}',
-                'email'                 => '${ADMIN_EMAIL}',
-                'password'              => bcrypt('${ADMIN_PASSWORD}'),
+                'username'              => getenv('ADMIN_USERNAME'),
+                'email'                 => getenv('ADMIN_EMAIL'),
+                'password'              => bcrypt(getenv('ADMIN_PASSWORD')),
                 'force_password_change' => false,
                 'email_verified_at'     => now(),
             ]);
@@ -96,7 +100,7 @@ if [ "$IS_PRIMARY" = "1" ]; then
         echo "║                                          ║"
         echo "║  URL:      ${APP_URL:-http://localhost}"
         echo "║  Login:    ${ADMIN_USERNAME}"
-        echo "║  Hasło:    ${ADMIN_PASSWORD}"
+        echo "║  Password: (the ADMIN_PASSWORD you configured)"
         echo "║                                          ║"
         echo "╚══════════════════════════════════════════╝"
         echo ""

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+# Several services share this image (backend/Octane, reverb, queue, mqtt,
+# modbus). Only the PRIMARY app server (Octane) may run migrations/seeders —
+# otherwise every sidecar races the same migrate against the same database on a
+# fresh `docker compose up`, producing "duplicate table / column already exists"
+# errors. Detect the primary by its command.
+case "$*" in
+    *octane:start*) IS_PRIMARY=1 ;;
+    *) IS_PRIMARY=0 ;;
+esac
+
 # ── .env ────────────────────────────────────────────────────────────────────
 if [ ! -f .env ]; then
     echo "[OpenMES] Creating .env from .env.example..."
@@ -43,60 +53,64 @@ rm -f bootstrap/cache/packages.php bootstrap/cache/services.php \
       bootstrap/cache/config.php bootstrap/cache/routes-v7.php bootstrap/cache/route.php
 php artisan package:discover --ansi 2>/dev/null || true
 
-# ── Migrations ───────────────────────────────────────────────────────────────
-echo "[OpenMES] Running migrations..."
-php artisan migrate --force
+if [ "$IS_PRIMARY" = "1" ]; then
+    # ── Migrations ───────────────────────────────────────────────────────────
+    echo "[OpenMES] Running migrations..."
+    php artisan migrate --force
 
-# ── Seeders (idempotent) ─────────────────────────────────────────────────────
-echo "[OpenMES] Running seeders..."
-php artisan db:seed --class=RolesAndPermissionsSeeder --force
-php artisan db:seed --class=IssueTypesSeeder --force
-php artisan db:seed --class=LineStatusSeeder --force
+    # ── Seeders (idempotent) ─────────────────────────────────────────────────
+    echo "[OpenMES] Running seeders..."
+    php artisan db:seed --class=RolesAndPermissionsSeeder --force
+    php artisan db:seed --class=IssueTypesSeeder --force
+    php artisan db:seed --class=LineStatusSeeder --force
 
-# Reset the Spatie permission cache so the freshly-seeded roles/permissions are
-# authoritative. Without this an upgrade can keep serving a stale cached map
-# (the cache store lives in the persisted DB), which surfaces as bogus 403
-# "user does not have the right roles" even for the admin.
-php artisan permission:cache-reset 2>/dev/null || true
+    # Reset the Spatie permission cache so the freshly-seeded roles/permissions
+    # are authoritative. Without this an upgrade can keep serving a stale cached
+    # map (the cache store lives in the persisted DB), which surfaces as bogus
+    # 403 "user does not have the right roles" even for the admin.
+    php artisan permission:cache-reset 2>/dev/null || true
 
-# ── Default admin (only if no users exist) ───────────────────────────────────
-ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
-ADMIN_EMAIL="${ADMIN_EMAIL:-admin@openmmes.local}"
-ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin1234!}"
+    # ── Default admin (only if no users exist) ───────────────────────────────
+    ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+    ADMIN_EMAIL="${ADMIN_EMAIL:-admin@openmmes.local}"
+    ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin1234!}"
 
-USER_COUNT=$(php artisan tinker --execute="echo \App\Models\User::count();" 2>/dev/null | tail -n1 | tr -d '[:space:]')
+    USER_COUNT=$(php artisan tinker --execute="echo \App\Models\User::count();" 2>/dev/null | tail -n1 | tr -d '[:space:]')
 
-if [ "$USER_COUNT" = "0" ]; then
-    echo "[OpenMES] Creating admin account (username: ${ADMIN_USERNAME})..."
-    php artisan tinker --execute="
-        \$u = \App\Models\User::create([
-            'name'                  => 'Administrator',
-            'username'              => '${ADMIN_USERNAME}',
-            'email'                 => '${ADMIN_EMAIL}',
-            'password'              => bcrypt('${ADMIN_PASSWORD}'),
-            'force_password_change' => false,
-            'email_verified_at'     => now(),
-        ]);
-        \$u->assignRole('Admin');
-    "
-    echo ""
-    echo "╔══════════════════════════════════════════╗"
-    echo "║            OpenMES — admin               ║"
-    echo "║                                          ║"
-    echo "║  URL:      ${APP_URL:-http://localhost}"
-    echo "║  Login:    ${ADMIN_USERNAME}"
-    echo "║  Hasło:    ${ADMIN_PASSWORD}"
-    echo "║                                          ║"
-    echo "╚══════════════════════════════════════════╝"
-    echo ""
+    if [ "$USER_COUNT" = "0" ]; then
+        echo "[OpenMES] Creating admin account (username: ${ADMIN_USERNAME})..."
+        php artisan tinker --execute="
+            \$u = \App\Models\User::create([
+                'name'                  => 'Administrator',
+                'username'              => '${ADMIN_USERNAME}',
+                'email'                 => '${ADMIN_EMAIL}',
+                'password'              => bcrypt('${ADMIN_PASSWORD}'),
+                'force_password_change' => false,
+                'email_verified_at'     => now(),
+            ]);
+            \$u->assignRole('Admin');
+        "
+        echo ""
+        echo "╔══════════════════════════════════════════╗"
+        echo "║            OpenMES — admin               ║"
+        echo "║                                          ║"
+        echo "║  URL:      ${APP_URL:-http://localhost}"
+        echo "║  Login:    ${ADMIN_USERNAME}"
+        echo "║  Hasło:    ${ADMIN_PASSWORD}"
+        echo "║                                          ║"
+        echo "╚══════════════════════════════════════════╝"
+        echo ""
+    else
+        echo "[OpenMES] Admin already exists, skipping default user creation."
+    fi
+
+    # ── Mark as installed (skip web installer) ───────────────────────────────
+    if [ ! -f storage/installed ]; then
+        echo "[OpenMES] Marking application as installed..."
+        date '+%Y-%m-%d %H:%M:%S' > storage/installed
+    fi
 else
-    echo "[OpenMES] Admin already exists, skipping default user creation."
-fi
-
-# ── Mark as installed (skip web installer) ───────────────────────────────────
-if [ ! -f storage/installed ]; then
-    echo "[OpenMES] Marking application as installed..."
-    date '+%Y-%m-%d %H:%M:%S' > storage/installed
+    echo "[OpenMES] Sidecar container ($*) — skipping migrations/seeders (handled by the primary)."
 fi
 
 # ── Cache ────────────────────────────────────────────────────────────────────
@@ -107,6 +121,9 @@ php artisan view:cache
 echo "[OpenMES] Ready at http://localhost:8080"
 
 # ── Scheduler (runs every 60s in background) ─────────────────────────────────
-(while true; do php artisan schedule:run >> storage/logs/scheduler.log 2>&1; sleep 60; done) &
+# Only on the primary, so sidecars don't each spawn a competing scheduler.
+if [ "$IS_PRIMARY" = "1" ]; then
+    (while true; do php artisan schedule:run >> storage/logs/scheduler.log 2>&1; sleep 60; done) &
+fi
 
 exec "$@"

--- a/backend/tests/Feature/DivisionTest.php
+++ b/backend/tests/Feature/DivisionTest.php
@@ -224,6 +224,20 @@ class DivisionTest extends TestCase
         $response->assertSessionHasErrors('factory_id');
     }
 
+    public function test_factory_id_is_required(): void
+    {
+        // divisions.factory_id is NOT NULL — omitting it must 422, not 500 on a
+        // NOT NULL violation (e.g. a fresh install with no factory selected).
+        $response = $this->actingAs($this->admin)->post(route('admin.divisions.store'), [
+            'code' => 'DIV01',
+            'name' => 'No Factory Division',
+            'is_active' => true,
+        ]);
+
+        $response->assertSessionHasErrors('factory_id');
+        $this->assertDatabaseMissing('divisions', ['code' => 'DIV01']);
+    }
+
     public function test_update_allows_same_code_for_same_division(): void
     {
         $division = Division::create([

--- a/backend/tests/Feature/DivisionTest.php
+++ b/backend/tests/Feature/DivisionTest.php
@@ -238,6 +238,26 @@ class DivisionTest extends TestCase
         $this->assertDatabaseMissing('divisions', ['code' => 'DIV01']);
     }
 
+    public function test_factory_id_is_required_on_update(): void
+    {
+        $division = Division::create([
+            'factory_id' => $this->factory->id,
+            'code' => 'DIV01',
+            'name' => 'Original Name',
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($this->admin)->put(route('admin.divisions.update', $division), [
+            'code' => 'DIV01',
+            'name' => 'Renamed Without Factory',
+            'is_active' => true,
+        ]);
+
+        $response->assertSessionHasErrors('factory_id');
+        // Unchanged — the update must not partially apply.
+        $this->assertDatabaseHas('divisions', ['id' => $division->id, 'name' => 'Original Name']);
+    }
+
     public function test_update_allows_same_code_for_same_division(): void
     {
         $division = Division::create([


### PR DESCRIPTION
## Release v0.15.1 — patch

Fresh-install / upgrade hardening on top of v0.15.0. Fixes reported after the v0.15.0 rollout.

### Fixed
- **Sidecar migration race** — `reverb` (and `queue`/`mqtt`/`modbus`) share the app image and ran the full entrypoint, so a fresh `docker compose up` had every sidecar run `migrate`/`db:seed` concurrently with the backend (`duplicate key … pg_type_typname_nsp_index`, `relation … already exists`, `column "deleted_at" … already exists`, crash-looping reverb). Migrations/seeders/admin/scheduler now run **only on the primary Octane container**.
- **Division without a factory returned 500** — `divisions.factory_id` is `NOT NULL` but was validated as `nullable`; submitting with no factory (e.g. a fresh install) hit a Postgres NOT NULL violation. Now `required` → 422. Regression test added.
- **Stale caches surviving a Docker upgrade** — `bootstrap/cache` is a persisted volume, so a `git pull` + rebuild could keep serving the previous release's compiled **route cache** (old `role:Admin` `/admin` group instead of `tab.access`), surfacing as a bogus **403 "user does not have the right roles"** for the admin. The entrypoint now wipes the route cache before rebuilding and resets the Spatie permission cache after seeding.

### Verified
- Clean `git clone` + `docker compose up` on a fresh DB: migrations run once, reverb logs "skipping migrations/seeders", admin logs in to `/onboarding` (no 403), division without a factory returns 422.
- Full suite green: **1354 tests, 4132 assertions**.

Thanks to the contributor who reported the upgrade/login issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fresh Docker Compose boots by preventing concurrent migrations/seeders across sidecar containers; only the primary container runs those tasks.
  * Division create/update now correctly requires `factory_id`, returning HTTP 422 when missing (and avoiding partial updates).
  * Refreshed routing and permission-related caches after Docker upgrades to prevent stale behavior.
  * Updated the demo seeder to address the related `kind` column regression.
* **Tests**
  * Added regression coverage for `factory_id` being required on create and update.
* **Chores**
  * Updated the app version to 0.15.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->