### PR TITLE
Release v0.15.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Keep shell scripts LF-only so they stay runnable after a Windows checkout
+# (autocrlf would otherwise add CRLF and break the `#!/bin/bash` shebang in
+# WSL / Git Bash and inside the Docker image).
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf
+Caddyfile text eol=lf
+*.bash text eol=lf
+
+# Windows-native scripts keep CRLF.
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [0.15.3] - 2026-06-16
+
 ### Added
 - **Windows installer (`install.ps1`)**: a PowerShell port of `install.sh` with the same behaviour — auto-selects a free host port (80 → 8080/8443+), generates `.env` with secure random credentials (written LF/no-BOM so values aren't corrupted), builds + starts production, waits until the app actually serves, and prints the URL + login. Run `.\install.ps1` in PowerShell with Docker Desktop (`-Interactive` to customise, `-Dev` for the watch overlay). A `.gitattributes` keeps shell scripts LF-only so a Windows checkout doesn't break the `#!/bin/bash` shebang.
 - **"Ready to start" batch-step status**: a new step state between **Pending** and **In Progress**. A step is **Pending** while it's still blocked (its predecessor isn't done), becomes **Ready to start** once its prerequisites are met (first step, predecessor done/skipped, or non-sequential mode) — i.e. it's next in line and waiting for an operator — and then **In Progress** once started. Operators only see the **Start** button on Ready steps; Pending steps show as blocked. The next step is promoted to Ready automatically when the current one is completed or skipped. No schema change (the status column is a free string); existing in-flight batches are backfilled by migration, and the value syncs to live views like any other status. _(Refs [discussion #69](https://github.com/orgs/Mes-Open/discussions/69))_
@@ -325,7 +329,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.15.2...develop
+[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.15.3...develop
+[0.15.3]: https://github.com/Mes-Open/OpenMes/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/Mes-Open/OpenMes/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/Mes-Open/OpenMes/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Mes-Open/OpenMes/compare/v0.14.5...v0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **"Ready to start" batch-step status**: a new step state between **Pending** and **In Progress**. A step is **Pending** while it's still blocked (its predecessor isn't done), becomes **Ready to start** once its prerequisites are met (first step, predecessor done/skipped, or non-sequential mode) — i.e. it's next in line and waiting for an operator — and then **In Progress** once started. Operators only see the **Start** button on Ready steps; Pending steps show as blocked. The next step is promoted to Ready automatically when the current one is completed or skipped. No schema change (the status column is a free string); existing in-flight batches are backfilled by migration, and the value syncs to live views like any other status. _(Refs [discussion #69](https://github.com/orgs/Mes-Open/discussions/69))_
+
 ---
 
 ## [0.15.2] - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Windows installer (`install.ps1`)**: a PowerShell port of `install.sh` with the same behaviour — auto-selects a free host port (80 → 8080/8443+), generates `.env` with secure random credentials (written LF/no-BOM so values aren't corrupted), builds + starts production, waits until the app actually serves, and prints the URL + login. Run `.\install.ps1` in PowerShell with Docker Desktop (`-Interactive` to customise, `-Dev` for the watch overlay). A `.gitattributes` keeps shell scripts LF-only so a Windows checkout doesn't break the `#!/bin/bash` shebang.
 - **"Ready to start" batch-step status**: a new step state between **Pending** and **In Progress**. A step is **Pending** while it's still blocked (its predecessor isn't done), becomes **Ready to start** once its prerequisites are met (first step, predecessor done/skipped, or non-sequential mode) — i.e. it's next in line and waiting for an operator — and then **In Progress** once started. Operators only see the **Start** button on Ready steps; Pending steps show as blocked. The next step is promoted to Ready automatically when the current one is completed or skipped. No schema change (the status column is a free string); existing in-flight batches are backfilled by migration, and the value syncs to live views like any other status. _(Refs [discussion #69](https://github.com/orgs/Mes-Open/discussions/69))_
 
 ---

--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ cd OpenMes
 
 `install.sh` generates secure credentials into `.env`, **auto-selects a free host port** (80 if it's available, otherwise the next free one — e.g. 8080), builds the app from the cloned source, and starts it in **production**. When it finishes it prints your URL and admin login. Use `./install.sh --yes` to accept all defaults non-interactively.
 
+**Windows?** In **PowerShell** (Docker Desktop) run the equivalent installer — same behaviour as `install.sh`:
+
+```powershell
+.\install.ps1
+```
+
+(Under WSL2 just use `./install.sh`.)
+
 **Prefer plain Compose?** `docker compose up -d --build` also works — it builds from source and serves on port 80 (override with `HTTP_PORT`/`HTTPS_PORT` in `.env` if 80 is taken).
 
 ### First boot

--- a/backend/app/Models/Batch.php
+++ b/backend/app/Models/Batch.php
@@ -132,7 +132,25 @@ class Batch extends Model
     }
 
     /**
-     * Get the current (in progress or next pending) step.
+     * Promote every PENDING step whose sequence prerequisites are now met to
+     * READY ("next in line"). Idempotent — safe to call after any step
+     * transition or right after a batch's steps are created.
+     */
+    public function promoteReadySteps(): void
+    {
+        $this->steps()
+            ->where('status', BatchStep::STATUS_PENDING)
+            ->orderBy('step_number')
+            ->get()
+            ->each(function (BatchStep $step) {
+                if ($step->prerequisitesMet()) {
+                    $step->update(['status' => BatchStep::STATUS_READY]);
+                }
+            });
+    }
+
+    /**
+     * Get the current (in progress or next ready/pending) step.
      */
     public function currentStep()
     {
@@ -145,9 +163,10 @@ class Batch extends Model
             return $inProgress;
         }
 
-        // Otherwise return first pending step
+        // Otherwise the next actionable step — READY first, then PENDING.
         return $this->steps()
-            ->where('status', BatchStep::STATUS_PENDING)
+            ->whereIn('status', [BatchStep::STATUS_READY, BatchStep::STATUS_PENDING])
+            ->orderByRaw("CASE status WHEN '".BatchStep::STATUS_READY."' THEN 0 ELSE 1 END")
             ->orderBy('step_number')
             ->first();
     }

--- a/backend/app/Models/BatchStep.php
+++ b/backend/app/Models/BatchStep.php
@@ -16,6 +16,11 @@ class BatchStep extends Model
 
     const STATUS_PENDING = 'PENDING';
 
+    // Prerequisites met (previous step done/skipped, or first step) but not yet
+    // started — the step is "next in line" and the operator may start it. Sits
+    // between PENDING (still blocked) and IN_PROGRESS.
+    const STATUS_READY = 'READY';
+
     const STATUS_IN_PROGRESS = 'IN_PROGRESS';
 
     const STATUS_DONE = 'DONE';
@@ -102,28 +107,17 @@ class BatchStep extends Model
     }
 
     /**
-     * Check if this step can be started.
+     * Whether this step's sequence prerequisites are met (so it may move from
+     * PENDING to READY): the first step, any step when sequential enforcement is
+     * off, or a step whose immediate predecessor is DONE/SKIPPED. Does NOT factor
+     * in work-order blocking — that's re-checked at start time.
      */
-    public function canStart(): bool
+    public function prerequisitesMet(): bool
     {
-        if ($this->status !== self::STATUS_PENDING) {
-            return false;
-        }
-
-        // Check if work order is blocked
-        $workOrder = $this->batch->workOrder;
-        if ($workOrder->isBlocked()) {
-            return false;
-        }
-
-        // Check if sequential steps enforcement is enabled
-        $forceSequential = config('openmmes.force_sequential_steps', true);
-
-        if (! $forceSequential) {
+        if (! config('openmmes.force_sequential_steps', true)) {
             return true;
         }
 
-        // Check if previous step is complete
         if ($this->step_number === 1) {
             return true;
         }
@@ -132,7 +126,26 @@ class BatchStep extends Model
             ->where('step_number', $this->step_number - 1)
             ->first();
 
-        return $previousStep && in_array($previousStep->status, [self::STATUS_DONE, self::STATUS_SKIPPED]);
+        return $previousStep && in_array($previousStep->status, [self::STATUS_DONE, self::STATUS_SKIPPED], true);
+    }
+
+    /**
+     * Check if this step can be started: it must be READY (the normal case,
+     * after promotion) or a still-PENDING step whose prerequisites are already
+     * met (safety net for steps created outside the promotion path), the work
+     * order must not be blocked. The operator UI only offers Start on READY.
+     */
+    public function canStart(): bool
+    {
+        if (! in_array($this->status, [self::STATUS_READY, self::STATUS_PENDING], true)) {
+            return false;
+        }
+
+        if ($this->batch->workOrder->isBlocked()) {
+            return false;
+        }
+
+        return $this->prerequisitesMet();
     }
 
     /**
@@ -149,7 +162,7 @@ class BatchStep extends Model
      */
     public function canSkip(): bool
     {
-        return in_array($this->status, [self::STATUS_PENDING, self::STATUS_IN_PROGRESS], true)
+        return in_array($this->status, [self::STATUS_PENDING, self::STATUS_READY, self::STATUS_IN_PROGRESS], true)
             && ($this->is_optional || $this->variant_group !== null);
     }
 

--- a/backend/app/Services/WorkOrder/BatchService.php
+++ b/backend/app/Services/WorkOrder/BatchService.php
@@ -94,6 +94,9 @@ class BatchService
             $batch = $step->batch;
             $this->updateBatchStatus($batch);
 
+            // The next step (prerequisites now met) becomes READY.
+            $batch->promoteReadySteps();
+
             // If batch is complete, update produced quantity and consume materials
             if ($batch->status === Batch::STATUS_DONE) {
                 // End-of-batch BOM rows (consumed_at='end') get allocated now,
@@ -134,6 +137,8 @@ class BatchService
             ]);
 
             $this->updateBatchStatus($step->batch);
+            // Skipping a step unblocks the next one (SKIPPED counts like DONE).
+            $step->batch->promoteReadySteps();
             $this->workOrderService->updateWorkOrderStatus($step->batch->workOrder);
 
             return $step->fresh();
@@ -169,6 +174,8 @@ class BatchService
                 ]);
 
             $this->updateBatchStatus($step->batch);
+            // Promote the chosen variant to READY if it's next in line.
+            $step->batch->promoteReadySteps();
 
             return $step->fresh();
         });
@@ -282,7 +289,7 @@ class BatchService
      */
     protected function throwValidationError(BatchStep $step): void
     {
-        if ($step->status !== BatchStep::STATUS_PENDING) {
+        if (! in_array($step->status, [BatchStep::STATUS_PENDING, BatchStep::STATUS_READY], true)) {
             throw new \Exception("Step is already {$step->status}");
         }
 

--- a/backend/app/Services/WorkOrder/WorkOrderService.php
+++ b/backend/app/Services/WorkOrder/WorkOrderService.php
@@ -146,6 +146,10 @@ class WorkOrderService
                 'variant_group' => $group,
             ]);
         }
+
+        // Mark the first eligible step(s) READY ("next in line") so the operator
+        // can start straight away; the rest stay PENDING until their turn.
+        $batch->promoteReadySteps();
     }
 
     /**

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.15.2',
+    'current' => 'v0.15.3',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];

--- a/backend/database/migrations/2026_06_16_120000_backfill_ready_batch_step_status.php
+++ b/backend/database/migrations/2026_06_16_120000_backfill_ready_batch_step_status.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Batch;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Backfill the new READY batch-step status on existing data. `batch_steps.status`
+ * is a free string column, so there's no schema change — we just promote the
+ * already-startable PENDING steps (first step, or one whose predecessor is
+ * DONE/SKIPPED) to READY so in-flight batches match the new model. No-op for
+ * finished batches (they have no PENDING steps).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('batches') || ! Schema::hasTable('batch_steps')) {
+            return;
+        }
+
+        Batch::query()->with('steps')->chunkById(200, function ($batches) {
+            foreach ($batches as $batch) {
+                $batch->promoteReadySteps();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('batch_steps')) {
+            return;
+        }
+
+        // Revert READY back to PENDING (its prior state).
+        \App\Models\BatchStep::query()
+            ->where('status', \App\Models\BatchStep::STATUS_READY)
+            ->update(['status' => \App\Models\BatchStep::STATUS_PENDING]);
+    }
+};

--- a/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
+++ b/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
@@ -19,6 +19,7 @@ function fmtQty(n, decimals = 2) {
 function statusBadge(status) {
     const map = {
         PENDING:     'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+        READY:       'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
         IN_PROGRESS: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
         DONE:        'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
         BLOCKED:     'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
@@ -28,6 +29,7 @@ function statusBadge(status) {
 
 function statusLabel(status) {
     if (status === 'PENDING') return 'Not Started';
+    if (status === 'READY') return 'Ready to Start';
     return (status ?? '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -756,6 +758,10 @@ function BatchStepList({ steps, labelTemplates = [], stepPhotos = {} }) {
                                     In progress{step.started_by ? ` by ${step.started_by.name}` : ''}
                                 </span>
                             )}
+                            {/* Blocked: waiting on the previous step */}
+                            {step.status === 'PENDING' && (
+                                <span className="text-xs text-gray-400 whitespace-nowrap">Pending</span>
+                            )}
                             {/* Fallback for older data without explicit status field */}
                             {!step.status && step.completed_at && (
                                 <span className="text-xs text-green-600 whitespace-nowrap">
@@ -768,8 +774,8 @@ function BatchStepList({ steps, labelTemplates = [], stepPhotos = {} }) {
                                 </span>
                             )}
 
-                            {/* Action buttons */}
-                            {step.status === 'PENDING' && (
+                            {/* Action buttons — Start only when the step is READY */}
+                            {step.status === 'READY' && (
                                 <button
                                     type="button"
                                     disabled={isInflight}

--- a/backend/tests/Feature/Api/BatchStepTest.php
+++ b/backend/tests/Feature/Api/BatchStepTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Api;
 
-use App\Models\User;
-use App\Models\WorkOrder;
 use App\Models\Batch;
 use App\Models\BatchStep;
+use App\Models\User;
+use App\Models\WorkOrder;
 use App\Services\WorkOrder\WorkOrderService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -24,6 +24,7 @@ class BatchStepTest extends TestCase
     {
         $user = User::factory()->create();
         $user->assignRole($role);
+
         return $user;
     }
 
@@ -45,7 +46,8 @@ class BatchStepTest extends TestCase
         $user->lines()->attach($workOrder->line_id);
 
         $firstStep = $batch->steps()->orderBy('step_number')->first();
-        $this->assertEquals(BatchStep::STATUS_PENDING, $firstStep->status);
+        // First step is promoted to READY ("ready to start") on creation.
+        $this->assertEquals(BatchStep::STATUS_READY, $firstStep->status);
 
         $token = $user->createToken('test')->plainTextToken;
 
@@ -143,7 +145,8 @@ class BatchStepTest extends TestCase
         $user->lines()->attach($workOrder->line_id);
 
         $firstStep = $batch->steps()->orderBy('step_number')->first();
-        $this->assertEquals(BatchStep::STATUS_PENDING, $firstStep->status);
+        // READY (not IN_PROGRESS) — completing it must still be rejected.
+        $this->assertEquals(BatchStep::STATUS_READY, $firstStep->status);
 
         $token = $user->createToken('test')->plainTextToken;
 
@@ -245,7 +248,7 @@ class BatchStepTest extends TestCase
 
         // Start first step
         $this->postJson("/api/v1/batch-steps/{$firstStep->id}/start", [], [
-            'Authorization' => "Bearer $token"
+            'Authorization' => "Bearer $token",
         ]);
 
         $batch->refresh();
@@ -275,7 +278,7 @@ class BatchStepTest extends TestCase
         $token = $user->createToken('test')->plainTextToken;
 
         $this->postJson("/api/v1/batch-steps/{$firstStep->id}/complete", [], [
-            'Authorization' => "Bearer $token"
+            'Authorization' => "Bearer $token",
         ]);
 
         $firstStep->refresh();

--- a/backend/tests/Feature/ProcessOptionalVariantStepTest.php
+++ b/backend/tests/Feature/ProcessOptionalVariantStepTest.php
@@ -59,15 +59,17 @@ class ProcessOptionalVariantStepTest extends TestCase
         $batch = app(WorkOrderService::class)->createBatch($wo, 10);
         $steps = $batch->steps()->orderBy('step_number')->get()->keyBy('step_number');
 
-        // Required + optional both start pending; optional flag copied.
-        $this->assertSame(BatchStep::STATUS_PENDING, $steps[1]->status);
+        // Step 1 is the first step → READY ("ready to start"); the optional
+        // step 2 is still blocked behind it → PENDING. Flags copied through.
+        $this->assertSame(BatchStep::STATUS_READY, $steps[1]->status);
         $this->assertFalse($steps[1]->is_optional);
         $this->assertSame(BatchStep::STATUS_PENDING, $steps[2]->status);
         $this->assertTrue($steps[2]->is_optional);
 
-        // Variant group: default (step 4) active, sibling (step 3) auto-skipped.
+        // Variant group: default (step 4) active; sibling (step 3) auto-skipped,
+        // which makes the default the next actionable step → READY.
         $this->assertSame(BatchStep::STATUS_SKIPPED, $steps[3]->status);
-        $this->assertSame(BatchStep::STATUS_PENDING, $steps[4]->status);
+        $this->assertSame(BatchStep::STATUS_READY, $steps[4]->status);
         $this->assertSame('finish', $steps[3]->variant_group);
         $this->assertSame('finish', $steps[4]->variant_group);
     }
@@ -83,7 +85,7 @@ class ProcessOptionalVariantStepTest extends TestCase
         $batch = app(WorkOrderService::class)->createBatch($wo, 10);
         $steps = $batch->steps()->orderBy('step_number')->get()->keyBy('step_number');
 
-        $this->assertSame(BatchStep::STATUS_PENDING, $steps[1]->status); // lowest = default
+        $this->assertSame(BatchStep::STATUS_READY, $steps[1]->status); // lowest = default, first step → ready
         $this->assertSame(BatchStep::STATUS_SKIPPED, $steps[2]->status);
     }
 

--- a/backend/tests/Feature/Web/Operator/OptionalVariantStepExecutionTest.php
+++ b/backend/tests/Feature/Web/Operator/OptionalVariantStepExecutionTest.php
@@ -79,7 +79,9 @@ class OptionalVariantStepExecutionTest extends TestCase
             ->post("/operator/batch-step/{$required->id}/skip")
             ->assertSessionHas('error');
 
-        $this->assertSame(BatchStep::STATUS_PENDING, $required->fresh()->status);
+        // First step is READY ("ready to start") and skipping it failed, so it
+        // is left untouched.
+        $this->assertSame(BatchStep::STATUS_READY, $required->fresh()->status);
     }
 
     public function test_default_variant_is_active_and_sibling_skipped(): void
@@ -87,7 +89,9 @@ class OptionalVariantStepExecutionTest extends TestCase
         $batch = $this->makeBatch();
 
         $this->assertSame(BatchStep::STATUS_SKIPPED, $this->step($batch, 3)->status); // matte
-        $this->assertSame(BatchStep::STATUS_PENDING, $this->step($batch, 4)->status);  // gloss (default)
+        // Gloss (default variant) is active; its sibling is skipped so it's the
+        // next actionable step → READY.
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 4)->status);  // gloss (default)
     }
 
     public function test_operator_can_switch_variant(): void

--- a/backend/tests/Feature/Web/Operator/ReadyToStartStepTest.php
+++ b/backend/tests/Feature/Web/Operator/ReadyToStartStepTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Web\Operator;
+
+use App\Models\Batch;
+use App\Models\BatchStep;
+use App\Models\ProcessTemplate;
+use App\Models\ProductType;
+use App\Models\TemplateStep;
+use App\Models\User;
+use App\Models\WorkOrder;
+use App\Services\WorkOrder\BatchService;
+use App\Services\WorkOrder\WorkOrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The READY ("Ready to start") batch-step status: PENDING (blocked) → READY
+ * (prerequisites met, awaiting an operator) → IN_PROGRESS.
+ */
+class ReadyToStartStepTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $operator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::create(['name' => 'Operator', 'guard_name' => 'web']);
+        $this->operator = User::factory()->create(['account_type' => 'operator']);
+        $this->operator->assignRole('Operator');
+    }
+
+    /** A batch with three plain sequential steps. */
+    private function makeBatch(): Batch
+    {
+        $pt = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $pt->id, 'is_active' => true]);
+        TemplateStep::factory()->create(['process_template_id' => $template->id, 'step_number' => 1, 'name' => 'Cut']);
+        TemplateStep::factory()->create(['process_template_id' => $template->id, 'step_number' => 2, 'name' => 'Drill']);
+        TemplateStep::factory()->create(['process_template_id' => $template->id, 'step_number' => 3, 'name' => 'Pack']);
+
+        $wo = WorkOrder::factory()->create(['process_snapshot' => $template->load('steps')->toSnapshot()]);
+
+        return app(WorkOrderService::class)->createBatch($wo, 10);
+    }
+
+    private function step(Batch $batch, int $number): BatchStep
+    {
+        return $batch->steps()->where('step_number', $number)->first();
+    }
+
+    public function test_first_step_is_ready_and_the_rest_pending_on_creation(): void
+    {
+        $batch = $this->makeBatch();
+
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 1)->status);
+        $this->assertSame(BatchStep::STATUS_PENDING, $this->step($batch, 2)->status);
+        $this->assertSame(BatchStep::STATUS_PENDING, $this->step($batch, 3)->status);
+    }
+
+    public function test_completing_a_step_promotes_the_next_to_ready(): void
+    {
+        $batch = $this->makeBatch();
+        $service = app(BatchService::class);
+
+        $service->startStep($this->step($batch, 1), $this->operator);
+        $service->completeStep($this->step($batch, 1), $this->operator);
+
+        $this->assertSame(BatchStep::STATUS_DONE, $this->step($batch, 1)->status);
+        // Step 2 (previous now DONE) is promoted PENDING → READY; step 3 stays blocked.
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 2)->status);
+        $this->assertSame(BatchStep::STATUS_PENDING, $this->step($batch, 3)->status);
+    }
+
+    public function test_only_a_ready_step_can_start(): void
+    {
+        $batch = $this->makeBatch();
+        $service = app(BatchService::class);
+
+        // Step 2 is PENDING (blocked) — starting it must fail.
+        $this->assertFalse($this->step($batch, 2)->canStart());
+        $this->expectException(\Exception::class);
+        $service->startStep($this->step($batch, 2), $this->operator);
+    }
+
+    public function test_ready_step_starts_into_in_progress(): void
+    {
+        $batch = $this->makeBatch();
+        $ready = $this->step($batch, 1);
+
+        $this->assertTrue($ready->canStart());
+        app(BatchService::class)->startStep($ready, $this->operator);
+
+        $this->assertSame(BatchStep::STATUS_IN_PROGRESS, $ready->fresh()->status);
+    }
+
+    public function test_non_sequential_mode_marks_all_steps_ready(): void
+    {
+        config(['openmmes.force_sequential_steps' => false]);
+
+        $batch = $this->makeBatch();
+
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 1)->status);
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 2)->status);
+        $this->assertSame(BatchStep::STATUS_READY, $this->step($batch, 3)->status);
+    }
+}

--- a/backend/tests/Unit/Services/BatchServiceTest.php
+++ b/backend/tests/Unit/Services/BatchServiceTest.php
@@ -16,8 +16,11 @@ class BatchServiceTest extends TestCase
     use RefreshDatabase;
 
     protected BatchService $service;
+
     protected WorkOrder $workOrder;
+
     protected Batch $batch;
+
     protected User $user;
 
     protected function setUp(): void
@@ -96,8 +99,8 @@ class BatchServiceTest extends TestCase
     {
         $firstStep = $this->batch->steps()->where('step_number', 1)->first();
         $firstStep->update([
-            'status'       => BatchStep::STATUS_DONE,
-            'started_at'   => now()->subMinutes(30),
+            'status' => BatchStep::STATUS_DONE,
+            'started_at' => now()->subMinutes(30),
             'completed_at' => now(),
         ]);
 
@@ -114,7 +117,7 @@ class BatchServiceTest extends TestCase
     {
         $step = $this->batch->steps()->orderBy('step_number')->first();
         $step->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(15),
         ]);
 
@@ -127,7 +130,7 @@ class BatchServiceTest extends TestCase
     {
         $step = $this->batch->steps()->orderBy('step_number')->first();
         $step->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(10),
         ]);
 
@@ -142,7 +145,7 @@ class BatchServiceTest extends TestCase
     {
         $step = $this->batch->steps()->orderBy('step_number')->first();
         $step->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(30),
         ]);
 
@@ -157,7 +160,8 @@ class BatchServiceTest extends TestCase
     public function test_complete_pending_step_throws(): void
     {
         $step = $this->batch->steps()->orderBy('step_number')->first();
-        $this->assertEquals(BatchStep::STATUS_PENDING, $step->status);
+        // First step is READY (not IN_PROGRESS) — completing it must still throw.
+        $this->assertEquals(BatchStep::STATUS_READY, $step->status);
 
         $this->expectException(\Exception::class);
 
@@ -171,8 +175,8 @@ class BatchServiceTest extends TestCase
         // Complete all but last manually
         foreach ($steps->slice(0, -1) as $step) {
             $step->update([
-                'status'       => BatchStep::STATUS_DONE,
-                'started_at'   => now()->subHour(),
+                'status' => BatchStep::STATUS_DONE,
+                'started_at' => now()->subHour(),
                 'completed_at' => now()->subMinutes(30),
             ]);
         }
@@ -180,7 +184,7 @@ class BatchServiceTest extends TestCase
         // Complete last step through service
         $lastStep = $steps->last();
         $lastStep->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(10),
         ]);
 
@@ -196,15 +200,15 @@ class BatchServiceTest extends TestCase
 
         foreach ($steps->slice(0, -1) as $step) {
             $step->update([
-                'status'       => BatchStep::STATUS_DONE,
-                'started_at'   => now()->subHour(),
+                'status' => BatchStep::STATUS_DONE,
+                'started_at' => now()->subHour(),
                 'completed_at' => now()->subMinutes(30),
             ]);
         }
 
         $lastStep = $steps->last();
         $lastStep->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(5),
         ]);
 
@@ -220,15 +224,15 @@ class BatchServiceTest extends TestCase
 
         foreach ($steps->slice(0, -1) as $step) {
             $step->update([
-                'status'       => BatchStep::STATUS_DONE,
-                'started_at'   => now()->subHour(),
+                'status' => BatchStep::STATUS_DONE,
+                'started_at' => now()->subHour(),
                 'completed_at' => now()->subMinutes(30),
             ]);
         }
 
         $lastStep = $steps->last();
         $lastStep->update([
-            'status'     => BatchStep::STATUS_IN_PROGRESS,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
             'started_at' => now()->subMinutes(5),
         ]);
 

--- a/backend/tests/Unit/Services/WorkOrderServiceTest.php
+++ b/backend/tests/Unit/Services/WorkOrderServiceTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Unit\Services;
 
-use App\Models\Line;
-use App\Models\ProductType;
-use App\Models\ProcessTemplate;
-use App\Models\WorkOrder;
 use App\Models\Batch;
+use App\Models\Line;
+use App\Models\ProcessTemplate;
+use App\Models\ProductType;
+use App\Models\WorkOrder;
 use App\Services\WorkOrder\WorkOrderService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -100,7 +100,9 @@ class WorkOrderServiceTest extends TestCase
             $this->assertEquals($snapshotStep['step_number'], $step->step_number);
             $this->assertEquals($snapshotStep['name'], $step->name);
             $this->assertEquals($snapshotStep['instruction'], $step->instruction);
-            $this->assertEquals('PENDING', $step->status);
+            // First step is promoted to READY ("ready to start"); the rest stay
+            // PENDING until their predecessor completes.
+            $this->assertEquals($index === 0 ? 'READY' : 'PENDING', $step->status);
         }
     }
 
@@ -211,13 +213,13 @@ class WorkOrderServiceTest extends TestCase
 
         WorkOrder::factory()->create([
             'line_id' => $line->id,
-            'status' => WorkOrder::STATUS_PENDING
+            'status' => WorkOrder::STATUS_PENDING,
         ]);
         WorkOrder::factory()->inProgress()->create(['line_id' => $line->id]);
         WorkOrder::factory()->done()->create(['line_id' => $line->id]);
 
         $result = $this->service->getWorkOrdersForUser($user, [
-            'status' => WorkOrder::STATUS_PENDING
+            'status' => WorkOrder::STATUS_PENDING,
         ]);
 
         $this->assertCount(1, $result);

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,270 @@
+#requires -version 5.1
+<#
+  OpenMES — Installer (Windows / PowerShell)
+
+  Behaves like install.sh: generates .env with secure defaults, picks free host
+  ports, and starts the stack for real (production build, frontend baked in).
+
+    .\install.ps1                 # production, unattended (just works)
+    .\install.ps1 -Interactive    # prompt for domain / admin user / email
+    .\install.ps1 -Dev            # vite-watch dev overlay (bind-mounted source)
+
+  Run from the repository root (where docker-compose.yml lives), in a shell with
+  Docker Desktop available. Requires Docker + the Docker Compose plugin.
+#>
+param(
+    [Alias('i')][switch]$Interactive,
+    [Alias('y')][switch]$Yes,        # kept for parity with --yes (unattended is the default)
+    [switch]$Dev,
+    [Alias('h')][switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+function Write-Ok   ($m) { Write-Host "OK  $m"  -ForegroundColor Green }
+function Write-Warn ($m) { Write-Host "!   $m"  -ForegroundColor Yellow }
+function Write-Info ($m) { Write-Host "->  $m"  -ForegroundColor Cyan }
+function Fail       ($m) { Write-Host "X   $m"  -ForegroundColor Red; exit 1 }
+
+if ($Help) {
+    Write-Host "Usage: .\install.ps1 [-Interactive] [-Dev]"
+    Write-Host "  (default)       unattended - sensible defaults, just works"
+    Write-Host "  -Interactive    prompt for domain / admin user / email"
+    Write-Host "  -Dev            run the vite-watch dev overlay instead of production"
+    exit 0
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+function Read-Default([string]$Prompt, [string]$Default) {
+    if (-not $Interactive) { return $Default }
+    $reply = Read-Host "  $Prompt [$Default]"
+    if ([string]::IsNullOrWhiteSpace($reply)) { return $Default }
+    return $reply
+}
+
+function Confirm-Proceed([string]$Prompt) {
+    if (-not $Interactive) { return $true }   # unattended = proceed
+    $reply = Read-Host "  $Prompt [Y/n]"
+    if ($reply -match '^(n|no)$') { return $false }
+    return $true
+}
+
+function New-Password {
+    # 24 alphanumeric chars from a CSPRNG (~143 bits). No symbols: the value is
+    # written to .env and passed through docker compose; alphanumeric avoids '#'
+    # comments, '$' interpolation and quoting hazards.
+    $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    $bytes = New-Object 'System.Byte[]' 24
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
+    -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] })
+}
+
+function Test-PortInUse([int]$Port) {
+    # A successful TCP connect to loopback means something is already listening.
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $iar = $client.BeginConnect('127.0.0.1', $Port, $null, $null)
+        if ($iar.AsyncWaitHandle.WaitOne(300) -and $client.Connected) {
+            $client.EndConnect($iar); return $true
+        }
+        return $false
+    } catch { return $false } finally { $client.Close() }
+}
+
+function Get-FreePort([int]$Preferred, [int]$FallbackStart) {
+    if (-not (Test-PortInUse $Preferred)) { return $Preferred }
+    $p = $FallbackStart
+    while (Test-PortInUse $p) { $p++ }
+    return $p
+}
+
+function Get-EnvValue([string]$Key) {
+    if (-not (Test-Path '.env')) { return '' }
+    foreach ($line in (Get-Content '.env')) {
+        if ($line -match "^$([regex]::Escape($Key))=(.*)$") { return $Matches[1] }
+    }
+    return ''
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "  OpenMES" -ForegroundColor Cyan
+Write-Host "  Manufacturing Execution System"
+Write-Host "  --------------------------------------------------------------"
+Write-Host ""
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Fail "Docker is not installed. See: https://docs.docker.com/get-docker/ (Docker Desktop)"
+}
+docker compose version *> $null
+if ($LASTEXITCODE -ne 0) { Fail "Docker Compose plugin not found. Install Docker Desktop." }
+Write-Ok ("Docker " + (((docker --version) -split ' ')[2].TrimEnd(',')))
+Write-Ok ("Docker Compose " + (docker compose version --short))
+Write-Host ""
+
+if (-not (Test-Path 'docker-compose.yml')) {
+    Fail "docker-compose.yml not found - run this from the repository root."
+}
+
+# ── Existing installation check (reuse passwords so they match the DB volume) ──
+
+$reuseEnv = $false
+if (Test-Path '.env') {
+    Write-Warn ".env already exists - keeping existing passwords (data is preserved)."
+    if (-not (Confirm-Proceed "Re-run setup? (existing data is preserved)")) { Write-Host "Aborted."; exit 0 }
+    $reuseEnv = $true
+    Write-Host ""
+}
+
+# ── Collect configuration ─────────────────────────────────────────────────────
+
+if ($Interactive) { Write-Info "Configure your installation (Enter accepts defaults):"; Write-Host "" }
+else { Write-Info "Unattended setup (run with -Interactive to customise)." }
+
+$domain        = Read-Default "Domain (e.g. demo.example.com)" "localhost"
+$adminUsername = Read-Default "Admin username" "admin"
+$adminEmail    = Read-Default "Admin email" "admin@example.com"
+
+# ── Pick free host ports (80/443 preferred, auto-fallback if taken) ───────────
+
+Write-Info "Selecting host ports..."
+$httpPort  = Get-FreePort 80 8080
+$httpsPort = Get-FreePort 443 8443
+if ($httpPort  -eq 80)  { Write-Ok "HTTP  port 80" }  else { Write-Warn "HTTP  port 80 busy -> using $httpPort" }
+if ($httpsPort -eq 443) { Write-Ok "HTTPS port 443" } else { Write-Warn "HTTPS port 443 busy -> using $httpsPort" }
+
+if ($domain -eq 'localhost') {
+    $appUrl  = if ($httpPort -eq 80) { 'http://localhost' } else { "http://localhost:$httpPort" }
+    $sanctum = "localhost,localhost:$httpPort,localhost:$httpsPort"
+} else {
+    $appUrl  = "https://$domain"
+    $sanctum = $domain
+}
+
+# ── Passwords + container-name prefix (reuse on re-run) ───────────────────────
+
+$dbPassword = ''; $adminPassword = ''; $namePrefix = ''
+if ($reuseEnv) {
+    $dbPassword    = Get-EnvValue 'POSTGRES_PASSWORD'
+    $adminPassword = Get-EnvValue 'ADMIN_PASSWORD'
+    $namePrefix    = Get-EnvValue 'OPENMES_NAME_PREFIX'
+}
+if (-not $dbPassword)    { $dbPassword    = New-Password }
+if (-not $adminPassword) { $adminPassword = New-Password }
+
+if (-not $namePrefix) {
+    $namePrefix = ((Split-Path -Leaf (Get-Location)).ToLower() -replace '[^a-z0-9_.-]','-') -replace '^[^a-z0-9]+','' -replace '-+$',''
+    if (-not $namePrefix) { $namePrefix = 'openmmes' }
+}
+Write-Ok "Container name prefix: $namePrefix (containers: $namePrefix-backend, ...)"
+
+Write-Host ""
+Write-Host "  Credentials (saved in .env - keep them safe):"
+Write-Host "    Admin login:    $adminUsername"
+Write-Host "    Admin password: $adminPassword"
+Write-Host "    DB password:    $dbPassword"
+Write-Host ""
+
+if (-not (Confirm-Proceed "Proceed with installation?")) { Write-Host "Aborted."; exit 0 }
+Write-Host ""
+
+# ── Write .env (LF, no BOM — CRLF would append \r to values and break auth) ───
+
+$envText = @"
+# OpenMES - Docker Compose configuration
+# Generated by install.ps1 on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+# DO NOT commit this file to version control.
+
+# Domain / URL
+DOMAIN=$domain
+APP_URL=$appUrl
+
+# Host ports (auto-selected; 80/443 preferred)
+HTTP_PORT=$httpPort
+HTTPS_PORT=$httpsPort
+
+# Container-name prefix - unique per install dir so multiple local instances
+# don't clash on container names (default is "openmmes" when unset).
+OPENMES_NAME_PREFIX=$namePrefix
+
+# Mode
+APP_ENV=production
+APP_DEBUG=false
+
+# SPA stateful hosts (must cover the host:port the app is served on).
+SANCTUM_STATEFUL_DOMAINS=$sanctum
+
+# Database
+POSTGRES_DB=openmmes
+POSTGRES_USER=openmmes_user
+POSTGRES_PASSWORD=$dbPassword
+
+# Admin account (created automatically on first run)
+ADMIN_USERNAME=$adminUsername
+ADMIN_EMAIL=$adminEmail
+ADMIN_PASSWORD=$adminPassword
+"@ -replace "`r`n", "`n"
+
+[System.IO.File]::WriteAllText((Join-Path (Get-Location) '.env'), $envText, (New-Object System.Text.UTF8Encoding($false)))
+Write-Ok ".env created"
+
+# ── Build and start (real production unless -Dev) ─────────────────────────────
+
+if ($Dev) {
+    $composeFiles = @('-f','docker-compose.yml','-f','docker-compose.dev.yml')
+    Write-Info "Building and starting (DEV: vite-watch overlay)..."
+} else {
+    $composeFiles = @('-f','docker-compose.yml')
+    Write-Info "Building and starting containers (production; first build takes a few minutes)..."
+}
+Write-Host ""
+
+docker compose @composeFiles up -d --build
+if ($LASTEXITCODE -ne 0) { Fail "docker compose failed - check the output above." }
+
+Write-Host ""
+Write-Ok "Containers started"
+Write-Info "Waiting for the application to come up (first boot builds the DB)..."
+
+# Poll the login page for a real 200 (Octane serving + migrations done + Caddy).
+try { [Net.ServicePointManager]::ServerCertificateValidationCallback = { $true } } catch {}
+$readyUrl = ($appUrl.TrimEnd('/')) + '/login'
+$ready = $false
+for ($i = 0; $i -le 90; $i++) {
+    try {
+        $resp = Invoke-WebRequest -Uri $readyUrl -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        if ($resp.StatusCode -eq 200) { $ready = $true; break }
+    } catch {}
+    Write-Host -NoNewline '.'
+    Start-Sleep -Seconds 2
+}
+Write-Host ""
+
+if ($ready) {
+    Write-Ok "Application is up - $appUrl is live."
+} else {
+    Write-Warn "App not serving yet. It may still be building/migrating."
+    Write-Warn "Watch it finish with:  docker compose logs -f backend"
+}
+
+Write-Host ""
+Write-Host "  ==========================================================" -ForegroundColor Green
+Write-Host ("  {0}" -f $(if ($ready) { 'OpenMES is ready!' } else { 'OpenMES is starting - give it a moment...' })) -ForegroundColor Green
+Write-Host "  URL:      $appUrl"
+Write-Host "  Login:    $adminUsername"
+Write-Host "  Password: $adminPassword"
+Write-Host "  Credentials are saved in .env (do not share this file)"
+Write-Host "  ==========================================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Useful commands:"
+Write-Host "    docker compose logs -f backend          # Live logs"
+Write-Host "    docker compose down                     # Stop"
+Write-Host "    docker compose up -d                     # Start (same ports)"
+Write-Host "    docker compose up -d --build             # Rebuild after a git pull"
+Write-Host ""


### PR DESCRIPTION
## Release v0.15.3

Merges `develop` → `main`.

### Added
- **"Ready to start" batch-step status** — a step state between **Pending** (blocked) and **In Progress**: a step becomes **Ready to start** once its prerequisites are met (first step, predecessor done/skipped, or non-sequential mode), and the next step is promoted automatically on complete/skip. Operators only get the **Start** button on Ready steps. No schema change (status is a free string); in-flight batches are backfilled by migration; syncs to live views like any other status. _(Refs [discussion #69](https://github.com/orgs/Mes-Open/discussions/69))_
- **Windows installer (`install.ps1`)** — PowerShell port of `install.sh` with the same behaviour (auto free-port, CSPRNG creds, reuse-on-rerun, production build, wait-for-200). Writes `.env` as LF/no-BOM so values aren't corrupted. `-Interactive` / `-Dev` flags.
- **`.gitattributes`** keeps shell scripts LF-only so a Windows checkout doesn't break the `#!/bin/bash` shebang.

### Quality
- Full suite green: **1360 tests, 4148 assertions** (incl. new `ReadyToStartStepTest`).

**Compare:** [v0.15.2...v0.15.3](https://github.com/Mes-Open/OpenMes/compare/v0.15.2...v0.15.3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows PowerShell installer (`install.ps1`) for Docker setup, matching functionality of the shell installer.
  * Introduced new "Ready to Start" batch step status, enabling operators to see when steps are prepared and actionable.

* **Documentation**
  * Updated README with Windows PowerShell installation instructions.
  * Updated CHANGELOG for v0.15.3 release notes.

* **Chores**
  * Enforced consistent line endings across configuration and script files.
  * Bumped version to v0.15.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->