### PR TITLE
chore(release): v0.15.5 (German terminology fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [0.15.5] - 2026-06-21
+
+### Fixed
+- **German locale terminology**: "Work Order" now translates as **Fertigungsauftrag** (production order) instead of the generic *Arbeitsauftrag*, matching the MES domain — applied across all singular/plural/compound occurrences in `backend/lang/de.json`.
+
+---
+
 ## [0.15.4] - 2026-06-19
 
 ### Added
@@ -342,7 +349,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.15.4...develop
+[Unreleased]: https://github.com/Mes-Open/OpenMes/compare/v0.15.5...develop
+[0.15.5]: https://github.com/Mes-Open/OpenMes/compare/v0.15.4...v0.15.5
 [0.15.4]: https://github.com/Mes-Open/OpenMes/compare/v0.15.3...v0.15.4
 [0.15.3]: https://github.com/Mes-Open/OpenMes/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/Mes-Open/OpenMes/compare/v0.15.1...v0.15.2

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.15.4',
+    'current' => 'v0.15.5',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];


### PR DESCRIPTION
## Release v0.15.5

Patch release on top of v0.15.4 — picks up the German terminology fix (#132) so the corrected `de.json` ships in a tagged image.

### Included
- **Fixed — German locale terminology**: "Work Order" → **Fertigungsauftrag** (production order) instead of the generic *Arbeitsauftrag*, across all singular/plural/compound occurrences in `backend/lang/de.json` (#132, already on `main`).

### Release mechanics
- `backend/config/version.php` → `v0.15.5`
- `CHANGELOG.md`: `[0.15.5] - 2026-06-21` + compare links

After you merge this, I'll tag **v0.15.5**, push the tag (triggers the `docker-publish.yml` image build → `ghcr.io/mes-open/openmes:v0.15.5`) and create the GitHub Release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected German language localization terminology for Work Order to properly reflect the production order designation throughout the application

* **Chores**
  * Version bumped to v0.15.5 with updated changelog documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->