### PR TITLE
fix(ci): pass release-notes vars via env, not ${{ }} shell interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,15 @@ jobs:
 
       - name: Build release notes
         id: notes
+        env:
+          # Pass through env, NOT ${{ }} interpolation into the script body:
+          # commit messages / notes contain quotes and backticks that would
+          # otherwise break out of the shell string (e.g. `"… & serials …"`
+          # ran `serials` as a command and failed the whole release).
+          VERSION: ${{ steps.version.outputs.version }}
+          CUSTOM: ${{ github.event.inputs.notes }}
+          LOG: ${{ steps.changelog.outputs.log }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          CUSTOM="${{ github.event.inputs.notes }}"
-          LOG="${{ steps.changelog.outputs.log }}"
           BODY=""
           if [ -n "$CUSTOM" ]; then
             BODY="${CUSTOM}"$'\n\n'


### PR DESCRIPTION
The Release workflow inlined `LOG="${{ steps.changelog.outputs.log }}"` (and the dispatch `notes` input) directly into the script body, so commit messages containing double quotes broke out of the shell string — e.g. a commit titled ... "Components & serials used" ... made bash run `serials` as a command and the whole release failed with exit 127 ("serials: command not found"), so no ZIP was attached. Pass VERSION/CUSTOM/LOG through `env:` instead; bash reads the values verbatim without re-parsing quotes/backticks.

## Summary
<!-- What does this PR do? Why? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Related issue
Closes #

## Testing
<!-- How was this tested? What scenarios were covered? -->
- [ ] Tested manually in browser
- [ ] `php artisan test` passes
- [ ] Tested as Operator / Supervisor / Admin role (if UI change)

## Checklist
- [ ] No `.env` secrets committed
- [ ] Migration added if schema changed
- [ ] `$fillable` updated if new model columns added
- [ ] No raw SQL with user input (use Eloquent / Query Builder)
- [ ] CSRF protection in place for any new forms
- [ ] `composer audit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release-notes generation workflow so it handles special characters in commit messages and notes more reliably.
  * Updated how release-related values are passed into the step to make the process more stable and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->