### PR TITLE
test(e2e): derive backend container from OPENMES_NAME_PREFIX (demo-safe)

### DIFF
--- a/tests/e2e/car-production-buildout.spec.ts
+++ b/tests/e2e/car-production-buildout.spec.ts
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
 const TS = Date.now().toString().slice(-6);
 
 const LINE = `Vehicle Assembly ${TS}`;
@@ -28,7 +29,7 @@ test.setTimeout(300_000);
 
 function tinker(php: string): string {
   const escaped = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
-  return execSync(`docker exec openmes-backend php artisan tinker --execute="${escaped}"`, {
+  return execSync(`docker exec ${BACKEND} php artisan tinker --execute="${escaped}"`, {
     encoding: 'utf8',
   }).trim().split('\n').pop()!.trim();
 }

--- a/tests/e2e/computer-production-buildout.spec.ts
+++ b/tests/e2e/computer-production-buildout.spec.ts
@@ -17,6 +17,7 @@ import { execSync } from 'child_process';
 
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
 const TS = Date.now().toString().slice(-6);
 
 const LINE = `PC Assembly ${TS}`;
@@ -34,7 +35,7 @@ function tinker(php: string): string {
   // Escape for the shell double-quoted --execute="..." wrapper: protect PHP
   // strings (") AND PHP variables ($) from being expanded by /bin/sh.
   const escaped = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
-  return execSync(`docker exec openmes-backend php artisan tinker --execute="${escaped}"`, {
+  return execSync(`docker exec ${BACKEND} php artisan tinker --execute="${escaped}"`, {
     encoding: 'utf8',
   }).trim().split('\n').pop()!.trim();
 }

--- a/tests/e2e/full-production-run.spec.ts
+++ b/tests/e2e/full-production-run.spec.ts
@@ -20,6 +20,7 @@ import { execSync } from 'child_process';
 // admin account alone cannot drive it; a dedicated operator is required.
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
 const TS = Date.now().toString().slice(-6);
 
 const LINE = `Run Line ${TS}`;
@@ -37,7 +38,7 @@ test.setTimeout(240_000);
 // still goes through the forms). Looks it up in the running om106 database.
 function dbValue(sql: string): string {
   const php = `echo DB::selectOne("${sql}")->v;`.replace(/"/g, '\\"');
-  return execSync(`docker exec openmes-backend php artisan tinker --execute="${php}"`, { encoding: 'utf8' })
+  return execSync(`docker exec ${BACKEND} php artisan tinker --execute="${php}"`, { encoding: 'utf8' })
     .trim()
     .split('\n')
     .pop()!
@@ -45,7 +46,7 @@ function dbValue(sql: string): string {
 }
 
 function dbExec(php: string): void {
-  execSync(`docker exec openmes-backend php artisan tinker --execute="${php.replace(/"/g, '\\"')}"`, {
+  execSync(`docker exec ${BACKEND} php artisan tinker --execute="${php.replace(/"/g, '\\"')}"`, {
     encoding: 'utf8',
   });
 }

--- a/tests/e2e/module-selection.spec.ts
+++ b/tests/e2e/module-selection.spec.ts
@@ -7,10 +7,11 @@ import { execSync } from 'child_process';
 // shares the same ModuleRegistry enforcement.
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
 
 function tinker(php: string): string {
   const e = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
-  return execSync(`docker exec openmes-backend php artisan tinker --execute="${e}"`, { encoding: 'utf8' })
+  return execSync(`docker exec ${BACKEND} php artisan tinker --execute="${e}"`, { encoding: 'utf8' })
     .trim().split('\n').pop()!.trim();
 }
 

--- a/tests/e2e/traceability-recall.spec.ts
+++ b/tests/e2e/traceability-recall.spec.ts
@@ -8,6 +8,7 @@ import { execSync } from 'child_process';
 // the console through the UI.
 const ADMIN = process.env.ADMIN_USERNAME || 'admin';
 const PASS = process.env.ADMIN_PASSWORD || 'Admin1234!';
+const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
 const TS = Date.now().toString().slice(-6);
 
 const CUST = `CUST-PO-${TS}`;
@@ -15,7 +16,7 @@ const WO = `WO-TRACE-${TS}`;
 
 function tinker(php: string): string {
   const escaped = php.replace(/"/g, '\\"').replace(/\$/g, '\\$');
-  return execSync(`docker exec openmes-backend php artisan tinker --execute="${escaped}"`, {
+  return execSync(`docker exec ${BACKEND} php artisan tinker --execute="${escaped}"`, {
     encoding: 'utf8',
   }).trim().split('\n').pop()!.trim();
 }


### PR DESCRIPTION
#157 changed the e2e tinker helper's container from `om106-backend` → `openmes-backend`, but that's still a hardcoded name that breaks anywhere the prefix differs — **including a default/demo build**, whose canonical container is `openmmes-backend` (docker-compose uses `${OPENMES_NAME_PREFIX:-openmmes}`).

These five specs now derive the name the way the other e2e specs (`material-hold-release`, `updater-banner`) already do:

```js
const BACKEND = `${process.env.OPENMES_NAME_PREFIX || 'openmmes'}-backend`;
… `docker exec ${BACKEND} php artisan tinker …`
```

So a plain `docker compose up` (→ `openmmes-backend`) works out of the box for the demo/default build, and any custom stack just sets `OPENMES_NAME_PREFIX` (e.g. `om106`). No hardcoded names left. Pure test-helper change; pre-commit suite green.