### PR TITLE
chore(seed): OEE demo seeder — all lines + real production + LOTs

### DIFF
--- a/backend/database/seeders/OeeAndDowntimeDemoSeeder.php
+++ b/backend/database/seeders/OeeAndDowntimeDemoSeeder.php
@@ -3,43 +3,215 @@
 namespace Database\Seeders;
 
 use App\Enums\DowntimeKind;
+use App\Models\Batch;
 use App\Models\DowntimeReason;
 use App\Models\Line;
+use App\Models\LotSequence;
 use App\Models\OeeRecord;
 use App\Models\ProductionDowntime;
+use App\Models\ProductType;
 use App\Models\User;
+use App\Models\WorkOrder;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 
 /**
- * Demo data for the OEE Command (tablet) + Downtime screens. Builds on the
- * lines created by AirFilterDemoSeeder — run that first.
+ * Demo data for the OEE dashboard + Downtime screens. Works on any line set.
  *
- *  - 7 days × 4 lines = 28 OeeRecord rows with realistic A/P/Q values that
- *    drift over the week (worse mid-week, better Fri/Sat).
- *  - 4 DowntimeReason rows (planned + unplanned) seeded once.
- *  - ~12 ProductionDowntime entries from the last 24h, one active "now".
+ *  - HISTORY_DAYS of OeeRecord rows per active line with realistic, drifting
+ *    A/P/Q (a mid-week dip) for the historical part of the window.
+ *  - REAL DONE production batches for today + yesterday on every line, because
+ *    the OEE page RECOMPUTES those two days from production on every load
+ *    (OeeController::ensureOeeCalculated). Without real batches the recompute
+ *    overwrites the seeded "today/yesterday" rows with nulls — so the dashboard
+ *    looks empty. Seeding production makes the recompute yield real OEE that
+ *    persists.
+ *  - Downtime reasons + recent/active ProductionDowntime entries.
  *
  * Run with: `php artisan db:seed --class=OeeAndDowntimeDemoSeeder`
  *
- * Idempotent: each row keyed on a stable composite so re-runs upsert in place.
+ * Idempotent: OeeRecords upsert on (line, date); production is skipped for a
+ * line that already has recent DONE batches, so re-runs don't duplicate.
  */
 class OeeAndDowntimeDemoSeeder extends Seeder
 {
+    /** How many days of OEE history to seed, ending today. */
+    private const HISTORY_DAYS = 14;
+
+    /**
+     * Days back (0 = today) that the OEE page recomputes from production on
+     * load, and therefore need REAL batches to survive.
+     */
+    private const RECOMPUTED_DAYS = [0, 1];
+
     public function run(): void
     {
-        $lines = Line::orderBy('code')->limit(4)->get();
+        // Every active line gets OEE history so the dashboard is fully populated
+        // regardless of the line set (air-filter L-0x, or any other demo data).
+        $lines = Line::where('is_active', true)->orderBy('code')->get();
         if ($lines->isEmpty()) {
-            $this->command?->warn('OeeAndDowntimeDemoSeeder: no lines found — run AirFilterDemoSeeder first.');
+            $this->command?->warn('OeeAndDowntimeDemoSeeder: no lines found — run a line seeder first.');
 
             return;
         }
 
         $reasons = $this->seedDowntimeReasons();
         $reporter = User::orderBy('id')->first();
+        $sequence = $this->ensureLotSequence();
 
         $this->seedOeeRecords($lines);
         $this->seedDowntimes($lines, $reasons, $reporter);
+
+        // Real production for the recomputed days, then compute OEE from it so
+        // today/yesterday hold real values instead of being nulled on page load.
+        $produced = $this->seedRecentProduction($lines, $reasons, $reporter);
+
+        // Give every finished batch a LOT number so reports, the work-order
+        // detail and traceability show real lots instead of blanks.
+        $lots = $this->assignLots($sequence);
+
+        $today = CarbonImmutable::now()->startOfDay();
+        foreach (self::RECOMPUTED_DAYS as $back) {
+            $date = $today->subDays($back);
+            Artisan::call('oee:calculate', ['--date' => $date->toDateString()]);
+            // Let the controller recompute on next load too (clear its day cache).
+            Cache::forget('oee_calculated_'.$date->toDateString());
+        }
+
+        $this->command?->info(sprintf(
+            'OEE demo seeded: %d lines × %d days history + production on today/yesterday; %d LOT(s) assigned.',
+            $lines->count(),
+            self::HISTORY_DAYS,
+            $lots,
+        ));
+    }
+
+    /**
+     * Seed REAL DONE batches on today + yesterday for every line, so the OEE
+     * recompute produces non-null values. Each line is given a work order if it
+     * has none. Returns the number of lines that received production.
+     */
+    private function seedRecentProduction($lines, array $reasons, ?User $reporter): int
+    {
+        $today = CarbonImmutable::now()->startOfDay();
+        $unplanned = $reasons['MACH_BREAK'] ?? $reasons['MAT_SHORTAGE'] ?? null;
+        $count = 0;
+
+        foreach ($lines as $line) {
+            $workOrder = $this->workOrderFor($line);
+            if (! $workOrder) {
+                continue;
+            }
+
+            // Idempotency: skip a line that already has DONE batches today.
+            $already = Batch::where('work_order_id', $workOrder->id)
+                ->where('status', Batch::STATUS_DONE)
+                ->whereDate('completed_at', $today->toDateString())
+                ->exists();
+            if ($already) {
+                $count++;
+
+                continue;
+            }
+
+            foreach (self::RECOMPUTED_DAYS as $back) {
+                $date = $today->subDays($back);
+
+                // 2 batches per day spread across the shift.
+                foreach ([7, 13] as $startHour) {
+                    $producedQty = random_int(60, 220);
+                    $scrap = random_int(0, (int) round($producedQty * 0.05));
+                    $started = $date->setTime($startHour, random_int(0, 59));
+                    $completed = $started->addMinutes(random_int(120, 220));
+
+                    Batch::create([
+                        'work_order_id' => $workOrder->id,
+                        'batch_number' => (Batch::where('work_order_id', $workOrder->id)->max('batch_number') ?? 0) + 1,
+                        'status' => Batch::STATUS_DONE,
+                        'target_qty' => $producedQty,
+                        'produced_qty' => $producedQty,
+                        'scrap_qty' => $scrap,
+                        'started_at' => $started,
+                        'completed_at' => $completed,
+                    ]);
+                }
+
+                // One unplanned downtime so availability isn't a flat 100%.
+                if ($unplanned) {
+                    $dtStart = $date->setTime(random_int(8, 16), random_int(0, 59));
+                    ProductionDowntime::updateOrCreate(
+                        ['line_id' => $line->id, 'downtime_reason_id' => $unplanned->id, 'started_at' => $dtStart],
+                        ['ended_at' => $dtStart->addMinutes(random_int(15, 55)), 'duration_minutes' => random_int(15, 55), 'reported_by' => $reporter?->id, 'notes' => 'Demo production-day downtime'],
+                    );
+                }
+            }
+
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /** The line's first work order, or a minimal demo one created on the fly. */
+    private function workOrderFor(Line $line): ?WorkOrder
+    {
+        $existing = WorkOrder::where('line_id', $line->id)->first();
+        if ($existing) {
+            return $existing;
+        }
+
+        $productTypeId = ProductType::value('id');
+        if (! $productTypeId) {
+            return null;
+        }
+
+        return WorkOrder::create([
+            'order_no' => 'WO-OEE-'.$line->id,
+            'line_id' => $line->id,
+            'product_type_id' => $productTypeId,
+            'planned_qty' => 1000,
+            'status' => WorkOrder::STATUS_IN_PROGRESS,
+        ]);
+    }
+
+    /** Ensure a default LOT sequence exists so finished batches can get LOTs. */
+    private function ensureLotSequence(): LotSequence
+    {
+        return LotSequence::firstOrCreate(
+            ['product_type_id' => null],
+            [
+                'name' => 'Default',
+                'prefix' => 'LOT',
+                'pad_size' => 5,
+                'year_prefix' => true,
+                'reset_period' => 'yearly',
+                'next_number' => 1,
+            ],
+        );
+    }
+
+    /**
+     * Assign a LOT number to every finished batch that still lacks one (the OEE
+     * production batches are created without lots), so reports / work-order
+     * detail / traceability render real lots. Idempotent — only fills blanks.
+     */
+    private function assignLots(LotSequence $sequence): int
+    {
+        $batches = Batch::where('status', Batch::STATUS_DONE)
+            ->whereNull('lot_number')
+            ->orderBy('completed_at')
+            ->get();
+
+        foreach ($batches as $batch) {
+            $batch->update([
+                'lot_number' => $sequence->generateNext(),
+                'lot_assigned_at' => Batch::LOT_ON_RELEASE,
+            ]);
+        }
+
+        return $batches->count();
     }
 
     /** @return array<string, DowntimeReason> */
@@ -66,36 +238,37 @@ class OeeAndDowntimeDemoSeeder extends Seeder
     }
 
     /**
-     * 7-day OEE history per line. Values stay in realistic bands (60–95%)
-     * with one bad day for narrative interest. Date+line is the unique key.
+     * OEE history per line over HISTORY_DAYS, ending today. Values stay in
+     * realistic bands with a mid-week dip for narrative interest. Date+line is
+     * the unique key, so re-runs upsert in place.
      */
     private function seedOeeRecords($lines): void
     {
-        // Per-line baseline A/P/Q so each line tells a different story.
+        // Named baselines keep the original air-filter story; any other line
+        // gets a stable, code-derived baseline so each tells its own story.
         $baselines = [
             'L-01' => ['a' => 88, 'p' => 84, 'q' => 96],
             'L-02' => ['a' => 92, 'p' => 81, 'q' => 94],
             'L-03' => ['a' => 76, 'p' => 79, 'q' => 91],
             'L-04' => ['a' => 90, 'p' => 86, 'q' => 97],
         ];
-        // Day index 0 = today, 6 = a week ago. Negative deltas = worse days.
-        $dailyShift = [0 => 0, 1 => -3, 2 => -8, 3 => -12, 4 => -2, 5 => 4, 6 => 2];
 
         $today = CarbonImmutable::now()->startOfDay();
 
         foreach ($lines as $line) {
-            $b = $baselines[$line->code] ?? ['a' => 85, 'p' => 80, 'q' => 95];
-            for ($i = 0; $i < 7; $i++) {
+            $b = $baselines[$line->code] ?? $this->baselineFor((string) $line->code);
+            for ($i = 0; $i < self::HISTORY_DAYS; $i++) {
                 $date = $today->subDays($i);
-                $shift = $dailyShift[$i] ?? 0;
+                // 0 = today; a recurring weekly dip mid-week for visual interest.
+                $shift = [0 => 0, 1 => -3, 2 => -8, 3 => -12, 4 => -2, 5 => 4, 6 => 2][$i % 7] ?? 0;
                 $a = max(40, min(99, $b['a'] + $shift + random_int(-2, 2)));
                 $p = max(40, min(99, $b['p'] + $shift + random_int(-3, 3)));
                 $q = max(70, min(100, $b['q'] + intdiv($shift, 2) + random_int(-1, 1)));
                 $oee = round(($a * $p * $q) / 10000, 1);
 
-                // Planned minutes = a 16h day (two shifts) for L-01..03,
-                // 8h for L-04. Operating minutes derive from availability.
-                $planned = in_array($line->code, ['L-04'], true) ? 480 : 960;
+                // Planned minutes: a 16h (two-shift) day for most lines, 8h for
+                // the named single-shift L-04. Operating derives from availability.
+                $planned = $line->code === 'L-04' ? 480 : 960;
                 $operating = (int) round($planned * ($a / 100));
                 $downtime = $planned - $operating;
                 $totalProduced = (int) round(($operating / 60) * ($p / 100) * 18);
@@ -123,12 +296,35 @@ class OeeAndDowntimeDemoSeeder extends Seeder
     }
 
     /**
+     * A stable, code-derived A/P/Q baseline for lines without a named one, so
+     * every line gets believable but distinct OEE (and re-runs are identical).
+     *
+     * @return array{a: int, p: int, q: int}
+     */
+    private function baselineFor(string $code): array
+    {
+        $h = crc32($code);
+
+        return [
+            'a' => 72 + ($h % 23),                 // 72–94
+            'p' => 70 + (intdiv($h, 23) % 25),     // 70–94
+            'q' => 90 + (intdiv($h, 575) % 9),     // 90–98
+        ];
+    }
+
+    /**
      * Recent + active downtimes. The active one is open (ended_at = null) and
      * scoped to L-03 — mirrors the "Line 3 down 12 min" card from the design.
      */
     private function seedDowntimes($lines, array $reasons, ?User $reporter): void
     {
-        $byCode = $lines->keyBy('code');
+        // Map the four narrative slots onto the actual lines by position, so the
+        // demo works for any line set (cycling if there are fewer than four).
+        $ordered = $lines->values();
+        $slots = [];
+        foreach (['L-01', 'L-02', 'L-03', 'L-04'] as $i => $slot) {
+            $slots[$slot] = $ordered->get($i % max(1, $ordered->count()));
+        }
 
         // Anchor every offset to "today at midnight" so re-runs on the same
         // day produce identical started_at values — the upsert key stays
@@ -140,7 +336,7 @@ class OeeAndDowntimeDemoSeeder extends Seeder
         // The "active now" row uses a moving started_at (now - 12m), so its
         // composite upsert key drifts between runs — we'd accumulate stale
         // open rows. Wipe any open downtime on the target line first.
-        $activeLine = $byCode->get('L-03');
+        $activeLine = $slots['L-03'];
         if ($activeLine) {
             ProductionDowntime::query()
                 ->where('line_id', $activeLine->id)
@@ -173,7 +369,7 @@ class OeeAndDowntimeDemoSeeder extends Seeder
         ];
 
         foreach ($rows as $row) {
-            $line = $byCode->get($row['line']);
+            $line = $slots[$row['line']] ?? null;
             $reason = $reasons[$row['reason']] ?? null;
             if (! $line || ! $reason) {
                 continue;


### PR DESCRIPTION
Improves the **demo-only** OEE seeder so the OEE dashboard, downtime screens and LOT reporting are fully populated on any demo dataset (not just the 4 air-filter lines).

## What changed
- **All active lines** get 14 days of OEE history with a deterministic, per-line A/P/Q baseline + a mid-week dip (was: first 4 lines only).
- **Real DONE production batches** seeded for today + yesterday (a work order is created per line if missing). The OEE page recomputes those two days from production on every load (`OeeController::ensureOeeCalculated`) — without real batches it overwrites the seeded rows with nulls and the dashboard looks empty. Seeding production makes the recompute yield real, persistent OEE.
- **LOT numbers** assigned to every finished batch (ensuring a default `LotSequence`) so reports / work-order detail / traceability show real lots instead of blanks.
- Downtimes generalized to the actual lines (was hard-coded `L-01..L-04`).

## Safety
- **Idempotent**: OeeRecords upsert on (line, date); production is skipped for a line that already has recent DONE batches, so re-runs don't duplicate.
- **Demo-only** seeder (run via `DemoDataSeeder` / `db:seed --class=OeeAndDowntimeDemoSeeder`) — not in the test path, no product behaviour changes.

## Verified
Runs idempotently on a seeded stack: 36 lines × 14 days history + production on today/yesterday + 144 LOTs. Pint clean; full suite green via pre-commit (1566).