### PR TITLE
fix(i18n): import missing __ helper on 3 pages (blank-page crash)

### DIFF
--- a/backend/resources/js/Pages/admin/schedule/Planner.jsx
+++ b/backend/resources/js/Pages/admin/schedule/Planner.jsx
@@ -3,7 +3,7 @@ import { Head, Link, router, usePage } from '@inertiajs/react';
 import { DatePicker, Dropdown } from '@openmes/ui';
 import AppLayout from '../../../layouts/AppLayout';
 import LiveRefresh from '../../../components/LiveRefresh';
-import { formatDate, formatNumber } from '../../../lib/i18n';
+import { __, formatDate, formatNumber } from '../../../lib/i18n';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 

--- a/backend/resources/js/Pages/packaging/label-templates/Form.jsx
+++ b/backend/resources/js/Pages/packaging/label-templates/Form.jsx
@@ -1,5 +1,6 @@
 import { Link } from '@inertiajs/react';
 import { Button, Checkbox, Dropdown } from '@openmes/ui';
+import { __ } from '../../../lib/i18n';
 
 /**
  * Label template form. Beyond the scalar selects (type/size/barcode), it has a

--- a/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
+++ b/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { Button, StatusPill } from '@openmes/ui';
 import AppLayout from '../../../layouts/AppLayout';
-import { formatDate, formatNumber } from '../../../lib/i18n';
+import { __, formatDate, formatNumber } from '../../../lib/i18n';
 
 const TERMINAL = ['DONE', 'REJECTED', 'CANCELLED'];
 


### PR DESCRIPTION
## Bug
`/admin/schedule` (and two other pages) rendered a **blank white page**. Console: `ReferenceError: __ is not defined`.

The Vietnamese-localization work wrapped UI strings in `__()` but left three page components **without importing `__`**. Vite doesn't catch a runtime `ReferenceError`, so the build passed and **production was affected too** — not just the dev stack.

## Fix
Added `__` to the i18n import on:
- `Pages/admin/schedule/Planner.jsx` (`/admin/schedule` — 10 calls)
- `Pages/supervisor/work-orders/Show.jsx` (22 calls)
- `Pages/packaging/label-templates/Form.jsx` (7 calls)

A repo-wide sweep of `resources/js` confirms these were the **only** three `.jsx` files using `__()` without importing it (`app.jsx`'s match is a comment + `window.__TENANT__`, not the helper).

Verified in the browser — the Production Planner now renders fully. Frontend builds clean; pre-commit suite green.