### PR TITLE
hotfix: make material type an optional field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- **Material type is now optional**: a material no longer has to belong to a material type. The `materials.material_type_id` column is nullable, the create/edit form offers a "— None —" option, and the web + API validation accepts a missing type (an invalid/non-existent type is still rejected). The foreign key (restrict-on-delete) is unchanged and still applies when a type is set.
+
 ---
 
 ## [0.15.3] - 2026-06-16

--- a/backend/app/Http/Requests/Api/V1/StoreMaterialRequest.php
+++ b/backend/app/Http/Requests/Api/V1/StoreMaterialRequest.php
@@ -17,7 +17,7 @@ class StoreMaterialRequest extends FormRequest
             'code' => ['required', 'string', 'max:50', 'unique:materials,code'],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
-            'material_type_id' => ['required', 'exists:material_types,id'],
+            'material_type_id' => ['nullable', 'exists:material_types,id'],
             'unit_of_measure' => ['nullable', 'string', 'max:20'],
             'tracking_type' => ['nullable', 'string', 'in:none,batch,serial'],
             'default_scrap_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],

--- a/backend/app/Http/Requests/Web/Admin/StoreMaterialRequest.php
+++ b/backend/app/Http/Requests/Web/Admin/StoreMaterialRequest.php
@@ -39,7 +39,7 @@ class StoreMaterialRequest extends FormRequest
             'code' => ['required', 'string', 'max:50', 'unique:materials,code'],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
-            'material_type_id' => ['required', 'exists:material_types,id'],
+            'material_type_id' => ['nullable', 'exists:material_types,id'],
             'unit_of_measure' => ['nullable', 'string', 'max:20'],
             'tracking_type' => ['nullable', 'in:none,batch,serial'],
             'default_scrap_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],

--- a/backend/app/Http/Requests/Web/Admin/UpdateMaterialRequest.php
+++ b/backend/app/Http/Requests/Web/Admin/UpdateMaterialRequest.php
@@ -43,7 +43,7 @@ class UpdateMaterialRequest extends FormRequest
             'code' => ['required', 'string', 'max:50', Rule::unique('materials', 'code')->ignore($this->route('material'))],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
-            'material_type_id' => ['required', 'exists:material_types,id'],
+            'material_type_id' => ['nullable', 'exists:material_types,id'],
             'unit_of_measure' => ['nullable', 'string', 'max:20'],
             'tracking_type' => ['nullable', 'in:none,batch,serial'],
             'default_scrap_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],

--- a/backend/database/migrations/2026_06_18_120000_make_material_type_id_nullable_on_materials.php
+++ b/backend/database/migrations/2026_06_18_120000_make_material_type_id_nullable_on_materials.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -20,6 +21,16 @@ return new class extends Migration
 
     public function down(): void
     {
+        // Re-tightening to NOT NULL can't succeed while rows have no type. Fail
+        // loudly with a clear message instead of a cryptic DB constraint error —
+        // the operator must assign a type to (or remove) those rows first.
+        if (DB::table('materials')->whereNull('material_type_id')->exists()) {
+            throw new \RuntimeException(
+                'Cannot roll back: some materials have a NULL material_type_id. '
+                .'Assign a material type to them (or delete those rows) before rolling back.'
+            );
+        }
+
         Schema::table('materials', function (Blueprint $table) {
             $table->unsignedBigInteger('material_type_id')->nullable(false)->change();
         });

--- a/backend/database/migrations/2026_06_18_120000_make_material_type_id_nullable_on_materials.php
+++ b/backend/database/migrations/2026_06_18_120000_make_material_type_id_nullable_on_materials.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Material type becomes optional: a material no longer has to belong to a
+ * material type. The foreign key (restrict-on-delete) is unchanged and still
+ * applies when a type is set.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('materials', function (Blueprint $table) {
+            $table->unsignedBigInteger('material_type_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('materials', function (Blueprint $table) {
+            $table->unsignedBigInteger('material_type_id')->nullable(false)->change();
+        });
+    }
+};

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -3442,5 +3442,6 @@
     "full": "full",
     "Grant each role access to individual admin-panel tabs": "Grant each role access to individual admin-panel tabs",
     "Grant each role access to individual admin-panel tabs. The Admin role always has full access.": "Grant each role access to individual admin-panel tabs. The Admin role always has full access.",
-    "Tab access updated successfully.": "Tab access updated successfully."
+    "Tab access updated successfully.": "Tab access updated successfully.",
+    "Optional.": "Optional."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -3442,5 +3442,6 @@
     "full": "pełny",
     "Grant each role access to individual admin-panel tabs": "Przyznaj rolom dostęp do poszczególnych zakładek panelu admina",
     "Grant each role access to individual admin-panel tabs. The Admin role always has full access.": "Przyznaj rolom dostęp do poszczególnych zakładek panelu admina. Rola Admin zawsze ma pełny dostęp.",
-    "Tab access updated successfully.": "Dostęp do zakładek zaktualizowany."
+    "Tab access updated successfully.": "Dostęp do zakładek zaktualizowany.",
+    "Optional.": "Opcjonalne."
 }

--- a/backend/lang/tr.json
+++ b/backend/lang/tr.json
@@ -1499,5 +1499,6 @@
     "full": "tam",
     "Grant each role access to individual admin-panel tabs": "Her role yönetici paneli sekmelerine erişim verin",
     "Grant each role access to individual admin-panel tabs. The Admin role always has full access.": "Her role yönetici paneli sekmelerine erişim verin. Admin rolü her zaman tam erişime sahiptir.",
-    "Tab access updated successfully.": "Sekme erişimi güncellendi."
+    "Tab access updated successfully.": "Sekme erişimi güncellendi.",
+    "Optional.": "İsteğe bağlı."
 }

--- a/backend/resources/js/Pages/admin/materials/fields.js
+++ b/backend/resources/js/Pages/admin/materials/fields.js
@@ -14,9 +14,9 @@ export function materialFields(materialTypes) {
             name: 'material_type_id',
             label: __('Material Type'),
             type: 'select',
-            required: true,
+            help: __('Optional.'),
             options: [
-                { value: '', label: __('— Select type —') },
+                { value: '', label: __('— None —') },
                 ...materialTypes.map((t) => ({ value: String(t.id), label: t.name })),
             ],
         },

--- a/backend/tests/Feature/Web/Admin/MaterialTypeOptionalTest.php
+++ b/backend/tests/Feature/Web/Admin/MaterialTypeOptionalTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Web\Admin;
+
+use App\Models\Material;
+use App\Models\MaterialType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Material type is an optional field: a material can be created/updated without
+ * one, but an invalid (non-existent) type is still rejected.
+ */
+class MaterialTypeOptionalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    public function test_material_can_be_created_without_a_material_type(): void
+    {
+        $this->actingAs($this->admin)
+            ->post('/admin/materials', [
+                'code' => 'NO-TYPE-1',
+                'name' => 'Untyped material',
+                'unit_of_measure' => 'pcs',
+            ])
+            ->assertRedirect(route('admin.materials.index'));
+
+        $this->assertDatabaseHas('materials', [
+            'code' => 'NO-TYPE-1',
+            'material_type_id' => null,
+        ]);
+    }
+
+    public function test_material_can_still_be_created_with_a_material_type(): void
+    {
+        $type = MaterialType::create(['code' => 'RAW', 'name' => 'Raw']);
+
+        $this->actingAs($this->admin)
+            ->post('/admin/materials', [
+                'code' => 'TYPED-1',
+                'name' => 'Typed material',
+                'material_type_id' => $type->id,
+                'unit_of_measure' => 'pcs',
+            ])
+            ->assertRedirect(route('admin.materials.index'));
+
+        $this->assertDatabaseHas('materials', ['code' => 'TYPED-1', 'material_type_id' => $type->id]);
+    }
+
+    public function test_non_existent_material_type_is_rejected(): void
+    {
+        $this->actingAs($this->admin)
+            ->post('/admin/materials', [
+                'code' => 'BAD-TYPE-1',
+                'name' => 'Bad type',
+                'material_type_id' => 999999,
+            ])
+            ->assertSessionHasErrors('material_type_id');
+
+        $this->assertDatabaseMissing('materials', ['code' => 'BAD-TYPE-1']);
+    }
+
+    public function test_material_type_can_be_cleared_on_update(): void
+    {
+        $type = MaterialType::create(['code' => 'RAW', 'name' => 'Raw']);
+        $material = Material::create([
+            'code' => 'CLR-1', 'name' => 'Clearable', 'material_type_id' => $type->id, 'unit_of_measure' => 'pcs',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->put("/admin/materials/{$material->id}", [
+                'code' => 'CLR-1',
+                'name' => 'Clearable',
+                'material_type_id' => '', // ConvertEmptyStringsToNull → null
+                'unit_of_measure' => 'pcs',
+            ])
+            ->assertRedirect(route('admin.materials.index'));
+
+        $this->assertNull($material->fresh()->material_type_id);
+    }
+}

--- a/backend/tests/Feature/Web/Admin/MaterialTypeOptionalTest.php
+++ b/backend/tests/Feature/Web/Admin/MaterialTypeOptionalTest.php
@@ -18,12 +18,16 @@ class MaterialTypeOptionalTest extends TestCase
 
     private User $admin;
 
+    private User $operator;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
         $this->admin = User::factory()->create();
         $this->admin->assignRole('Admin');
+        $this->operator = User::factory()->create();
+        $this->operator->assignRole('Operator');
     }
 
     public function test_material_can_be_created_without_a_material_type(): void
@@ -44,7 +48,7 @@ class MaterialTypeOptionalTest extends TestCase
 
     public function test_material_can_still_be_created_with_a_material_type(): void
     {
-        $type = MaterialType::create(['code' => 'RAW', 'name' => 'Raw']);
+        $type = MaterialType::factory()->create();
 
         $this->actingAs($this->admin)
             ->post('/admin/materials', [
@@ -73,10 +77,7 @@ class MaterialTypeOptionalTest extends TestCase
 
     public function test_material_type_can_be_cleared_on_update(): void
     {
-        $type = MaterialType::create(['code' => 'RAW', 'name' => 'Raw']);
-        $material = Material::create([
-            'code' => 'CLR-1', 'name' => 'Clearable', 'material_type_id' => $type->id, 'unit_of_measure' => 'pcs',
-        ]);
+        $material = Material::factory()->create(['code' => 'CLR-1', 'name' => 'Clearable']);
 
         $this->actingAs($this->admin)
             ->put("/admin/materials/{$material->id}", [
@@ -88,5 +89,27 @@ class MaterialTypeOptionalTest extends TestCase
             ->assertRedirect(route('admin.materials.index'));
 
         $this->assertNull($material->fresh()->material_type_id);
+    }
+
+    public function test_guest_cannot_create_a_material(): void
+    {
+        $this->post('/admin/materials', [
+            'code' => 'GUEST-1',
+            'name' => 'Guest material',
+        ])->assertRedirect(route('login'));
+
+        $this->assertDatabaseMissing('materials', ['code' => 'GUEST-1']);
+    }
+
+    public function test_operator_cannot_create_a_material(): void
+    {
+        $this->actingAs($this->operator)
+            ->post('/admin/materials', [
+                'code' => 'OP-1',
+                'name' => 'Operator material',
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('materials', ['code' => 'OP-1']);
     }
 }


### PR DESCRIPTION
## Hotfix → main: make material type an optional field

Direct-to-`main` per request. Same change is on `develop` via #127.

A material no longer has to belong to a material type (`materials.material_type_id` was a required NOT-NULL FK).

- **Migration** `2026_06_18_120000_make_material_type_id_nullable_on_materials`: column → nullable. FK (restrict-on-delete) unchanged, still applies when a type is set.
- **Validation**: web (`Web/Admin/StoreMaterialRequest`, `UpdateMaterialRequest`) + API (`Api/V1/StoreMaterialRequest`) `required` → `nullable`; an invalid/non-existent type is still rejected (`exists`). Empty form value → `null` via `ConvertEmptyStringsToNull`.
- **Form**: Material create/edit select offers **"— None —"** and is no longer required.
- **i18n**: `Optional.` added to en/pl/tr (parity kept).

### Tests
`MaterialTypeOptionalTest` (4): create without type (→ null), create with type, non-existent type → 422, clear type on update. **12 assertions green** on the `main` base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Material type is now optional for creating or editing materials; select “— None —” to leave it unspecified.
  * Validation now permits missing/cleared material types while still rejecting invalid or non-existent IDs.
  * Database schema updated to allow `material_type_id` to be unset, with safe rollback safeguards.
* **Tests**
  * Added coverage for create/update scenarios, validation errors, and admin access/authorization behavior.
* **Documentation**
  * Changelog updated to reflect the new optional material type behavior and UI/validation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->