### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-06-30
+
+### Fixed
+- **Release workflow couldn't build the distributable ZIP** *(CI)*: the GitHub release workflow inlined the commit log into a shell assignment (`LOG="${{ … }}"`), so a commit message containing double quotes broke out of the string and bash ran part of it as a command (`serials: command not found`, exit 127) — failing the release before any `openmmes-*.zip` was attached. The release-notes variables (`VERSION`, `CUSTOM`, `LOG`) now pass through `env:` instead of `${{ }}` interpolation, so commit text is read verbatim.
+
 ## [0.16.0] - 2026-06-30
 
 ### Added

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.16.0',
+    'current' => 'v0.16.1',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];


### PR DESCRIPTION
# OpenMES v0.16.1

Patch release. Bumps `config/version.php` → **v0.16.1** and finalizes the CHANGELOG.

## 🐛 Fixed
- **Release workflow couldn't build the distributable ZIP** *(CI)* — the release workflow inlined the commit log into a shell `LOG="${{ … }}"`, so a commit message with double quotes (`… "Components & serials used" …`) broke the script (`serials: command not found`, exit 127) and no `openmmes-*.zip` was attached. Release-notes vars now pass through `env:` instead of `${{ }}` interpolation. *(The fix itself already merged to `main` via #165; this release tags it + bumps the version so the tag-triggered build runs the corrected workflow.)*

No app/runtime code changes, no new migrations.

---
After you merge this manually (main is branch-protected), I'll tag `v0.16.1` — the tag-triggered Release workflow (now fixed on main) will build and attach `openmmes-v0.16.1.zip`.