### PR TITLE
test(e2e): full-buildout (car/computer) + traceability Playwright specs

### DIFF
--- a/tests/e2e/car-production-buildout.spec.ts
+++ b/tests/e2e/car-production-buildout.spec.ts
@@ -2,37 +2,31 @@ import { test, expect, Page, Browser } from '@playwright/test';
 import { execSync } from 'child_process';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HUGE manual buildout: stand up a brand-new "Desktop PC" production
-// configuration from zero and run it end-to-end, exercising the freshly merged
-// features — MRP/net-requirements (#90), machine states waiting/cleaning/
-// maintenance (#87), pallet quality + ship-gate (#106) and the non-conformance
-// disposition workflow (#11). Each phase is a test.step so a failure pinpoints
-// the exact stage.
-//
-// UI drives every operator/admin-facing flow. A few structural fixtures the UI
-// doesn't expose cheaply (a workstation on the line, the BOM lines + component
-// stock, a seeded non-conformance) are created via tinker and clearly labelled
-// SETUP — everything user-facing is clicked.
+// Full manual buildout: stand up a brand-new CAR-manufacturing configuration
+// from zero and run it end-to-end — exercising MRP/net-requirements (#90),
+// machine states waiting/cleaning/maintenance (#87), pallet quality + ship-gate
+// (#106) and the non-conformance disposition workflow (#11). Themed as an EV
+// sedan assembly line. Each phase is a test.step so a failure pinpoints the
+// exact stage. UI drives every user-facing flow; a workstation, the BOM + part
+// stock, and a seeded non-conformance are created via tinker (SETUP).
 // ─────────────────────────────────────────────────────────────────────────────
 
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
 const TS = Date.now().toString().slice(-6);
 
-const LINE = `PC Assembly ${TS}`;
-const PRODUCT = `Desktop PC ${TS}`;
-const WO = `WO-PC-${TS}`;
-const TRIGGER = `PC in-production QC ${TS}`;
-const EAN = `59${TS}0000`.slice(0, 13).padEnd(13, '0');
-const OP_USER = `pcop${TS}`;
+const LINE = `Vehicle Assembly ${TS}`;
+const PRODUCT = `Sedan EV ${TS}`;
+const WO = `WO-CAR-${TS}`;
+const TRIGGER = `Car in-line QC ${TS}`;
+const EAN = `40${TS}0000`.slice(0, 13).padEnd(13, '0');
+const OP_USER = `carop${TS}`;
 const OP_PASS = 'Operator123!';
 
 test.describe.configure({ mode: 'serial' });
 test.setTimeout(300_000);
 
 function tinker(php: string): string {
-  // Escape for the shell double-quoted --execute="..." wrapper: protect PHP
-  // strings (") AND PHP variables ($) from being expanded by /bin/sh.
   const escaped = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
   return execSync(`docker exec om106-backend php artisan tinker --execute="${escaped}"`, {
     encoding: 'utf8',
@@ -58,72 +52,70 @@ async function pickDropdown(button, optionName: string | RegExp) {
   await button.page().getByRole('option', { name: optionName, exact: typeof optionName === 'string' }).click();
 }
 
-test('build a Desktop PC production configuration from zero and run it', async ({ page, browser }: { page: Page; browser: Browser }) => {
-  // Deterministic slate: silence leftover triggers/tasks from earlier runs.
+test('build an EV sedan production configuration from zero and run it', async ({ page, browser }: { page: Page; browser: Browser }) => {
+  // Deterministic slate.
   tinker("App\\\\Models\\\\QualityControlTrigger::query()->update(['is_active'=>false]); App\\\\Models\\\\QualityControlTask::where('status','due')->update(['status'=>'skipped']);");
 
   await login(page, ADMIN, PASS);
 
-  // ── 1. Production line ──────────────────────────────────────────────────
-  await test.step('create production line', async () => {
+  // ── 1. Vehicle assembly line ────────────────────────────────────────────
+  await test.step('create assembly line', async () => {
     await page.goto('/admin/lines/create');
-    await page.fill('input[name="code"]', `PCL-${TS}`);
+    await page.fill('input[name="code"]', `CAR-${TS}`);
     await page.fill('input[name="name"]', LINE);
     await createBtn(page).click();
     await page.waitForURL(/\/admin\/lines$/);
   });
-  const lineId = tinker(`echo App\\\\Models\\\\Line::where('code','PCL-${TS}')->value('id');`);
+  const lineId = tinker(`echo App\\\\Models\\\\Line::where('code','CAR-${TS}')->value('id');`);
 
-  // ── 2. Product type (the PC) ────────────────────────────────────────────
+  // ── 2. Product type (the car) ───────────────────────────────────────────
   await test.step('create product type', async () => {
     await page.goto('/admin/product-types/create');
-    await page.fill('input[name="code"]', `PC-${TS}`);
+    await page.fill('input[name="code"]', `SED-${TS}`);
     await page.fill('input[name="name"]', PRODUCT);
     await page.fill('input[name="unit_of_measure"]', 'pcs');
     await createBtn(page).click();
     await page.waitForURL(/\/admin\/product-types$/);
   });
-  const productTypeId = tinker(`echo App\\\\Models\\\\ProductType::where('code','PC-${TS}')->value('id');`);
+  const productTypeId = tinker(`echo App\\\\Models\\\\ProductType::where('code','SED-${TS}')->value('id');`);
 
   // ── 3. Process template + assembly step ─────────────────────────────────
   await test.step('create active process template with a step', async () => {
     await page.goto(`/admin/product-types/${productTypeId}/process-templates/create`);
-    await page.fill('input#name', `PC Assembly Process ${TS}`);
+    await page.fill('input#name', `Vehicle Assembly Process ${TS}`);
     await page.getByRole('button', { name: 'Create Template', exact: true }).click();
     await page.waitForURL(new RegExp(`/admin/product-types/${productTypeId}/process-templates/\\d+`));
     await page.getByRole('button', { name: 'Add Step', exact: true }).first().click();
-    await page.locator('input[placeholder*="Attach component"]').fill('Assemble & test PC');
+    await page.locator('input[placeholder*="Attach component"]').fill('Final assembly & roll test');
     await page.locator('form').getByRole('button', { name: 'Add Step', exact: true }).click();
-    await expect(page.getByText('Assemble & test PC')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Final assembly & roll test')).toBeVisible({ timeout: 15_000 });
   });
   const templateId = tinker(`echo App\\\\Models\\\\ProcessTemplate::where('product_type_id',${productTypeId})->where('is_active',true)->orderByDesc('version')->value('id');`);
 
-  // ── SETUP: a workstation on the line, the BOM (6 PC components) with low
-  //    stock, so MRP shows shortages and #87 has a workstation to drive. ────
-  await test.step('SETUP: workstation + BOM components with low stock', async () => {
+  // ── SETUP: workstation + car-part BOM with low stock (typeless materials,
+  //    which also re-proves the #129 / BOM-snapshot null-type fix). ─────────
+  await test.step('SETUP: workstation + car-part BOM with low stock', async () => {
     const php = [
-      `$ws = App\\Models\\Workstation::create(['line_id'=>${lineId},'code'=>'WS-${TS}','name'=>'PC Bench ${TS}','is_active'=>true]);`,
-      // 6 components: CPU/RAM/SSD/Mainboard/PSU/Case, low stock to force shortages.
-      `$defs = [['CPU',1,5],['RAM',2,4],['SSD',1,50],['MB',1,3],['PSU',1,40],['CASE',1,60]];`,
+      `$ws = App\\Models\\Workstation::create(['line_id'=>${lineId},'code'=>'WB-${TS}','name'=>'Assembly Bay ${TS}','is_active'=>true]);`,
+      // EV parts. WHEEL ×4/car (low stock → big shortage), BATTERY scarce too.
+      `$defs = [['BATTERY',1,2],['CHASSIS',1,3],['WHEEL',4,10],['MOTOR',1,5],['SEAT',5,200],['ECU',1,40]];`,
       `foreach ($defs as [$c,$q,$stock]) { $m = App\\Models\\Material::create(['code'=>$c.'-${TS}','name'=>$c.' ${TS}','unit_of_measure'=>'pcs','stock_quantity'=>$stock]); App\\Models\\BomItem::create(['process_template_id'=>${templateId},'material_id'=>$m->id,'quantity_per_unit'=>$q,'scrap_percentage'=>0,'consumed_at'=>'start','sort_order'=>0]); }`,
       `echo $ws->id;`,
     ].join(' ');
-    const wsId = tinker(php);
-    expect(Number(wsId)).toBeGreaterThan(0);
+    expect(Number(tinker(php))).toBeGreaterThan(0);
   });
 
-  // ── 4. Work order (planned PC build of 100) ─────────────────────────────
+  // ── 4. Work order (planned build of 50 cars) ────────────────────────────
   await test.step('create planned work order', async () => {
     await page.goto('/admin/work-orders/create');
     await page.fill('input[name="order_no"]', WO);
     await pickFormSelect(page, 0, LINE);
     await pickFormSelect(page, 1, PRODUCT);
-    await page.fill('input[name="planned_qty"]', '100');
+    await page.fill('input[name="planned_qty"]', '50');
     await createBtn(page).click();
     await page.waitForURL(/\/admin\/work-orders$/);
   });
-  // Make the WO due within the MRP window (next 30 days).
-  tinker(`App\\\\Models\\\\WorkOrder::where('order_no','WO-PC-${TS}')->update(['due_date'=>now()->addDays(5)]);`);
+  tinker(`App\\\\Models\\\\WorkOrder::where('order_no','WO-CAR-${TS}')->update(['due_date'=>now()->addDays(7)]);`);
 
   // ── 5. EAN + QC trigger ─────────────────────────────────────────────────
   await test.step('register EAN', async () => {
@@ -133,27 +125,27 @@ test('build a Desktop PC production configuration from zero and run it', async (
     await page.getByRole('button', { name: /Dodaj EAN/ }).click();
     await expect(page.getByText(EAN)).toBeVisible({ timeout: 15_000 });
   });
-  await test.step('create in-production QC trigger', async () => {
+  await test.step('create in-line QC trigger', async () => {
     await page.goto('/admin/quality-control-triggers/create');
     await page.fill('input[name="name"]', TRIGGER);
     await createBtn(page).click();
     await page.waitForURL(/\/admin\/quality-control-triggers$/);
   });
 
-  // ── 6. MRP: the net-requirements report shows the PC component shortages ─
-  await test.step('MRP net requirements shows component shortages', async () => {
+  // ── 6. MRP: net-requirements shows the part shortages ───────────────────
+  await test.step('MRP net requirements shows part shortages', async () => {
     await page.goto('/admin/net-requirements');
     await expect(page.getByRole('heading', { name: 'Net requirements', exact: true })).toBeVisible({ timeout: 15_000 });
-    // RAM: 2/unit × 100 = 200 required, stock 4 → short. MB: 1×100=100, stock 3 → short.
-    const ramRow = page.locator('tr', { hasText: `RAM-${TS}` }).first();
-    await expect(ramRow).toBeVisible({ timeout: 15_000 });
-    await expect(ramRow).toContainText(WO); // driving work order
+    // WHEEL: 4/car × 50 = 200 required, stock 10 → short by 190, driven by the WO.
+    const wheelRow = page.locator('tr', { hasText: `WHEEL-${TS}` }).first();
+    await expect(wheelRow).toBeVisible({ timeout: 15_000 });
+    await expect(wheelRow).toContainText(WO);
   });
 
   // ── 7. Operator account + line assignment ───────────────────────────────
   await test.step('create operator + assign to line', async () => {
     await page.goto('/admin/users/create');
-    await page.locator('input[type="text"]').nth(0).fill(`PC Operator ${TS}`);
+    await page.locator('input[type="text"]').nth(0).fill(`Car Operator ${TS}`);
     await page.locator('input[type="text"]').nth(1).fill(OP_USER);
     await page.locator('input[type="email"]').fill(`${OP_USER}@example.test`);
     await page.locator('input[type="password"]').nth(0).fill(OP_PASS);
@@ -167,20 +159,19 @@ test('build a Desktop PC production configuration from zero and run it', async (
     await opForm.locator('button[aria-haspopup="listbox"]').click();
     await page.getByRole('option', { name: new RegExp(OP_USER) }).click();
     await opForm.getByRole('button', { name: 'Assign', exact: true }).click();
-    await expect(page.getByText(`PC Operator ${TS}`)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(`Car Operator ${TS}`)).toBeVisible({ timeout: 15_000 });
   });
 
-  // ── 8. Operator session: machine states (#87) + run the batch ───────────
+  // ── 8. Operator: machine states (#87) + run the batch ───────────────────
   const opCtx = await browser.newContext({ ignoreHTTPSErrors: true });
   const op = await opCtx.newPage();
   await login(op, OP_USER, OP_PASS);
 
-  await test.step('operator sets machine state to maintenance then running (#87)', async () => {
+  await test.step('operator sets machine state cleaning then running (#87)', async () => {
     await op.goto(`/operator/workstation?line=${lineId}`);
-    // The machine-state panel lists the line's workstation with a <select>.
-    const select = op.locator(`select[aria-label="Set state for PC Bench ${TS}"]`);
+    const select = op.locator(`select[aria-label="Set state for Assembly Bay ${TS}"]`);
     await expect(select).toBeVisible({ timeout: 15_000 });
-    await select.selectOption('MAINTENANCE');
+    await select.selectOption('CLEANING');
     await op.waitForTimeout(800);
     await select.selectOption('RUNNING');
     await op.waitForTimeout(800);
@@ -198,9 +189,9 @@ test('build a Desktop PC production configuration from zero and run it', async (
     await expect(op.getByRole('button', { name: 'Complete', exact: true }).first()).toBeVisible({ timeout: 15_000 });
   });
 
-  // ── 9. Packaging: open pallet, scan a PC, close ─────────────────────────
+  // ── 9. Packaging: a finished car onto a pallet ──────────────────────────
   let palletNo = '';
-  await test.step('package a PC onto a pallet', async () => {
+  await test.step('package a car onto a pallet', async () => {
     await op.goto('/packaging/station');
     await pickDropdown(op.locator('button[aria-haspopup="listbox"]').first(), new RegExp(WO));
     await op.getByRole('button', { name: /Create pallet/ }).click();
@@ -230,7 +221,7 @@ test('build a Desktop PC production configuration from zero and run it', async (
     await expect(dialog).toBeHidden({ timeout: 15_000 });
   });
 
-  // ── 11. Pallet is Passed → ship it (#106 gate) ──────────────────────────
+  // ── 11. Pallet Passed → ship it (#106 gate) ─────────────────────────────
   await test.step('ship the passed pallet', async () => {
     await page.goto('/admin/pallets');
     const palletRow = page.locator('tr', { hasText: palletNo });
@@ -247,23 +238,22 @@ test('build a Desktop PC production configuration from zero and run it', async (
     await expect(page.locator('tr', { hasText: palletNo })).toContainText('Shipped');
   });
 
-  // ── 12. Non-conformance disposition (#11): set a disposition on an issue ─
+  // ── 12. Non-conformance disposition (#11) ───────────────────────────────
   await test.step('set disposition on a non-conformance (#11)', async () => {
-    // Seed a non-conformance for this work order (SETUP), then disposition it via UI.
-    tinker(`$wo=App\\\\Models\\\\WorkOrder::where('order_no','WO-PC-${TS}')->first(); $it=App\\\\Models\\\\IssueType::first() ?? App\\\\Models\\\\IssueType::create(['name'=>'Defect ${TS}','is_blocking'=>false]); App\\\\Models\\\\Issue::create(['work_order_id'=>$wo->id,'issue_type_id'=>$it->id,'title'=>'PC NCR ${TS}','status'=>'OPEN','disposition'=>'pending','reported_at'=>now()]);`);
+    tinker(`$wo=App\\\\Models\\\\WorkOrder::where('order_no','WO-CAR-${TS}')->first(); $it=App\\\\Models\\\\IssueType::first() ?? App\\\\Models\\\\IssueType::create(['name'=>'Defect ${TS}','is_blocking'=>false]); App\\\\Models\\\\Issue::create(['work_order_id'=>$wo->id,'issue_type_id'=>$it->id,'title'=>'Car NCR ${TS}','status'=>'OPEN','disposition'=>'pending','reported_at'=>now()]);`);
     await page.goto('/admin/issues');
-    const row = page.locator('tr', { hasText: `PC NCR ${TS}` }).first();
+    const row = page.locator('tr', { hasText: `Car NCR ${TS}` }).first();
     await expect(row).toBeVisible({ timeout: 30_000 });
     await row.locator('[data-action="Disposition"]').first().click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible({ timeout: 10_000 });
-    await pickDropdown(dialog.locator('button[aria-haspopup="listbox"]').first(), 'Scrap');
+    await pickDropdown(dialog.locator('button[aria-haspopup="listbox"]').first(), 'Rework');
     await page.getByRole('button', { name: 'Record disposition', exact: true }).click();
     await expect(dialog).toBeHidden({ timeout: 15_000 });
-    await expect(page.locator('tr', { hasText: `PC NCR ${TS}` }).first()).toContainText('Scrap');
+    await expect(page.locator('tr', { hasText: `Car NCR ${TS}` }).first()).toContainText('Rework');
   });
 
-  // ── 13. Verify #87: the maintenance state opened a planned downtime ──────
+  // ── 13. Verify #87: cleaning opened a planned downtime + manual state ────
   await test.step('verify machine-state downtime was recorded (#87)', async () => {
     const planned = tinker(`echo App\\\\Models\\\\ProductionDowntime::where('line_id',${lineId})->whereHas('reason',fn($q)=>$q->where('kind','planned'))->count();`);
     expect(Number(planned)).toBeGreaterThan(0);
@@ -271,6 +261,6 @@ test('build a Desktop PC production configuration from zero and run it', async (
     expect(Number(manual)).toBeGreaterThan(0);
   });
 
-  await page.screenshot({ path: 'test-results/computer-production-buildout.png', fullPage: true });
+  await page.screenshot({ path: 'test-results/car-production-buildout.png', fullPage: true });
   await opCtx.close();
 });

--- a/tests/e2e/traceability-recall.spec.ts
+++ b/tests/e2e/traceability-recall.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, Page } from '@playwright/test';
+import { execSync } from 'child_process';
+
+// Focused manual test for the newest change set (#135 traceability suite):
+// the Admin → Traceability console resolving a CUSTOMER ORDER number and a
+// PALLET number into their genealogy, plus the customer_order_no / pallet→batch
+// links. Seeds a minimal WO → batch → pallet(linked) via tinker, then drives
+// the console through the UI.
+const ADMIN = process.env.ADMIN_USERNAME || 'admin';
+const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const TS = Date.now().toString().slice(-6);
+
+const CUST = `CUST-PO-${TS}`;
+const WO = `WO-TRACE-${TS}`;
+
+function tinker(php: string): string {
+  const escaped = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
+  return execSync(`docker exec om106-backend php artisan tinker --execute="${escaped}"`, {
+    encoding: 'utf8',
+  }).trim().split('\n').pop()!.trim();
+}
+
+async function login(page: Page) {
+  await page.goto('/login');
+  await page.fill('input[name="username"]', ADMIN);
+  await page.fill('input[name="password"]', PASS);
+  await Promise.all([page.waitForURL((u) => !u.pathname.startsWith('/login')), page.click('button[type="submit"]')]);
+  await page.setViewportSize({ width: 1500, height: 1100 });
+}
+
+async function search(page: Page, term: string) {
+  await page.goto('/admin/traceability');
+  await page.locator('form input[placeholder*="Pallet no"]').fill(term);
+  await page.locator('form').getByRole('button', { name: 'Trace', exact: true }).click();
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe.configure({ mode: 'serial' });
+
+let palletNo = '';
+
+test.beforeAll(() => {
+  // Minimal genealogy: line, product, WO with a customer order number, one
+  // batch, one pallet linked to that batch.
+  const php = [
+    `$line = App\\Models\\Line::create(['code'=>'TRL-${TS}','name'=>'Trace Line ${TS}','is_active'=>true]);`,
+    `$pt = App\\Models\\ProductType::create(['code'=>'TRP-${TS}','name'=>'Trace Product ${TS}','unit_of_measure'=>'pcs','is_active'=>true]);`,
+    `$wo = App\\Models\\WorkOrder::create(['order_no'=>'${WO}','customer_order_no'=>'${CUST}','product_type_id'=>$pt->id,'line_id'=>$line->id,'planned_qty'=>10,'status'=>'IN_PROGRESS','due_date'=>now()->addDays(3)]);`,
+    `$b = App\\Models\\Batch::create(['work_order_id'=>$wo->id,'batch_number'=>1,'target_qty'=>10,'status'=>'IN_PROGRESS','started_at'=>now()]);`,
+    `$p = App\\Models\\Pallet::create(['work_order_id'=>$wo->id,'batch_id'=>$b->id,'status'=>'closed','qty'=>10]);`,
+    `echo $p->pallet_no;`,
+  ].join(' ');
+  palletNo = tinker(php);
+});
+
+test('traceability console resolves a customer order number', async ({ page }) => {
+  await login(page);
+  await search(page, CUST);
+
+  // CustomerOrderResult shows the customer order number heading + the matching WO.
+  await expect(page.getByRole('heading', { name: CUST })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(WO).first()).toBeVisible({ timeout: 15_000 });
+});
+
+test('traceability console resolves a pallet number into its chain', async ({ page }) => {
+  await login(page);
+  expect(palletNo).toMatch(/^PAL-\d{6}$/);
+  await search(page, palletNo);
+
+  // PalletResult shows the pallet number + its work order + the linked customer order.
+  await expect(page.getByRole('heading', { name: palletNo })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(WO).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(CUST).first()).toBeVisible({ timeout: 15_000 });
+
+  await page.screenshot({ path: 'test-results/traceability-pallet.png', fullPage: true });
+});


### PR DESCRIPTION
Adds the manual/E2E Playwright harnesses used to validate the integrated develop end-to-end against a live stack.

- **car-production-buildout** / **computer-production-buildout** — stand up a brand-new production configuration from zero and run the full chain: line → product → process template → BOM → work order → **MRP (#90)** → operator **machine states (#87)** → batch → packaging → **pallet quality + ship-gate (#106)** → **non-conformance disposition (#11)**. The computer spec's ship step was made robust to the pallet form's new batch picker (from the traceability suite).
- **traceability-recall** — Admin → Traceability console resolves a **customer order number** and a **pallet number** into the `pallet → batch → work order → customer order` chain (**#135**).

Run against a live stack (`E2E_BASE_URL=http://localhost:8098`) with om106 tinker seeding — not part of the CI PHP gate. Full PHP suite green (1528).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)