### PR TITLE
style(backup): restyle Backup/Reset UI to the om-* design system

### DIFF
--- a/backend/resources/js/Pages/settings/System.jsx
+++ b/backend/resources/js/Pages/settings/System.jsx
@@ -859,203 +859,122 @@ export default function System() {
                         </form>
                     </div>
 
-                    {/* Backups & Recovery */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-                        <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-1">{__('Backup & Recovery')}</h2>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                    {/* Backup & Recovery */}
+                    <div>
+                        <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-om-ink mb-1">{__('Backup & Recovery')}</h2>
+                        <p className={`${HELP_CLASS} mb-4`}>
                             {__('Create and manage backups of the database and uploaded files. Full backups include all uploaded attachments, while data-only backups only contain database records.')}
                         </p>
 
-                        <div className="flex flex-wrap gap-3 mb-6">
+                        <div className="flex flex-wrap items-center gap-3 mb-5">
                             <form method="POST" action="/settings/backups/full">
                                 <input type="hidden" name="_token" value={csrf_token} />
-                                <button type="submit" className="btn-touch bg-blue-600 text-white hover:bg-blue-700 inline-flex items-center gap-2">
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                    </svg>
-                                    {__('Create Full Backup')}
-                                </button>
+                                <Button type="submit" variant="secondary">{__('Create Full Backup')}</Button>
                             </form>
-
                             <form method="POST" action="/settings/backups/data">
                                 <input type="hidden" name="_token" value={csrf_token} />
-                                <button type="submit" className="btn-touch bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 inline-flex items-center gap-2">
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                    </svg>
-                                    {__('Create Data Backup')}
-                                </button>
+                                <Button type="submit" variant="secondary">{__('Create Data Backup')}</Button>
                             </form>
                         </div>
 
-                        {/* Upload Backup & Restore */}
-                        <div className="bg-gray-50 dark:bg-gray-800/40 p-4 rounded-lg border border-gray-200 dark:border-gray-700 mb-6">
-                            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">{__('Upload Backup File')}</h3>
-                            <form onSubmit={handleUploadRestoreSubmit} className="flex flex-wrap items-center gap-3">
-                                <input
-                                    type="file"
-                                    name="backup_file"
-                                    accept=".zip"
-                                    required
-                                    className="text-sm text-gray-600 dark:text-gray-300 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-gray-100 dark:file:bg-gray-700 file:text-gray-700 dark:file:text-gray-200 hover:file:bg-gray-200 dark:hover:file:bg-gray-600"
-                                />
-                                <button type="submit" className="btn-touch bg-amber-600 text-white hover:bg-amber-700 px-4 py-2 text-sm font-medium">
-                                    {__('Restore')}
-                                </button>
-                            </form>
-                        </div>
+                        {/* Upload a backup and restore from it */}
+                        <form onSubmit={handleUploadRestoreSubmit} className="flex flex-wrap items-center gap-3 mb-5">
+                            <input
+                                type="file"
+                                name="backup_file"
+                                accept=".zip"
+                                className="text-[13px] text-om-muted file:mr-3 file:py-2 file:px-4 file:rounded-om-sm file:border-0 file:text-[13px] file:font-semibold file:bg-om-chip file:text-om-ink hover:file:bg-om-line2 file:transition-colors file:cursor-pointer"
+                            />
+                            <Button type="submit" variant="primary" disabled={isRestoring}>{__('Restore')}</Button>
+                        </form>
 
-                        {/* Backups List */}
-                        <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
-                            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-                                <thead className="bg-gray-50 dark:bg-gray-800">
-                                    <tr>
-                                        <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300">{__('Filename')}</th>
-                                        <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300">{__('Size')}</th>
-                                        <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300">{__('Created At')}</th>
-                                        <th className="px-4 py-3 text-right font-semibold text-gray-700 dark:text-gray-300">{__('Actions')}</th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900/20">
-                                    {(!backups || backups.length === 0) ? (
-                                        <tr>
-                                            <td colSpan="4" className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                                                {__('No backups found.')}
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        backups.map((backup) => (
-                                            <tr key={backup.filename} className="hover:bg-gray-50/50 dark:hover:bg-gray-800/10">
-                                                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{backup.filename}</td>
-                                                <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
-                                                    {(backup.size_bytes / (1024 * 1024)).toFixed(2)} MB
-                                                </td>
-                                                <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
-                                                    {new Date(backup.created_at).toLocaleString()}
-                                                </td>
-                                                <td className="px-4 py-3 text-right">
-                                                    <div className="flex justify-end gap-3">
-                                                        <a
-                                                            href={`/settings/backups/download/${backup.filename}`}
-                                                            className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
-                                                            title={__('Download')}
-                                                        >
-                                                            {__('Download')}
-                                                        </a>
-                                                        <form onSubmit={(e) => {
-                                                            e.preventDefault();
-                                                            if (confirm(__('Are you sure you want to restore the system from this backup? Current data will be overwritten.'))) {
-                                                                handleRestoreSubmit(e, backup.filename);
-                                                            }
-                                                        }}>
-                                                            <button
-                                                                type="submit"
-                                                                className="text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 font-medium"
-                                                            >
-                                                                {__('Restore')}
-                                                            </button>
-                                                        </form>
-                                                        <form method="POST" action={`/settings/backups/${backup.filename}`}>
-                                                            <input type="hidden" name="_token" value={csrf_token} />
-                                                            <input type="hidden" name="_method" value="DELETE" />
-                                                            <button
-                                                                type="submit"
-                                                                onClick={(e) => {
-                                                                    if (!confirm(__('Are you sure you want to delete this backup?'))) {
-                                                                        e.preventDefault();
-                                                                    }
-                                                                }}
-                                                                className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 font-medium"
-                                                            >
-                                                                {__('Delete')}
-                                                            </button>
-                                                        </form>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        ))
-                                    )}
-                                </tbody>
-                            </table>
-                        </div>
+                        {/* Existing backups */}
+                        {(!backups || backups.length === 0) ? (
+                            <p className="text-[13px] text-om-faint">{__('No backups found.')}</p>
+                        ) : (
+                            <div className="border border-om-line rounded-om divide-y divide-om-line">
+                                {backups.map((backup) => (
+                                    <div key={backup.filename} className="flex items-center justify-between gap-3 px-4 py-2.5 text-[13px]">
+                                        <div className="min-w-0">
+                                            <div className="font-mono text-om-ink truncate">{backup.filename}</div>
+                                            <div className="text-om-faint text-[11.5px]">{(backup.size_bytes / (1024 * 1024)).toFixed(2)} MB · {new Date(backup.created_at).toLocaleString()}</div>
+                                        </div>
+                                        <div className="flex items-center gap-3 shrink-0">
+                                            <a href={`/settings/backups/download/${backup.filename}`} className="text-[12.5px] font-semibold text-om-ink hover:underline">{__('Download')}</a>
+                                            <button
+                                                type="button"
+                                                onClick={(e) => confirm(__('Are you sure you want to restore the system from this backup? Current data will be overwritten.')) && handleRestoreSubmit(e, backup.filename)}
+                                                disabled={isRestoring}
+                                                className="text-[12.5px] font-semibold text-om-accent hover:underline disabled:opacity-50"
+                                            >
+                                                {__('Restore')}
+                                            </button>
+                                            <form method="POST" action={`/settings/backups/${backup.filename}`} onSubmit={(e) => !confirm(__('Are you sure you want to delete this backup?')) && e.preventDefault()}>
+                                                <input type="hidden" name="_token" value={csrf_token} />
+                                                <input type="hidden" name="_method" value="DELETE" />
+                                                <button type="submit" className="text-[12.5px] font-semibold text-om-blocked hover:underline">{__('Delete')}</button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
 
-                    {/* Reset System */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-                        <div className="card border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/20">
-                            <h2 className="text-lg font-bold text-red-800 dark:text-red-400 mb-1">{__('Reset System')}</h2>
-                            <p className="text-sm text-red-700 dark:text-red-300 mb-4">
-                                {__('Wipe all database records (production data, settings, configurations) and delete all uploaded attachments. The system will be restored to its initial state, and you will be logged out.')}
-                            </p>
-
-                            <form onSubmit={handleResetSubmit} className="space-y-4">
-                                <div className="flex flex-col gap-2">
-                                    <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
-                                        <input
-                                            type="checkbox"
-                                            checked={resetConfirm}
-                                            onChange={(e) => setResetConfirm(e.target.checked)}
-                                            className="rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
-                                        />
-                                        {__('I understand that this action is irreversible and all data will be permanently lost.')}
-                                    </label>
+                    {/* Reset System — destructive */}
+                    <div className="bg-om-blocked-bg border border-om-blocked/20 rounded-om p-6">
+                        <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-om-blocked mb-1">{__('Reset System')}</h2>
+                        <p className={`${HELP_CLASS} mb-4`}>
+                            {__('Wipe all database records (production data, settings, configurations) and delete all uploaded attachments. The system will be restored to its initial state, and you will be logged out.')}
+                        </p>
+                        <form onSubmit={handleResetSubmit} className="space-y-4">
+                            <Checkbox
+                                checked={resetConfirm}
+                                onChange={setResetConfirm}
+                                label={__('I understand that this action is irreversible and all data will be permanently lost.')}
+                            />
+                            {resetConfirm && (
+                                <div className="flex flex-wrap items-center gap-3">
+                                    <input
+                                        type="text"
+                                        name="confirm_text"
+                                        value={resetText}
+                                        onChange={(e) => setResetText(e.target.value)}
+                                        placeholder={__('Type RESET to confirm')}
+                                        className="bg-om-card border border-om-line rounded-om-sm px-3 py-2 text-[13px] text-om-ink outline-none focus:border-om-blocked"
+                                    />
+                                    <Button type="submit" variant="danger" disabled={resetText !== 'RESET' || isResetting}>{__('Reset System')}</Button>
                                 </div>
-
-                                {resetConfirm && (
-                                    <div className="flex items-center gap-3">
-                                        <input
-                                            type="text"
-                                            name="confirm_text"
-                                            value={resetText}
-                                            onChange={(e) => setResetText(e.target.value)}
-                                            placeholder={__('Type RESET to confirm')}
-                                            className="px-3 py-2 border border-red-300 dark:border-red-700 bg-white dark:bg-gray-800 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500 text-gray-900 dark:text-gray-100"
-                                            required
-                                        />
-                                        <button
-                                            type="submit"
-                                            disabled={resetText !== 'RESET'}
-                                            className="btn-touch px-4 py-2 text-sm font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                                        >
-                                            {__('Reset System')}
-                                        </button>
-                                    </div>
-                                )}
-                            </form>
-                        </div>
+                            )}
+                        </form>
                     </div>
                 </div>
             )}
 
-            {/* Countdown Overlay Modal */}
+            {/* Blocking overlay while a restore/reset runs */}
             {(isResetting || isRestoring) && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/60 backdrop-blur-sm p-4">
-                    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-8 max-w-md w-full text-center space-y-6">
-                        <div className="flex justify-center">
-                            {resetCountdown !== null || restoreCountdown !== null ? (
-                                <div className="w-20 h-20 rounded-full border-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center text-3xl font-bold text-blue-600 dark:text-blue-400 animate-pulse">
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+                    <div className="bg-om-card border border-om-line rounded-om px-8 py-6 max-w-sm w-full text-center">
+                        <div className="flex justify-center mb-4">
+                            {(resetCountdown !== null || restoreCountdown !== null) ? (
+                                <div className="w-16 h-16 rounded-full border-[3px] border-om-accent flex items-center justify-center text-2xl font-bold text-om-accent">
                                     {resetCountdown !== null ? resetCountdown : restoreCountdown}
                                 </div>
                             ) : (
-                                <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+                                <div className="w-12 h-12 border-[3px] border-om-accent border-t-transparent rounded-full animate-spin" />
                             )}
                         </div>
-
-                        <div>
-                            <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">
-                                {resetCountdown !== null || restoreCountdown !== null 
-                                    ? __('Redirecting...') 
-                                    : (isResetting ? __('Resetting the system') : __('Restoring data'))}
-                            </h3>
-                            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                                {statusMessage}
+                        <h3 className="text-[15px] font-semibold text-om-ink">
+                            {(resetCountdown !== null || restoreCountdown !== null)
+                                ? __('Redirecting...')
+                                : (isResetting ? __('Resetting the system') : __('Restoring data'))}
+                        </h3>
+                        <p className={`${HELP_CLASS} mt-1`}>{statusMessage}</p>
+                        {(resetCountdown !== null || restoreCountdown !== null) && (
+                            <p className="text-[12px] text-om-accent mt-2">
+                                {__('Redirecting to the login page in')} {resetCountdown !== null ? resetCountdown : restoreCountdown} {__('seconds...')}
                             </p>
-                            {(resetCountdown !== null || restoreCountdown !== null) && (
-                                <p className="text-xs text-blue-500 mt-2">
-                                    {__('Redirecting to the login page in')} {resetCountdown !== null ? resetCountdown : restoreCountdown} {__('seconds...')}
-                                </p>
-                            )}
-                        </div>
+                        )}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
The backup/restore/reset UI (Settings → System → Data) reached develop via #155 in **raw Tailwind** (`bg-gray-*`, `dark:…`, `btn-touch`, blue/red literals), clashing with the rest of the page.

This reworks it to the **design-system tokens** (`om-*` colours, `@openmes/ui` `Button` + `Checkbox`, `HELP_CLASS`) so it matches the Sample Data / Export / Import sections directly above it:
- Backup & Recovery: secondary `Button`s for create, file input + `Button` for upload-restore, a clean `om-line` list (instead of a gray table) with Download / Restore / Delete.
- Reset System: an `om-blocked` danger card with a `Checkbox` + RESET input + `danger` `Button`.
- Progress overlay: `om-card` with an accent spinner/countdown.

**Pure visual change** — same handlers, routes and i18n strings (no new keys). Frontend builds clean; full suite green via pre-commit.