### PR TITLE
feat: non-conformity CAPA actions + closure gate (#107 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Non-conformity workflow — corrective/preventive actions (CAPA) on issues** *(part 1 of [#107](https://github.com/Mes-Open/OpenMes/issues/107))*: an issue (the non-conformance record) can now carry **corrective and preventive actions**, each with an assignee, due date and lifecycle **Open → In progress → Done → Verified**. The issue **can only be CLOSED once every action is Verified** (enforced server-side in `IssueService::closeIssue` for both the admin/supervisor UI and the API). Manage actions from a panel on the Issues page (Admin → Issues / Supervisor → Issues). New `issue_actions` table follows the soft-delete-with-audit pattern and cascades when its issue is deleted.
+
 ---
 
 ## [0.15.3] - 2026-06-16

--- a/backend/app/Http/Controllers/Api/V1/IssueController.php
+++ b/backend/app/Http/Controllers/Api/V1/IssueController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CreateIssueRequest;
-use App\Http\Requests\UpdateIssueRequest;
 use App\Http\Requests\ResolveIssueRequest;
+use App\Http\Requests\UpdateIssueRequest;
 use App\Models\Issue;
 use App\Services\IssueService;
 use Illuminate\Http\JsonResponse;
@@ -155,7 +155,8 @@ class IssueController extends Controller
                 'data' => $updatedIssue,
                 'message' => 'Issue closed successfully',
             ]);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException|\DomainException $e) {
+            // DomainException = closure gate (unverified corrective/preventive actions).
             return response()->json([
                 'message' => $e->getMessage(),
             ], 422);
@@ -183,10 +184,11 @@ class IssueController extends Controller
      */
     public function destroy(Request $request, Issue $issue): JsonResponse
     {
-        if (!$request->user()->hasRole('Admin')) {
+        if (! $request->user()->hasRole('Admin')) {
             return response()->json(['message' => 'Forbidden'], 403);
         }
         $issue->delete();
+
         return response()->json(['message' => 'Issue deleted']);
     }
 }

--- a/backend/app/Http/Controllers/Web/IssueManagementController.php
+++ b/backend/app/Http/Controllers/Web/IssueManagementController.php
@@ -3,11 +3,15 @@
 namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreIssueActionRequest;
+use App\Http\Requests\UpdateIssueActionRequest;
 use App\Models\Issue;
+use App\Models\IssueAction;
 use App\Models\IssueType;
 use App\Models\Line;
 use App\Models\User;
 use App\Models\WorkOrder;
+use App\Services\Quality\IssueActionService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -20,9 +24,9 @@ class IssueManagementController extends Controller
     {
         return Inertia::render('shared/issues/Index', [
             'issueTypeNames' => IssueType::pluck('name', 'id'),
-            'lineNames'      => Line::pluck('name', 'id'),
-            'reporterNames'  => User::pluck('name', 'id'),
-            'workOrderNos'   => WorkOrder::pluck('order_no', 'id'),
+            'lineNames' => Line::pluck('name', 'id'),
+            'reporterNames' => User::pluck('name', 'id'),
+            'workOrderNos' => WorkOrder::pluck('order_no', 'id'),
         ]);
     }
 
@@ -33,7 +37,7 @@ class IssueManagementController extends Controller
         }
 
         $issue->update([
-            'status'          => Issue::STATUS_ACKNOWLEDGED,
+            'status' => Issue::STATUS_ACKNOWLEDGED,
             'acknowledged_at' => now(),
         ]);
 
@@ -46,13 +50,13 @@ class IssueManagementController extends Controller
             'resolution_notes' => 'nullable|string|max:2000',
         ]);
 
-        if (!in_array($issue->status, [Issue::STATUS_OPEN, Issue::STATUS_ACKNOWLEDGED])) {
+        if (! in_array($issue->status, [Issue::STATUS_OPEN, Issue::STATUS_ACKNOWLEDGED])) {
             return redirect()->back()->with('error', 'Issue is already resolved or closed.');
         }
 
         $issue->update([
-            'status'           => Issue::STATUS_RESOLVED,
-            'resolved_at'      => now(),
+            'status' => Issue::STATUS_RESOLVED,
+            'resolved_at' => now(),
             'resolution_notes' => $request->input('resolution_notes'),
         ]);
 
@@ -73,11 +77,99 @@ class IssueManagementController extends Controller
             return redirect()->back()->with('error', 'Only resolved issues can be closed.');
         }
 
+        // Closure gate: every corrective/preventive action must be verified.
+        if ($issue->hasUnverifiedActions()) {
+            return redirect()->back()->with('error', 'Cannot close: all corrective/preventive actions must be verified first.');
+        }
+
         $issue->update([
-            'status'    => Issue::STATUS_CLOSED,
+            'status' => Issue::STATUS_CLOSED,
             'closed_at' => now(),
         ]);
 
         return redirect()->back()->with('success', 'Issue closed.');
+    }
+
+    // ── Corrective / preventive actions (CAPA) ───────────────────────────────
+
+    /** JSON list of an issue's actions (for the actions modal). */
+    public function actions(Issue $issue)
+    {
+        return response()->json([
+            'actions' => $this->serializeActions($issue),
+        ]);
+    }
+
+    public function storeAction(StoreIssueActionRequest $request, Issue $issue, IssueActionService $service)
+    {
+        $service->create($issue, $request->validated());
+
+        return response()->json(['actions' => $this->serializeActions($issue->fresh())], 201);
+    }
+
+    public function updateAction(UpdateIssueActionRequest $request, IssueAction $action)
+    {
+        $action->update($request->validated());
+
+        return response()->json(['actions' => $this->serializeActions($action->issue)]);
+    }
+
+    public function startAction(IssueAction $action, IssueActionService $service)
+    {
+        return $this->runAction(fn () => $service->start($action), $action);
+    }
+
+    public function completeAction(Request $request, IssueAction $action, IssueActionService $service)
+    {
+        $notes = $request->input('notes');
+
+        return $this->runAction(fn () => $service->complete($action, $request->user(), $notes), $action);
+    }
+
+    public function verifyAction(Request $request, IssueAction $action, IssueActionService $service)
+    {
+        return $this->runAction(fn () => $service->verify($action, $request->user()), $action);
+    }
+
+    public function destroyAction(IssueAction $action)
+    {
+        $issue = $action->issue;
+        $action->delete();
+
+        return response()->json(['actions' => $this->serializeActions($issue)]);
+    }
+
+    /** Run a transition, mapping DomainException to a 422 with the actions list. */
+    private function runAction(callable $fn, IssueAction $action)
+    {
+        try {
+            $fn();
+        } catch (\DomainException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json(['actions' => $this->serializeActions($action->issue)]);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function serializeActions(Issue $issue): array
+    {
+        return $issue->actions()
+            ->with(['assignedTo:id,name', 'completedBy:id,name', 'verifiedBy:id,name'])
+            ->orderBy('id')
+            ->get()
+            ->map(fn (IssueAction $a) => [
+                'id' => $a->id,
+                'type' => $a->type,
+                'title' => $a->title,
+                'description' => $a->description,
+                'status' => $a->status,
+                'assigned_to' => $a->assignedTo?->name,
+                'due_date' => $a->due_date?->toDateString(),
+                'completed_by' => $a->completedBy?->name,
+                'verified_by' => $a->verifiedBy?->name,
+                'notes' => $a->notes,
+            ])
+            ->all();
     }
 }

--- a/backend/app/Http/Requests/StoreIssueActionRequest.php
+++ b/backend/app/Http/Requests/StoreIssueActionRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\IssueAction;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreIssueActionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + role:Admin|Supervisor middleware.
+    }
+
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::in(IssueAction::TYPES)],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:2000'],
+            'assigned_to_id' => ['nullable', 'integer', 'exists:users,id'],
+            'due_date' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UpdateIssueActionRequest.php
+++ b/backend/app/Http/Requests/UpdateIssueActionRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\IssueAction;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateIssueActionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + role:Admin|Supervisor middleware.
+    }
+
+    public function rules(): array
+    {
+        return [
+            'type' => ['sometimes', 'required', Rule::in(IssueAction::TYPES)],
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:2000'],
+            'assigned_to_id' => ['nullable', 'integer', 'exists:users,id'],
+            'due_date' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/backend/app/Models/Issue.php
+++ b/backend/app/Models/Issue.php
@@ -8,6 +8,7 @@ use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Issue extends Model
 {
@@ -106,12 +107,39 @@ class Issue extends Model
     }
 
     /**
+     * Corrective / preventive actions (CAPA) attached to this issue.
+     */
+    public function actions(): HasMany
+    {
+        return $this->hasMany(IssueAction::class);
+    }
+
+    /**
+     * Soft-deleting an issue also soft-deletes its CAPA actions (mirrors the
+     * cascadeOnDelete FK, which doesn't fire on a soft delete).
+     */
+    public function softDeleteCascades(): array
+    {
+        return [
+            [IssueAction::class, 'issue_id'],
+        ];
+    }
+
+    /**
      * Check if this is a blocking issue.
      */
     public function isBlocking(): bool
     {
         return $this->issueType->is_blocking &&
             in_array($this->status, [self::STATUS_OPEN, self::STATUS_ACKNOWLEDGED]);
+    }
+
+    /**
+     * Whether the issue has any non-verified CAPA action (which blocks closure).
+     */
+    public function hasUnverifiedActions(): bool
+    {
+        return $this->actions()->unverified()->exists();
     }
 
     /**

--- a/backend/app/Models/IssueAction.php
+++ b/backend/app/Models/IssueAction.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\SoftDeletesWithAudit;
+use App\Traits\Auditable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A corrective or preventive action (CAPA) attached to an Issue. Lifecycle:
+ * OPEN → IN_PROGRESS → DONE → VERIFIED. An issue can only be closed once all of
+ * its actions are VERIFIED (enforced in IssueService::closeIssue).
+ */
+class IssueAction extends Model
+{
+    use Auditable, HasFactory;
+    use SoftDeletesWithAudit;
+
+    const TYPE_CORRECTIVE = 'corrective';
+
+    const TYPE_PREVENTIVE = 'preventive';
+
+    const STATUS_OPEN = 'open';
+
+    const STATUS_IN_PROGRESS = 'in_progress';
+
+    const STATUS_DONE = 'done';
+
+    const STATUS_VERIFIED = 'verified';
+
+    public const TYPES = [self::TYPE_CORRECTIVE, self::TYPE_PREVENTIVE];
+
+    public const STATUSES = [self::STATUS_OPEN, self::STATUS_IN_PROGRESS, self::STATUS_DONE, self::STATUS_VERIFIED];
+
+    protected $fillable = [
+        'issue_id',
+        'type',
+        'title',
+        'description',
+        'assigned_to_id',
+        'due_date',
+        'status',
+        'completed_at',
+        'completed_by_id',
+        'verified_at',
+        'verified_by_id',
+        'notes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'due_date' => 'date',
+            'completed_at' => 'datetime',
+            'verified_at' => 'datetime',
+        ];
+    }
+
+    public function issue(): BelongsTo
+    {
+        return $this->belongsTo(Issue::class);
+    }
+
+    public function assignedTo(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to_id');
+    }
+
+    public function completedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'completed_by_id');
+    }
+
+    public function verifiedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'verified_by_id');
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->status === self::STATUS_VERIFIED;
+    }
+
+    public function scopeUnverified($query)
+    {
+        return $query->where('status', '!=', self::STATUS_VERIFIED);
+    }
+}

--- a/backend/app/Services/IssueService.php
+++ b/backend/app/Services/IssueService.php
@@ -4,8 +4,6 @@ namespace App\Services;
 
 use App\Models\Issue;
 use App\Models\WorkOrder;
-use App\Models\BatchStep;
-use App\Models\IssueType;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -47,7 +45,7 @@ class IssueService
      */
     public function acknowledgeIssue(Issue $issue, int $userId): Issue
     {
-        if (!in_array($issue->status, [Issue::STATUS_OPEN])) {
+        if (! in_array($issue->status, [Issue::STATUS_OPEN])) {
             throw new \InvalidArgumentException('Only OPEN issues can be acknowledged');
         }
 
@@ -70,9 +68,9 @@ class IssueService
     /**
      * Resolve an issue (mark as fixed but not yet verified).
      */
-    public function resolveIssue(Issue $issue, string $resolutionNotes = null): Issue
+    public function resolveIssue(Issue $issue, ?string $resolutionNotes = null): Issue
     {
-        if (!in_array($issue->status, [Issue::STATUS_OPEN, Issue::STATUS_ACKNOWLEDGED])) {
+        if (! in_array($issue->status, [Issue::STATUS_OPEN, Issue::STATUS_ACKNOWLEDGED])) {
             throw new \InvalidArgumentException('Only OPEN or ACKNOWLEDGED issues can be resolved');
         }
 
@@ -106,6 +104,11 @@ class IssueService
             throw new \InvalidArgumentException('Only RESOLVED issues can be closed');
         }
 
+        // Closure gate: every corrective/preventive action must be verified.
+        if ($issue->hasUnverifiedActions()) {
+            throw new \DomainException('Cannot close: all corrective/preventive actions must be verified first.');
+        }
+
         return DB::transaction(function () use ($issue) {
             $issue->update([
                 'status' => Issue::STATUS_CLOSED,
@@ -128,7 +131,7 @@ class IssueService
         $workOrder = WorkOrder::findOrFail($workOrderId);
 
         // Only block if not already blocked or done
-        if (!in_array($workOrder->status, [WorkOrder::STATUS_BLOCKED, WorkOrder::STATUS_DONE, WorkOrder::STATUS_CANCELLED])) {
+        if (! in_array($workOrder->status, [WorkOrder::STATUS_BLOCKED, WorkOrder::STATUS_DONE, WorkOrder::STATUS_CANCELLED])) {
             $workOrder->update(['status' => WorkOrder::STATUS_BLOCKED]);
 
             Log::info('Work order blocked due to issue', [
@@ -154,7 +157,7 @@ class IssueService
             ->blocking()
             ->exists();
 
-        if (!$hasBlockingIssues) {
+        if (! $hasBlockingIssues) {
             // Determine the appropriate status to restore
             // If there are in-progress batches, set to IN_PROGRESS, otherwise PENDING
             $hasBatchesInProgress = $workOrder->batches()
@@ -223,7 +226,7 @@ class IssueService
             'acknowledged' => $issues->where('status', Issue::STATUS_ACKNOWLEDGED)->count(),
             'resolved' => $issues->where('status', Issue::STATUS_RESOLVED)->count(),
             'closed' => $issues->where('status', Issue::STATUS_CLOSED)->count(),
-            'blocking' => $issues->filter(fn($i) => $i->isBlocking())->count(),
+            'blocking' => $issues->filter(fn ($i) => $i->isBlocking())->count(),
         ];
     }
 }

--- a/backend/app/Services/Quality/IssueActionService.php
+++ b/backend/app/Services/Quality/IssueActionService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services\Quality;
+
+use App\Models\Issue;
+use App\Models\IssueAction;
+use App\Models\User;
+
+/**
+ * Lifecycle of corrective / preventive actions attached to an Issue:
+ * OPEN → IN_PROGRESS → DONE → VERIFIED. Closing the parent issue is gated on all
+ * actions being VERIFIED (see IssueService::closeIssue).
+ */
+class IssueActionService
+{
+    /**
+     * @param  array{type:string,title:string,description?:?string,assigned_to_id?:?int,due_date?:?string}  $data
+     */
+    public function create(Issue $issue, array $data): IssueAction
+    {
+        return $issue->actions()->create([
+            'type' => $data['type'],
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'assigned_to_id' => $data['assigned_to_id'] ?? null,
+            'due_date' => $data['due_date'] ?? null,
+            'status' => IssueAction::STATUS_OPEN,
+        ]);
+    }
+
+    public function start(IssueAction $action): IssueAction
+    {
+        if ($action->status !== IssueAction::STATUS_OPEN) {
+            throw new \DomainException("Only an OPEN action can be started (is {$action->status}).");
+        }
+
+        $action->update(['status' => IssueAction::STATUS_IN_PROGRESS]);
+
+        return $action->fresh();
+    }
+
+    public function complete(IssueAction $action, User $by, ?string $notes = null): IssueAction
+    {
+        if (! in_array($action->status, [IssueAction::STATUS_OPEN, IssueAction::STATUS_IN_PROGRESS], true)) {
+            throw new \DomainException("Only an open/in-progress action can be completed (is {$action->status}).");
+        }
+
+        $action->update([
+            'status' => IssueAction::STATUS_DONE,
+            'completed_at' => now(),
+            'completed_by_id' => $by->id,
+            'notes' => $notes ?? $action->notes,
+        ]);
+
+        return $action->fresh();
+    }
+
+    public function verify(IssueAction $action, User $by): IssueAction
+    {
+        if ($action->status !== IssueAction::STATUS_DONE) {
+            throw new \DomainException("Only a completed (DONE) action can be verified (is {$action->status}).");
+        }
+
+        $action->update([
+            'status' => IssueAction::STATUS_VERIFIED,
+            'verified_at' => now(),
+            'verified_by_id' => $by->id,
+        ]);
+
+        return $action->fresh();
+    }
+}

--- a/backend/app/Support/SoftDeleteRegistry.php
+++ b/backend/app/Support/SoftDeleteRegistry.php
@@ -28,6 +28,7 @@ class SoftDeleteRegistry
         'workstation_types' => Models\WorkstationType::class,
         'subassemblies' => Models\Subassembly::class,
         'issue_types' => Models\IssueType::class,
+        'issue_actions' => Models\IssueAction::class,
         'line_statuses' => Models\LineStatus::class,
         'lot_sequences' => Models\LotSequence::class,
         'view_templates' => Models\ViewTemplate::class,

--- a/backend/app/Sync/ShapeRegistry.php
+++ b/backend/app/Sync/ShapeRegistry.php
@@ -193,6 +193,10 @@ class ShapeRegistry
             'table' => 'issues',
             'columns' => ['id', 'work_order_id', 'issue_type_id', 'title', 'description', 'status', 'reported_by_id', 'assigned_to_id', 'reported_at', 'acknowledged_at', 'resolved_at', 'closed_at', 'material_id', 'source', 'custom_fields', 'created_at', 'updated_at'],
         ],
+        'issue_actions' => [
+            'table' => 'issue_actions',
+            'columns' => ['id', 'issue_id', 'type', 'title', 'description', 'status', 'assigned_to_id', 'due_date', 'completed_at', 'completed_by_id', 'verified_at', 'verified_by_id', 'notes', 'created_at', 'updated_at'],
+        ],
     ];
 
     public function find(string $name): ?Shape

--- a/backend/database/factories/IssueActionFactory.php
+++ b/backend/database/factories/IssueActionFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Issue;
+use App\Models\IssueAction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class IssueActionFactory extends Factory
+{
+    protected $model = IssueAction::class;
+
+    public function definition(): array
+    {
+        return [
+            'issue_id' => Issue::factory(),
+            'type' => IssueAction::TYPE_CORRECTIVE,
+            'title' => $this->faker->sentence(4),
+            'description' => $this->faker->optional()->sentence(),
+            'assigned_to_id' => null,
+            'due_date' => null,
+            'status' => IssueAction::STATUS_OPEN,
+        ];
+    }
+
+    public function preventive(): static
+    {
+        return $this->state(fn () => ['type' => IssueAction::TYPE_PREVENTIVE]);
+    }
+
+    public function verified(): static
+    {
+        return $this->state(fn () => [
+            'status' => IssueAction::STATUS_VERIFIED,
+            'completed_at' => now(),
+            'verified_at' => now(),
+        ]);
+    }
+}

--- a/backend/database/migrations/2026_06_17_100000_create_issue_actions_table.php
+++ b/backend/database/migrations/2026_06_17_100000_create_issue_actions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Corrective / preventive actions (CAPA) attached to an Issue (the
+ * non-conformance / incident record). An issue can carry many actions; it can
+ * only be CLOSED once every action is VERIFIED — enforced in IssueService.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('issue_actions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('issue_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 20);                 // corrective | preventive
+            $table->string('title', 255);
+            $table->text('description')->nullable();
+            $table->foreignId('assigned_to_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->date('due_date')->nullable();
+            $table->string('status', 20)->default('open'); // open | in_progress | done | verified
+            $table->timestamp('completed_at')->nullable();
+            $table->foreignId('completed_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('verified_at')->nullable();
+            $table->foreignId('verified_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreignId('deleted_by_id')->nullable()->constrained('users')->nullOnDelete();
+
+            $table->index(['issue_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('issue_actions');
+    }
+};

--- a/backend/resources/js/Pages/shared/issues/Index.jsx
+++ b/backend/resources/js/Pages/shared/issues/Index.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Head, router, usePage } from '@inertiajs/react';
 import AppLayout from '../../../layouts/AppLayout';
 import ResourceTable from '../../../components/ResourceTable';
@@ -9,12 +10,20 @@ const STATUS_STYLES = {
     CLOSED: 'bg-gray-200 text-gray-600',
 };
 
+const ACTION_STATUS_STYLES = {
+    open: 'bg-gray-100 text-gray-700',
+    in_progress: 'bg-blue-100 text-blue-800',
+    done: 'bg-amber-100 text-amber-800',
+    verified: 'bg-green-100 text-green-800',
+};
+
 export default function IssuesIndex() {
     const {
         issueTypeNames = {},
         lineNames = {},
         reporterNames = {},
         workOrderNos = {},
+        csrf_token: csrf,
     } = usePage().props;
 
     const base =
@@ -24,6 +33,8 @@ export default function IssuesIndex() {
 
     const post = (id, verb, data = {}) =>
         router.post(`${base}/issues/${id}/${verb}`, data, { preserveScroll: true });
+
+    const [actionsFor, setActionsFor] = useState(null); // issue row whose actions modal is open
 
     const columns = [
         { key: 'title', label: 'Issue', className: 'font-medium text-gray-800' },
@@ -46,20 +57,16 @@ export default function IssuesIndex() {
     });
 
     const actions = (r) => {
+        const list = [{ label: 'Actions', onClick: () => setActionsFor(r) }];
         const s = r.status;
         if (s === 'OPEN') {
-            return [
-                { label: 'Acknowledge', onClick: () => post(r.id, 'acknowledge') },
-                resolveAction(r),
-            ];
+            list.push({ label: 'Acknowledge', onClick: () => post(r.id, 'acknowledge') }, resolveAction(r));
+        } else if (s === 'ACKNOWLEDGED') {
+            list.push(resolveAction(r));
+        } else if (s === 'RESOLVED') {
+            list.push({ label: 'Close', onClick: () => post(r.id, 'close') });
         }
-        if (s === 'ACKNOWLEDGED') {
-            return [resolveAction(r)];
-        }
-        if (s === 'RESOLVED') {
-            return [{ label: 'Close', onClick: () => post(r.id, 'close') }];
-        }
-        return [];
+        return list;
     };
 
     return (
@@ -74,8 +81,131 @@ export default function IssuesIndex() {
                 actions={actions}
                 emptyText="No issues."
             />
+            {actionsFor && (
+                <ActionsModal
+                    issue={actionsFor}
+                    base={base}
+                    csrf={csrf}
+                    users={reporterNames}
+                    onClose={() => setActionsFor(null)}
+                />
+            )}
         </>
     );
 }
 
 IssuesIndex.layout = (page) => <AppLayout>{page}</AppLayout>;
+
+// ── Corrective / preventive actions modal ───────────────────────────────────
+
+function ActionsModal({ issue, base, csrf, users, onClose }) {
+    const [actions, setActions] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [form, setForm] = useState({ type: 'corrective', title: '', assigned_to_id: '', due_date: '' });
+
+    const api = async (url, method = 'GET', body) => {
+        const res = await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
+            credentials: 'same-origin',
+            body: body ? JSON.stringify(body) : undefined,
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(json.message || 'Request failed');
+        return json;
+    };
+
+    const load = () => {
+        setLoading(true);
+        api(`${base}/issues/${issue.id}/actions`)
+            .then((d) => setActions(d.actions ?? []))
+            .catch((e) => setError(e.message))
+            .finally(() => setLoading(false));
+    };
+    useEffect(load, []);
+
+    const run = async (fn) => {
+        setError(null);
+        try {
+            const d = await fn();
+            setActions(d.actions ?? []);
+        } catch (e) { setError(e.message); }
+    };
+
+    const add = (e) => {
+        e.preventDefault();
+        if (!form.title.trim()) return;
+        run(() => api(`${base}/issues/${issue.id}/actions`, 'POST', {
+            type: form.type,
+            title: form.title.trim(),
+            assigned_to_id: form.assigned_to_id || null,
+            due_date: form.due_date || null,
+        })).then(() => setForm({ type: 'corrective', title: '', assigned_to_id: '', due_date: '' }));
+    };
+
+    const start = (a) => run(() => api(`${base}/issues/actions/${a.id}/start`, 'POST'));
+    const complete = (a) => {
+        const notes = prompt('Completion notes (optional):') ?? undefined;
+        run(() => api(`${base}/issues/actions/${a.id}/complete`, 'POST', { notes }));
+    };
+    const verify = (a) => run(() => api(`${base}/issues/actions/${a.id}/verify`, 'POST'));
+    const remove = (a) => { if (confirm('Delete this action?')) run(() => api(`${base}/issues/actions/${a.id}`, 'DELETE')); };
+
+    return (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+            <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+            <div className="flex min-h-full items-center justify-center p-4">
+                <div className="relative bg-white dark:bg-slate-800 rounded-xl shadow-xl max-w-2xl w-full p-6" onClick={(e) => e.stopPropagation()}>
+                    <div className="flex justify-between items-start mb-4">
+                        <div>
+                            <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100">Corrective / preventive actions</h3>
+                            <p className="text-sm text-gray-500">{issue.title}</p>
+                        </div>
+                        <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">×</button>
+                    </div>
+
+                    {error && <div className="mb-3 p-2 rounded bg-red-50 border border-red-200 text-red-700 text-sm">{error}</div>}
+
+                    {loading ? (
+                        <p className="text-gray-400 text-sm py-4">Loading…</p>
+                    ) : actions.length === 0 ? (
+                        <p className="text-gray-400 text-sm py-3">No actions yet. The issue can only be closed once all actions are verified.</p>
+                    ) : (
+                        <ul className="space-y-2 mb-4 max-h-72 overflow-y-auto">
+                            {actions.map((a) => (
+                                <li key={a.id} className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+                                    <span className="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded bg-purple-100 text-purple-700">{a.type}</span>
+                                    <span className="flex-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+                                        {a.title}
+                                        {a.assigned_to && <span className="ml-2 text-xs text-gray-400">→ {a.assigned_to}</span>}
+                                        {a.due_date && <span className="ml-2 text-xs text-gray-400">due {a.due_date}</span>}
+                                    </span>
+                                    <span className={`text-xs px-2 py-0.5 rounded font-medium ${ACTION_STATUS_STYLES[a.status] ?? 'bg-gray-100'}`}>{a.status}</span>
+                                    {a.status === 'open' && <button onClick={() => start(a)} className="text-xs px-2 py-1 rounded bg-blue-600 text-white">Start</button>}
+                                    {(a.status === 'open' || a.status === 'in_progress') && <button onClick={() => complete(a)} className="text-xs px-2 py-1 rounded bg-amber-600 text-white">Complete</button>}
+                                    {a.status === 'done' && <button onClick={() => verify(a)} className="text-xs px-2 py-1 rounded bg-green-600 text-white">Verify</button>}
+                                    <button onClick={() => remove(a)} className="text-xs px-2 py-1 rounded bg-gray-200 text-gray-600">Delete</button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    <form onSubmit={add} className="flex flex-wrap items-end gap-2 border-t border-gray-200 dark:border-gray-700 pt-4">
+                        <select value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })} className="form-input text-sm">
+                            <option value="corrective">Corrective</option>
+                            <option value="preventive">Preventive</option>
+                        </select>
+                        <input value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} placeholder="Action title" className="form-input text-sm flex-1 min-w-[12rem]" maxLength={255} required />
+                        <select value={form.assigned_to_id} onChange={(e) => setForm({ ...form, assigned_to_id: e.target.value })} className="form-input text-sm">
+                            <option value="">— Assignee —</option>
+                            {Object.entries(users).map(([id, name]) => <option key={id} value={id}>{name}</option>)}
+                        </select>
+                        <input type="date" value={form.due_date} onChange={(e) => setForm({ ...form, due_date: e.target.value })} className="form-input text-sm" />
+                        <button type="submit" className="btn-touch btn-primary text-sm">Add</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -292,6 +292,14 @@ Route::middleware('auth')->group(function () {
         Route::post('/issues/{issue}/acknowledge', [IssueManagementController::class, 'acknowledge'])->name('issues.acknowledge');
         Route::post('/issues/{issue}/resolve', [IssueManagementController::class, 'resolve'])->name('issues.resolve');
         Route::post('/issues/{issue}/close', [IssueManagementController::class, 'close'])->name('issues.close');
+        // Corrective / preventive actions (CAPA)
+        Route::get('/issues/{issue}/actions', [IssueManagementController::class, 'actions'])->name('issues.actions');
+        Route::post('/issues/{issue}/actions', [IssueManagementController::class, 'storeAction'])->name('issues.actions.store');
+        Route::put('/issues/actions/{action}', [IssueManagementController::class, 'updateAction'])->name('issues.actions.update');
+        Route::post('/issues/actions/{action}/start', [IssueManagementController::class, 'startAction'])->name('issues.actions.start');
+        Route::post('/issues/actions/{action}/complete', [IssueManagementController::class, 'completeAction'])->name('issues.actions.complete');
+        Route::post('/issues/actions/{action}/verify', [IssueManagementController::class, 'verifyAction'])->name('issues.actions.verify');
+        Route::delete('/issues/actions/{action}', [IssueManagementController::class, 'destroyAction'])->name('issues.actions.destroy');
         Route::get('/reports', [AdminReportController::class, 'index'])->name('reports');
     });
 
@@ -368,6 +376,14 @@ Route::middleware('auth')->group(function () {
         Route::post('/issues/{issue}/acknowledge', [IssueManagementController::class, 'acknowledge'])->name('issues.acknowledge');
         Route::post('/issues/{issue}/resolve', [IssueManagementController::class, 'resolve'])->name('issues.resolve');
         Route::post('/issues/{issue}/close', [IssueManagementController::class, 'close'])->name('issues.close');
+        // Corrective / preventive actions (CAPA)
+        Route::get('/issues/{issue}/actions', [IssueManagementController::class, 'actions'])->name('issues.actions');
+        Route::post('/issues/{issue}/actions', [IssueManagementController::class, 'storeAction'])->name('issues.actions.store');
+        Route::put('/issues/actions/{action}', [IssueManagementController::class, 'updateAction'])->name('issues.actions.update');
+        Route::post('/issues/actions/{action}/start', [IssueManagementController::class, 'startAction'])->name('issues.actions.start');
+        Route::post('/issues/actions/{action}/complete', [IssueManagementController::class, 'completeAction'])->name('issues.actions.complete');
+        Route::post('/issues/actions/{action}/verify', [IssueManagementController::class, 'verifyAction'])->name('issues.actions.verify');
+        Route::delete('/issues/actions/{action}', [IssueManagementController::class, 'destroyAction'])->name('issues.actions.destroy');
 
         // User Management
         Route::resource('users', \App\Http\Controllers\Web\Admin\UserManagementController::class);

--- a/backend/tests/Feature/Web/IssueActionTest.php
+++ b/backend/tests/Feature/Web/IssueActionTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Issue;
+use App\Models\IssueAction;
+use App\Models\User;
+use App\Services\IssueService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Corrective/preventive actions (CAPA) on issues + the closure gate: an issue
+ * can only be CLOSED once all of its actions are VERIFIED.
+ */
+class IssueActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    public function test_admin_can_add_a_corrective_action(): void
+    {
+        $issue = Issue::factory()->create();
+
+        $this->actingAs($this->admin)
+            ->postJson("/admin/issues/{$issue->id}/actions", ['type' => 'corrective', 'title' => 'Fix the root cause'])
+            ->assertStatus(201)
+            ->assertJsonPath('actions.0.title', 'Fix the root cause');
+
+        $this->assertDatabaseHas('issue_actions', [
+            'issue_id' => $issue->id,
+            'type' => 'corrective',
+            'status' => 'open',
+        ]);
+    }
+
+    public function test_action_runs_through_start_complete_verify(): void
+    {
+        $issue = Issue::factory()->create();
+        $action = IssueAction::factory()->create(['issue_id' => $issue->id]);
+
+        $this->actingAs($this->admin)->postJson("/admin/issues/actions/{$action->id}/start")
+            ->assertOk()->assertJsonPath('actions.0.status', 'in_progress');
+        $this->actingAs($this->admin)->postJson("/admin/issues/actions/{$action->id}/complete", ['notes' => 'done it'])
+            ->assertOk()->assertJsonPath('actions.0.status', 'done');
+        $this->actingAs($this->admin)->postJson("/admin/issues/actions/{$action->id}/verify")
+            ->assertOk()->assertJsonPath('actions.0.status', 'verified');
+
+        $action->refresh();
+        $this->assertSame($this->admin->id, $action->verified_by_id);
+        $this->assertNotNull($action->verified_at);
+    }
+
+    public function test_verifying_a_non_completed_action_is_rejected(): void
+    {
+        $issue = Issue::factory()->create();
+        $action = IssueAction::factory()->create(['issue_id' => $issue->id, 'status' => 'open']);
+
+        $this->actingAs($this->admin)->postJson("/admin/issues/actions/{$action->id}/verify")
+            ->assertStatus(422);
+        $this->assertSame('open', $action->fresh()->status);
+    }
+
+    public function test_issue_cannot_be_closed_while_an_action_is_unverified(): void
+    {
+        $issue = Issue::factory()->create(['status' => Issue::STATUS_RESOLVED, 'resolved_at' => now()]);
+        IssueAction::factory()->create(['issue_id' => $issue->id, 'status' => 'done']);
+
+        $this->actingAs($this->admin)->post("/admin/issues/{$issue->id}/close")
+            ->assertRedirect()->assertSessionHas('error');
+
+        $this->assertSame(Issue::STATUS_RESOLVED, $issue->fresh()->status);
+    }
+
+    public function test_issue_closes_once_all_actions_are_verified(): void
+    {
+        $issue = Issue::factory()->create(['status' => Issue::STATUS_RESOLVED, 'resolved_at' => now()]);
+        IssueAction::factory()->verified()->create(['issue_id' => $issue->id]);
+
+        $this->actingAs($this->admin)->post("/admin/issues/{$issue->id}/close")
+            ->assertRedirect()->assertSessionHas('success');
+
+        $this->assertSame(Issue::STATUS_CLOSED, $issue->fresh()->status);
+    }
+
+    public function test_close_issue_service_throws_on_unverified_actions(): void
+    {
+        $issue = Issue::factory()->create(['status' => Issue::STATUS_RESOLVED, 'resolved_at' => now()]);
+        IssueAction::factory()->create(['issue_id' => $issue->id, 'status' => 'done']);
+
+        $this->expectException(\DomainException::class);
+        app(IssueService::class)->closeIssue($issue);
+    }
+
+    public function test_action_validation_rejects_missing_title_and_bad_type(): void
+    {
+        $issue = Issue::factory()->create();
+
+        $this->actingAs($this->admin)
+            ->postJson("/admin/issues/{$issue->id}/actions", ['type' => 'corrective'])
+            ->assertStatus(422)->assertJsonValidationErrors('title');
+
+        $this->actingAs($this->admin)
+            ->postJson("/admin/issues/{$issue->id}/actions", ['type' => 'nonsense', 'title' => 'x'])
+            ->assertStatus(422)->assertJsonValidationErrors('type');
+    }
+
+    public function test_destroying_an_action_soft_deletes_it(): void
+    {
+        $issue = Issue::factory()->create();
+        $action = IssueAction::factory()->create(['issue_id' => $issue->id]);
+
+        $this->actingAs($this->admin)->deleteJson("/admin/issues/actions/{$action->id}")->assertOk();
+        $this->assertSoftDeleted('issue_actions', ['id' => $action->id]);
+    }
+
+    public function test_soft_deleting_an_issue_cascades_to_its_actions(): void
+    {
+        $issue = Issue::factory()->create();
+        $action = IssueAction::factory()->create(['issue_id' => $issue->id]);
+
+        $issue->delete();
+
+        $this->assertSoftDeleted('issue_actions', ['id' => $action->id]);
+    }
+
+    public function test_guest_cannot_add_actions(): void
+    {
+        $issue = Issue::factory()->create();
+
+        $this->postJson("/admin/issues/{$issue->id}/actions", ['type' => 'corrective', 'title' => 'x'])
+            ->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Non-conformity workflow — Phase 1: corrective/preventive actions (CAPA) + closure gate

Part 1 of [#107](https://github.com/Mes-Open/OpenMes/issues/107). Reuses the existing **Issue** as the non-conformance/incident record (it already has statuses, `is_blocking`, and blocks work orders) and adds CAPA on top.

### What's new
- **`IssueAction`** (corrective | preventive) attached to an issue: assignee, due date, lifecycle **Open → In progress → Done → Verified** (`IssueActionService`).
- **Closure gate**: an issue can only be **CLOSED once every action is Verified** — enforced in `IssueService::closeIssue` (`DomainException` → 422), so it holds for the admin/supervisor UI **and** the API `close` endpoint.
- **UI**: an "Actions" panel on the Issues page (Admin → Issues / Supervisor → Issues) to add/start/complete/verify/delete actions.
- New `issue_actions` table — soft-delete-with-audit pattern, registered in `SoftDeleteRegistry`, cascaded from `Issue::softDeleteCascades()`, synced via `ShapeRegistry`. Form Requests for validation.

### Tests
`IssueActionTest`: CRUD, lifecycle transitions, **closure gate** (can't close with unverified actions → can after verify), validation 422, soft-delete cascade, guest authz. Full suite green: **1370 tests, 4178 assertions**.

### Next (Phase 2, separate PR)
General material **Hold/Release** on lots + **batch-release quality gate** (blocked while open blocking NCRs / quarantined lots exist).
