### PR TITLE
feat: material hold/release + batch-release gate (#107 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Non-conformity workflow — material hold/release + batch-release quality gate** *(part 2 of [#107](https://github.com/Mes-Open/OpenMes/issues/107))*: quality can now put **any material lot on hold** (→ quarantine, with a reason and an optional link to the triggering issue) and **release** it later, straight from Admin → Material Lots — not just via an inbound-inspection disposition. Held lots stay out of the allocation engine. A new **quality gate on batch release** refuses to release a batch whose work order is blocked by an open non-conformance, or that consumed a held (quarantined/rejected) lot. Implemented in `MaterialHoldService` + `BatchReleaseService`.
 - **Non-conformity workflow — corrective/preventive actions (CAPA) on issues** *(part 1 of [#107](https://github.com/Mes-Open/OpenMes/issues/107))*: an issue (the non-conformance record) can now carry **corrective and preventive actions**, each with an assignee, due date and lifecycle **Open → In progress → Done → Verified**. The issue **can only be CLOSED once every action is Verified** (enforced server-side in `IssueService::closeIssue` for both the admin/supervisor UI and the API). Manage actions from a panel on the Issues page (Admin → Issues / Supervisor → Issues). New `issue_actions` table follows the soft-delete-with-audit pattern and cascades when its issue is deleted.
 
 ---

--- a/backend/app/Http/Controllers/Web/Admin/MaterialLotController.php
+++ b/backend/app/Http/Controllers/Web/Admin/MaterialLotController.php
@@ -3,9 +3,12 @@
 namespace App\Http\Controllers\Web\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\HoldMaterialLotRequest;
+use App\Models\Issue;
 use App\Models\Material;
 use App\Models\MaterialLot;
 use App\Models\MaterialSource;
+use App\Services\Quality\MaterialHoldService;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
@@ -180,6 +183,32 @@ class MaterialLotController extends Controller
 
         return redirect()->route('admin.material-lots.index')
             ->with('success', __('Material lot deleted.'));
+    }
+
+    /** Put a lot on quality hold (QUARANTINE), optionally against an issue. */
+    public function hold(HoldMaterialLotRequest $request, MaterialLot $materialLot, MaterialHoldService $service)
+    {
+        $issue = $request->filled('issue_id') ? Issue::find($request->integer('issue_id')) : null;
+
+        try {
+            $service->hold($materialLot, $request->validated()['reason'], $request->user(), $issue);
+        } catch (\DomainException $e) {
+            return redirect()->back()->with('error', $e->getMessage());
+        }
+
+        return redirect()->back()->with('success', __('Lot placed on hold.'));
+    }
+
+    /** Release a held lot back to RELEASED. */
+    public function release(Request $request, MaterialLot $materialLot, MaterialHoldService $service)
+    {
+        try {
+            $service->release($materialLot, $request->user());
+        } catch (\DomainException $e) {
+            return redirect()->back()->with('error', $e->getMessage());
+        }
+
+        return redirect()->back()->with('success', __('Lot released.'));
     }
 
     /**

--- a/backend/app/Http/Requests/HoldMaterialLotRequest.php
+++ b/backend/app/Http/Requests/HoldMaterialLotRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class HoldMaterialLotRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Route sits behind auth + the admin tab-access middleware.
+    }
+
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'max:255'],
+            'issue_id' => ['nullable', 'integer', 'exists:issues,id'],
+        ];
+    }
+}

--- a/backend/app/Models/MaterialLot.php
+++ b/backend/app/Models/MaterialLot.php
@@ -59,10 +59,16 @@ class MaterialLot extends Model
         'supplier_reference',
         'source_container_no',
         'inspection_id',
+        'issue_id',
         'source_batch_id',
         'created_by_id',
         'tenant_id',
         'extra_data',
+        'hold_reason',
+        'held_at',
+        'held_by_id',
+        'released_at',
+        'released_by_id',
     ];
 
     protected function casts(): array
@@ -74,7 +80,14 @@ class MaterialLot extends Model
             'quantity_received' => 'decimal:4',
             'quantity_available' => 'decimal:4',
             'extra_data' => 'array',
+            'held_at' => 'datetime',
+            'released_at' => 'datetime',
         ];
+    }
+
+    public function isOnHold(): bool
+    {
+        return $this->status === self::STATUS_QUARANTINE;
     }
 
     // ── Relations ───────────────────────────────────────────────────────────
@@ -92,6 +105,22 @@ class MaterialLot extends Model
     public function inspection(): BelongsTo
     {
         return $this->belongsTo(Inspection::class);
+    }
+
+    /** The non-conformance (issue) this lot is held against, if any. */
+    public function issue(): BelongsTo
+    {
+        return $this->belongsTo(Issue::class);
+    }
+
+    public function heldBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'held_by_id');
+    }
+
+    public function releasedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'released_by_id');
     }
 
     /**

--- a/backend/app/Services/Lot/BatchReleaseService.php
+++ b/backend/app/Services/Lot/BatchReleaseService.php
@@ -3,12 +3,32 @@
 namespace App\Services\Lot;
 
 use App\Models\Batch;
+use App\Models\BatchStepLotConsumption;
+use App\Models\MaterialLot;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 class BatchReleaseService
 {
     public function __construct(private LotService $lotService) {}
+
+    /** Did this batch consume any material lot that is currently on hold? */
+    private function hasHeldConsumedLot(Batch $batch): bool
+    {
+        $stepIds = $batch->steps()->pluck('id');
+
+        if ($stepIds->isEmpty()) {
+            return false;
+        }
+
+        $lotIds = BatchStepLotConsumption::whereIn('batch_step_id', $stepIds)
+            ->pluck('material_lot_id')
+            ->unique();
+
+        return MaterialLot::whereIn('id', $lotIds)
+            ->whereIn('status', [MaterialLot::STATUS_QUARANTINE, MaterialLot::STATUS_REJECTED])
+            ->exists();
+    }
 
     /**
      * Release a completed batch for production (semi-finished) or sale (finished goods).
@@ -26,6 +46,15 @@ class BatchReleaseService
 
         if (! in_array($releaseType, [Batch::RELEASE_FOR_PRODUCTION, Batch::RELEASE_FOR_SALE])) {
             throw new \RuntimeException("Invalid release type: {$releaseType}");
+        }
+
+        // Quality gate: don't release a batch whose work order is blocked by an
+        // open non-conformance, or that consumed a held (quarantined/rejected) lot.
+        if ($batch->workOrder?->isBlocked()) {
+            throw new \RuntimeException('Cannot release: the work order is blocked by an open non-conformance.');
+        }
+        if ($this->hasHeldConsumedLot($batch)) {
+            throw new \RuntimeException('Cannot release: a material lot consumed by this batch is on quality hold.');
         }
 
         return DB::transaction(function () use ($batch, $user, $releaseType) {

--- a/backend/app/Services/Quality/MaterialHoldService.php
+++ b/backend/app/Services/Quality/MaterialHoldService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services\Quality;
+
+use App\Models\Issue;
+use App\Models\MaterialLot;
+use App\Models\User;
+
+/**
+ * Manual quality hold/release on a material lot. Putting a lot on hold moves it
+ * to QUARANTINE (so the allocation engine won't pick it); releasing moves it
+ * back to RELEASED. A hold can be linked to the Issue (non-conformance) that
+ * triggered it. Inbound-inspection dispositions still drive lot status via
+ * DispositionService — this is the general, manual path.
+ */
+class MaterialHoldService
+{
+    public function hold(MaterialLot $lot, string $reason, User $by, ?Issue $issue = null): MaterialLot
+    {
+        if (in_array($lot->status, [MaterialLot::STATUS_CONSUMED, MaterialLot::STATUS_REJECTED], true)) {
+            throw new \DomainException("Cannot hold a {$lot->status} lot.");
+        }
+
+        $lot->update([
+            'status' => MaterialLot::STATUS_QUARANTINE,
+            'hold_reason' => $reason,
+            'held_at' => now(),
+            'held_by_id' => $by->id,
+            'issue_id' => $issue?->id ?? $lot->issue_id,
+            'released_at' => null,
+            'released_by_id' => null,
+        ]);
+
+        return $lot->fresh();
+    }
+
+    public function release(MaterialLot $lot, User $by): MaterialLot
+    {
+        if (! in_array($lot->status, [MaterialLot::STATUS_QUARANTINE, MaterialLot::STATUS_RECEIVED], true)) {
+            throw new \DomainException("Only a quarantined/received lot can be released (is {$lot->status}).");
+        }
+
+        $lot->update([
+            'status' => MaterialLot::STATUS_RELEASED,
+            'released_at' => now(),
+            'released_by_id' => $by->id,
+        ]);
+
+        return $lot->fresh();
+    }
+}

--- a/backend/app/Sync/ShapeRegistry.php
+++ b/backend/app/Sync/ShapeRegistry.php
@@ -174,7 +174,7 @@ class ShapeRegistry
         ],
         'material_lots' => [
             'table' => 'material_lots',
-            'columns' => ['id', 'lot_number', 'material_id', 'source_id', 'quantity_received', 'quantity_available', 'unit_of_measure', 'received_at', 'manufacturing_date', 'expiry_date', 'status', 'supplier_lot_no', 'supplier_reference', 'source_container_no', 'created_at', 'updated_at'],
+            'columns' => ['id', 'lot_number', 'material_id', 'source_id', 'quantity_received', 'quantity_available', 'unit_of_measure', 'received_at', 'manufacturing_date', 'expiry_date', 'status', 'supplier_lot_no', 'supplier_reference', 'source_container_no', 'issue_id', 'hold_reason', 'held_at', 'held_by_id', 'released_at', 'released_by_id', 'created_at', 'updated_at'],
         ],
         'view_templates' => [
             'table' => 'view_templates',

--- a/backend/database/migrations/2026_06_17_110000_add_hold_fields_to_material_lots_table.php
+++ b/backend/database/migrations/2026_06_17_110000_add_hold_fields_to_material_lots_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Manual quality hold/release on material lots. Until now a lot only reached
+ * QUARANTINE via an inbound-inspection disposition; these fields let quality
+ * put any lot on hold (and later release it), optionally linked to the Issue
+ * (non-conformance) that triggered it.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('material_lots', function (Blueprint $table) {
+            $table->foreignId('issue_id')->nullable()->after('inspection_id')->constrained()->nullOnDelete();
+            $table->string('hold_reason', 255)->nullable()->after('status');
+            $table->timestamp('held_at')->nullable()->after('hold_reason');
+            $table->foreignId('held_by_id')->nullable()->after('held_at')->constrained('users')->nullOnDelete();
+            $table->timestamp('released_at')->nullable()->after('held_by_id');
+            $table->foreignId('released_by_id')->nullable()->after('released_at')->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('material_lots', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('issue_id');
+            $table->dropConstrainedForeignId('held_by_id');
+            $table->dropConstrainedForeignId('released_by_id');
+            $table->dropColumn(['hold_reason', 'held_at', 'released_at']);
+        });
+    }
+};

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -1,4 +1,9 @@
 {
+    "Hold": "Hold",
+    "Release": "Release",
+    "Hold reason:": "Hold reason:",
+    "Lot placed on hold.": "Lot placed on hold.",
+    "Lot released.": "Lot released.",
     "% of Total": "% of Total",
     "(default)": "(default)",
     "(leave blank to keep)": "(leave blank to keep)",

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -1,4 +1,9 @@
 {
+    "Hold": "Wstrzymaj",
+    "Release": "Zwolnij",
+    "Hold reason:": "Powód wstrzymania:",
+    "Lot placed on hold.": "Partia wstrzymana.",
+    "Lot released.": "Partia zwolniona.",
     "% of Total": "% całości",
     "(default)": "(domyślnie)",
     "(leave blank to keep)": "(pozostaw puste, aby zachować)",

--- a/backend/lang/tr.json
+++ b/backend/lang/tr.json
@@ -1,4 +1,9 @@
 {
+    "Hold": "Beklet",
+    "Release": "Serbest bırak",
+    "Hold reason:": "Bekletme nedeni:",
+    "Lot placed on hold.": "Parti beklemeye alındı.",
+    "Lot released.": "Parti serbest bırakıldı.",
     "% of Total": "Toplamın %'si",
     "(default)": "(varsayılan)",
     "(leave blank to keep)": "(korumak için boş bırakın)",

--- a/backend/resources/js/Pages/admin/material-lots/Index.jsx
+++ b/backend/resources/js/Pages/admin/material-lots/Index.jsx
@@ -24,9 +24,26 @@ export default function MaterialLotsIndex() {
         },
     ];
 
-    const actions = (r) => [
-        { label: __('Edit'), icon: 'edit', href: `/admin/material-lots/${r.id}/edit` },
-        {
+    const actions = (r) => {
+        const list = [{ label: __('Edit'), icon: 'edit', href: `/admin/material-lots/${r.id}/edit` }];
+
+        // Quality hold / release.
+        if (r.status === 'received' || r.status === 'released') {
+            list.push({
+                label: __('Hold'),
+                onClick: () => {
+                    const reason = prompt(__('Hold reason:'));
+                    if (reason) router.post(`/admin/material-lots/${r.id}/hold`, { reason }, { preserveScroll: true });
+                },
+            });
+        } else if (r.status === 'quarantine') {
+            list.push({
+                label: __('Release'),
+                onClick: () => router.post(`/admin/material-lots/${r.id}/release`, {}, { preserveScroll: true }),
+            });
+        }
+
+        list.push({
             label: __('Delete'),
             icon: 'delete',
             variant: 'danger',
@@ -35,8 +52,9 @@ export default function MaterialLotsIndex() {
                     router.delete(`/admin/material-lots/${r.id}`, { preserveScroll: true });
                 }
             },
-        },
-    ];
+        });
+        return list;
+    };
 
     return (
         <>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -465,6 +465,8 @@ Route::middleware('auth')->group(function () {
 
         // ── ISA-95: Material Lots (physical lots) ───────────────────────────
         Route::resource('material-lots', AdminMaterialLotController::class);
+        Route::post('/material-lots/{materialLot}/hold', [AdminMaterialLotController::class, 'hold'])->name('material-lots.hold');
+        Route::post('/material-lots/{materialLot}/release', [AdminMaterialLotController::class, 'release'])->name('material-lots.release');
 
         // ── Material Traceability / Genealogy (React/Inertia — ported from develop Blade) ──
         Route::get('/traceability', [\App\Http\Controllers\Web\Admin\TraceabilityController::class, 'index'])->name('traceability.index');

--- a/backend/tests/Feature/Web/MaterialHoldTest.php
+++ b/backend/tests/Feature/Web/MaterialHoldTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Batch;
+use App\Models\BatchStepLotConsumption;
+use App\Models\Issue;
+use App\Models\IssueType;
+use App\Models\MaterialLot;
+use App\Models\User;
+use App\Models\WorkOrder;
+use App\Services\Lot\BatchReleaseService;
+use App\Services\Quality\MaterialHoldService;
+use App\Services\WorkOrder\WorkOrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Manual quality hold/release on material lots + the batch-release quality gate
+ * (no release while the work order is blocked or a consumed lot is on hold).
+ */
+class MaterialHoldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    public function test_admin_can_hold_and_release_a_lot(): void
+    {
+        $lot = MaterialLot::factory()->create(['status' => MaterialLot::STATUS_RELEASED]);
+
+        $this->actingAs($this->admin)
+            ->post("/admin/material-lots/{$lot->id}/hold", ['reason' => 'Suspected contamination'])
+            ->assertRedirect()->assertSessionHas('success');
+
+        $lot->refresh();
+        $this->assertSame(MaterialLot::STATUS_QUARANTINE, $lot->status);
+        $this->assertSame('Suspected contamination', $lot->hold_reason);
+        $this->assertSame($this->admin->id, $lot->held_by_id);
+
+        $this->actingAs($this->admin)
+            ->post("/admin/material-lots/{$lot->id}/release")
+            ->assertRedirect()->assertSessionHas('success');
+
+        $this->assertSame(MaterialLot::STATUS_RELEASED, $lot->fresh()->status);
+        $this->assertSame($this->admin->id, $lot->fresh()->released_by_id);
+    }
+
+    public function test_hold_requires_a_reason(): void
+    {
+        $lot = MaterialLot::factory()->create(['status' => MaterialLot::STATUS_RELEASED]);
+
+        $this->actingAs($this->admin)
+            ->post("/admin/material-lots/{$lot->id}/hold", [])
+            ->assertSessionHasErrors('reason');
+    }
+
+    public function test_holding_a_consumed_lot_is_rejected(): void
+    {
+        $lot = MaterialLot::factory()->create(['status' => MaterialLot::STATUS_CONSUMED]);
+
+        $this->expectException(\DomainException::class);
+        app(MaterialHoldService::class)->hold($lot, 'too late', $this->admin);
+    }
+
+    public function test_batch_release_blocked_while_work_order_has_an_open_blocking_issue(): void
+    {
+        $batch = $this->doneBatch();
+        $type = IssueType::factory()->create(['is_blocking' => true]);
+        Issue::factory()->create([
+            'work_order_id' => $batch->work_order_id,
+            'issue_type_id' => $type->id,
+            'status' => Issue::STATUS_OPEN,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        app(BatchReleaseService::class)->release($batch, $this->admin, Batch::RELEASE_FOR_PRODUCTION);
+    }
+
+    public function test_batch_release_blocked_when_a_consumed_lot_is_on_hold(): void
+    {
+        $batch = $this->doneBatch();
+        $lot = MaterialLot::factory()->create(['status' => MaterialLot::STATUS_QUARANTINE]);
+        BatchStepLotConsumption::create([
+            'batch_step_id' => $batch->steps()->first()->id,
+            'material_lot_id' => $lot->id,
+            'quantity_consumed' => 1,
+            'consumed_at' => now(),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        app(BatchReleaseService::class)->release($batch, $this->admin, Batch::RELEASE_FOR_PRODUCTION);
+    }
+
+    public function test_batch_release_succeeds_when_clear(): void
+    {
+        $batch = $this->doneBatch();
+
+        $released = app(BatchReleaseService::class)->release($batch, $this->admin, Batch::RELEASE_FOR_PRODUCTION);
+
+        $this->assertNotNull($released->released_at);
+    }
+
+    /** A DONE batch with a pre-assigned lot number (skips lot assignment on release). */
+    private function doneBatch(): Batch
+    {
+        $wo = WorkOrder::factory()->create();
+        $batch = app(WorkOrderService::class)->createBatch($wo, 10);
+        $batch->update(['status' => Batch::STATUS_DONE, 'completed_at' => now(), 'lot_number' => 'LOT-TEST-1']);
+
+        return $batch->fresh();
+    }
+}


### PR DESCRIPTION
## Non-conformity workflow — Phase 2: material hold/release + batch-release quality gate

Part 2 of [#107](https://github.com/Mes-Open/OpenMes/issues/107) (builds on the CAPA actions merged in #116).

### What's new
- **Manual hold/release on any material lot** (`MaterialHoldService`): put a lot on hold (→ quarantine) with a reason and an optional link to the triggering Issue, and release it later — straight from **Admin → Material Lots** (Hold/Release row actions). Until now a lot only reached quarantine via an inbound-inspection disposition. Held lots stay out of the allocation engine (quarantine isn't pickable).
- **Quality gate on batch release** (`BatchReleaseService`): a batch can't be released if its work order is **blocked by an open non-conformance**, or if it **consumed a held (quarantined/rejected) lot**.
- Migration adds `issue_id` + hold/release audit fields to `material_lots` (+ `ShapeRegistry` columns, model relations, `HoldMaterialLotRequest`). en/pl/tr i18n keys added.

### Tests
`MaterialHoldTest`: hold/release happy path, reason required (422), consumed-lot guard, batch-release blocked by open blocking issue, blocked by held consumed lot, and succeeds when clear. Full suite green: **1376 tests, 4193 assertions**.

Together with #116 this completes #107: block/release non-conforming material · incidents (Issue) · corrective/preventive actions · closure only when actions are done.
