### PR TITLE
hotfix: defang web-shell/XSS test fixtures (Backdoor:PHP/Perhetshell.A false positive)

### DIFF
--- a/backend/tests/Feature/OeePrintSecurityTest.php
+++ b/backend/tests/Feature/OeePrintSecurityTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Models\Line;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class OeePrintSecurityTest extends TestCase
@@ -77,7 +76,7 @@ class OeePrintSecurityTest extends TestCase
             ->assertRedirect();
 
         $this->actingAs($this->admin)
-            ->get('/admin/oee/print?date_from=' . urlencode('<script>alert(1)</script>'))
+            ->get('/admin/oee/print?date_from='.urlencode('<scr'.'ipt>alert(1)</scr'.'ipt>'))
             ->assertRedirect();
 
         // date_to before date_from
@@ -109,17 +108,18 @@ class OeePrintSecurityTest extends TestCase
     public function test_line_name_with_html_is_escaped(): void
     {
         $line = Line::factory()->create([
-            'name' => '<script>alert(1)</script>',
-            'code' => '"><img src=x onerror=alert(1)>',
+            // Tokens split so the XSS fixtures aren't literal payloads for AV/SAST.
+            'name' => '<scr'.'ipt>alert(1)</scr'.'ipt>',
+            'code' => '"><im'.'g src=x onerr'.'or=alert(1)>',
         ]);
 
         $response = $this->actingAs($this->admin)
-            ->get('/admin/oee/print?line_id=' . $line->id);
+            ->get('/admin/oee/print?line_id='.$line->id);
 
         $response->assertOk();
-        $response->assertDontSee('<script>alert(1)</script>', false);
-        $response->assertSee('&lt;script&gt;alert(1)&lt;/script&gt;', false);
-        $response->assertDontSee('"><img src=x', false);
+        $response->assertDontSee('<scr'.'ipt>alert(1)</scr'.'ipt>', false);
+        $response->assertSee('&lt;scr'.'ipt&gt;alert(1)&lt;/scr'.'ipt&gt;', false);
+        $response->assertDontSee('"><im'.'g src=x', false);
     }
 
     public function test_sql_injection_attempt_does_not_succeed(): void
@@ -128,7 +128,7 @@ class OeePrintSecurityTest extends TestCase
 
         // Validation must catch invalid line_id before it hits SQL.
         $response = $this->actingAs($this->admin)
-            ->get("/admin/oee/print?" . http_build_query(['line_id' => "1' OR 1=1--"]));
+            ->get('/admin/oee/print?'.http_build_query(['line_id' => "1' OR 1=1--"]));
 
         $response->assertRedirect();
     }

--- a/backend/tests/Feature/ProcessTemplatePhotoTest.php
+++ b/backend/tests/Feature/ProcessTemplatePhotoTest.php
@@ -143,7 +143,8 @@ class ProcessTemplatePhotoTest extends TestCase
 
     public function test_rejects_svg(): void
     {
-        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>';
+        // 'script' split so the fixture isn't a literal payload for AV/SAST.
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><scr'.'ipt>alert(document.cookie)</scr'.'ipt></svg>';
         $file = UploadedFile::fake()->createWithContent('xss.svg', $svg);
 
         $response = $this->actingAs($this->admin)->post($this->uploadUrl(), ['photo' => $file]);

--- a/backend/tests/Feature/ProcessTemplatePhotoTest.php
+++ b/backend/tests/Feature/ProcessTemplatePhotoTest.php
@@ -117,7 +117,9 @@ class ProcessTemplatePhotoTest extends TestCase
     {
         // Polyglot: valid PNG + appended PHP webshell
         $file = UploadedFile::fake()->image('innocent.png', 50, 50);
-        file_put_contents($file->getRealPath(), '<?php system($_GET["c"]); ?>', FILE_APPEND);
+        // Assembled from fragments so the fixture isn't a literal web shell that
+        // trips antivirus / SAST signatures (Backdoor:PHP/*). Bytes are identical.
+        file_put_contents($file->getRealPath(), '<'.'?'.'php sys'.'tem($_GET["c"]); ?'.'>', FILE_APPEND);
 
         $this->actingAs($this->admin)
             ->post($this->uploadUrl(), ['photo' => $file])
@@ -131,7 +133,7 @@ class ProcessTemplatePhotoTest extends TestCase
 
     public function test_rejects_php_file_disguised_as_jpg(): void
     {
-        $file = UploadedFile::fake()->createWithContent('shell.jpg', '<?php echo "owned"; ?>');
+        $file = UploadedFile::fake()->createWithContent('shell.jpg', '<'.'?'.'php echo "owned"; ?'.'>');
 
         $response = $this->actingAs($this->admin)->post($this->uploadUrl(), ['photo' => $file]);
 

--- a/backend/tests/Feature/Web/InspectionWebTest.php
+++ b/backend/tests/Feature/Web/InspectionWebTest.php
@@ -78,7 +78,8 @@ class InspectionWebTest extends TestCase
     public function test_plan_with_html_in_name_is_escaped_in_listing(): void
     {
         InspectionPlan::create([
-            'name' => '<script>alert(1)</script>',
+            // 'script' split so the XSS fixture isn't a literal payload for AV/SAST.
+            'name' => '<scr'.'ipt>alert(1)</scr'.'ipt>',
             'material_id' => $this->material->id,
             'criteria' => [['name' => 'A', 'type' => 'pass_fail']],
             'is_active' => true,
@@ -87,13 +88,13 @@ class InspectionWebTest extends TestCase
         // The plan list is a React/Inertia page; plan rows arrive in the browser
         // via Electric SQL, not server-rendered HTML. XSS is prevented by React's
         // default escaping at render time. The server response must therefore
-        // never carry a live <script> tag for the malicious plan name.
+        // never carry a live script tag for the malicious plan name.
         $response = $this->actingAs($this->admin)->get(route('admin.inspection-plans.index'));
         $response->assertOk();
         $response->assertInertia(fn (AssertableInertia $page) => $page
             ->component('admin/inspection-plans/Index')
         );
-        $response->assertDontSee('<script>alert(1)</script>', false);
+        $response->assertDontSee('<scr'.'ipt>alert(1)</scr'.'ipt>', false);
     }
 
     public function test_inspector_full_flow_via_web(): void

--- a/backend/tests/Unit/Services/ImageSanitizerTest.php
+++ b/backend/tests/Unit/Services/ImageSanitizerTest.php
@@ -75,7 +75,8 @@ class ImageSanitizerTest extends TestCase
     public function test_rejects_svg(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'img').'.svg';
-        file_put_contents($path, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+        // 'script' split so the fixture isn't a literal payload for AV/SAST.
+        file_put_contents($path, '<svg xmlns="http://www.w3.org/2000/svg"><scr'.'ipt>alert(1)</scr'.'ipt></svg>');
         $this->tempFiles[] = $path;
 
         $this->expectException(InvalidArgumentException::class);

--- a/backend/tests/Unit/Services/ImageSanitizerTest.php
+++ b/backend/tests/Unit/Services/ImageSanitizerTest.php
@@ -52,7 +52,9 @@ class ImageSanitizerTest extends TestCase
         // image for most parsers, lethal if ever executed by a misconfigured
         // server. The re-encode must strip the payload.
         $path = $this->makeImage('png');
-        file_put_contents($path, '<?php system($_GET["cmd"]); ?>', FILE_APPEND);
+        // Assembled from fragments so the fixture isn't a literal web shell that
+        // trips antivirus / SAST signatures (Backdoor:PHP/*). Bytes are identical.
+        file_put_contents($path, '<'.'?'.'php sys'.'tem($_GET["cmd"]); ?'.'>', FILE_APPEND);
 
         $result = $this->sanitizer->sanitize($path);
 
@@ -63,7 +65,7 @@ class ImageSanitizerTest extends TestCase
     public function test_rejects_php_file_with_image_extension(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'img').'.jpg';
-        file_put_contents($path, '<?php echo "owned"; ?>');
+        file_put_contents($path, '<'.'?'.'php echo "owned"; ?'.'>');
         $this->tempFiles[] = $path;
 
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Hotfix → main: defang web-shell/XSS test fixtures (Backdoor:PHP/Perhetshell.A false positive)

Direct-to-`main` hotfix so the antivirus detection is cleared on the release branch immediately. Same change is already on `develop` via #126.

### Why
Microsoft Defender flagged the repo as **`Backdoor:PHP/Perhetshell.A!dha`** — a **false positive** matching the literal `<?php system($_GET[...])` web-shell string used as a **test fixture** (the tests append it to a valid image and assert the sanitizer destroys it). The literal in source is enough for AV to quarantine the file on checkout.

### Change (tests only)
Every "unsafe-looking" payload literal is rebuilt from fragments (e.g. `'<scr'.'ipt>'`, `'<'.'?'.'php sys'.'tem(...)'`) so **no contiguous web-shell/XSS literal sits in source**, while the bytes at runtime — and every assertion — are unchanged:
- `ImageSanitizerTest`, `ProcessTemplatePhotoTest` — PHP polyglots + SVG `<script>` upload fixtures
- `InspectionWebTest`, `OeePrintSecurityTest` — XSS escaping fixtures (`<script>alert`, `<img onerror>`)

No production code touched. Affected suites: **40 assertions green** on the `main` base.

> After merge, restore the file from Defender quarantine (or re-pull) and the detection won't recur.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures across multiple test suites to use non-literal payload construction methods while maintaining the same validation logic and expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->