### PR TITLE
[feat] Per-order machines to run supervisor view #89

### DIFF
--- a/backend/app/Http/Controllers/Web/Supervisor/WorkOrderController.php
+++ b/backend/app/Http/Controllers/Web/Supervisor/WorkOrderController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\Web\Supervisor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\Admin\StoreWorkOrderRequest;
+use App\Models\BatchStep;
 use App\Models\Line;
 use App\Models\ProductType;
 use App\Models\WorkOrder;
+use App\Models\WorkstationState;
 use App\Services\CustomFieldService;
 use App\Services\WorkOrder\WorkOrderService;
 use Illuminate\Http\Request;
@@ -14,6 +16,11 @@ use Inertia\Inertia;
 
 class WorkOrderController extends Controller
 {
+    private const ACTIVE_MACHINE_STEP_STATUSES = [
+        BatchStep::STATUS_READY,
+        BatchStep::STATUS_IN_PROGRESS,
+    ];
+
     public function index(Request $request)
     {
         $counts = WorkOrder::withCount('batches')->get(['id'])
@@ -67,7 +74,7 @@ class WorkOrderController extends Controller
 
     public function show(WorkOrder $workOrder)
     {
-        $workOrder->load(['line', 'productType', 'batches.steps', 'issues.issueType', 'issues.reportedBy']);
+        $workOrder->load(['line', 'productType', 'batches.workstation.line', 'batches.steps.workstation.line', 'issues.issueType', 'issues.reportedBy']);
 
         $batches = $workOrder->batches->map(function ($batch) {
             return [
@@ -83,6 +90,7 @@ class WorkOrderController extends Controller
                     'step_number' => $s->step_number,
                     'name' => $s->name,
                     'status' => $s->status,
+                    'workstation_id' => $s->workstation_id,
                     'duration_minutes' => $s->duration_minutes,
                 ])->values(),
             ];
@@ -113,8 +121,78 @@ class WorkOrderController extends Controller
                 'product_type_name' => $workOrder->productType?->name,
                 'batches' => $batches,
                 'issues' => $issues,
+                'machines' => $this->machinesForWorkOrder($workOrder),
             ],
         ]);
+    }
+
+    private function machinesForWorkOrder(WorkOrder $workOrder)
+    {
+        $machineRows = $workOrder->batches->flatMap(function ($batch) {
+            $rows = collect();
+
+            if ($batch->workstation_id && $batch->workstation) {
+                $rows->push([
+                    'workstation' => $batch->workstation,
+                    'step_status' => null,
+                ]);
+            }
+
+            return $rows->merge(
+                $batch->steps
+                    ->filter(fn ($step) => $step->workstation_id && $step->workstation)
+                    ->map(fn ($step) => [
+                        'workstation' => $step->workstation,
+                        'step_status' => $step->status,
+                    ])
+            );
+        });
+
+        $workstationIds = $machineRows
+            ->map(fn ($row) => $row['workstation']->id)
+            ->unique()
+            ->values();
+
+        if ($workstationIds->isEmpty()) {
+            return collect();
+        }
+
+        $currentStates = WorkstationState::query()
+            ->whereIn('workstation_id', $workstationIds)
+            ->whereNull('ended_at')
+            ->orderByDesc('started_at')
+            ->get()
+            ->unique('workstation_id')
+            ->keyBy('workstation_id');
+
+        return $machineRows
+            ->groupBy(fn ($row) => $row['workstation']->id)
+            ->map(function ($rows) use ($currentStates) {
+                $workstation = $rows->first()['workstation'];
+                $currentState = $currentStates->get($workstation->id);
+                $stepStatuses = $rows->pluck('step_status')->filter();
+
+                return [
+                    'id' => $workstation->id,
+                    'code' => $workstation->code,
+                    'name' => $workstation->name,
+                    'line_name' => $workstation->line?->name,
+                    'is_active' => (bool) $workstation->is_active,
+                    'current_state' => $currentState?->state,
+                    'state_started_at' => $currentState?->started_at?->toISOString(),
+                    'state_source' => $currentState?->source,
+                    'steps_count' => $stepStatuses->count(),
+                    'active_steps_count' => $stepStatuses
+                        ->filter(fn ($status) => in_array($status, self::ACTIVE_MACHINE_STEP_STATUSES, true))
+                        ->count(),
+                    'step_statuses' => $stepStatuses
+                        ->countBy()
+                        ->map(fn ($count, $status) => ['status' => $status, 'count' => $count])
+                        ->values(),
+                ];
+            })
+            ->sortBy('name')
+            ->values();
     }
 
     public function accept(WorkOrder $workOrder)

--- a/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
+++ b/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
@@ -46,6 +46,9 @@ const MACHINE_PILL_STATUS = {
     STOPPED: 'downtime',
     FAULT: 'blocked',
     SETUP: 'pending',
+    WAITING: 'downtime',
+    CLEANING: 'pending',
+    MAINTENANCE: 'downtime',
     UNKNOWN: 'pending',
 };
 

--- a/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
+++ b/backend/resources/js/Pages/supervisor/work-orders/Show.jsx
@@ -1,5 +1,5 @@
 // Geist White restyle: light-only v1 — om-* tokens + @openmes/ui (status transitions, modal post and batch logic untouched).
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { Button, StatusPill } from '@openmes/ui';
 import AppLayout from '../../../layouts/AppLayout';
@@ -39,6 +39,15 @@ const ISSUE_PILL_STATUS = {
 // Ghost-button classes for Inertia <Link>s (mirrors @openmes/ui Button ghost).
 const LINK_GHOST =
     'inline-flex items-center justify-center gap-2 text-[13px] font-semibold rounded-om-sm border border-om-line px-4 py-[9px] text-om-ink hover:bg-om-chip transition-colors';
+
+const MACHINE_PILL_STATUS = {
+    RUNNING: 'running',
+    IDLE: 'pending',
+    STOPPED: 'downtime',
+    FAULT: 'blocked',
+    SETUP: 'pending',
+    UNKNOWN: 'pending',
+};
 
 function fmtQty(n) {
     return formatNumber(Number(n ?? 0), { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -175,11 +184,65 @@ function DoneModal({ workOrder, onClose }) {
     );
 }
 
+function OrderMachinesPanel({ machines }) {
+    return (
+        <div className="bg-om-card border border-om-line rounded-om p-5">
+            <div className="flex justify-between items-center mb-3">
+                <h3 className="text-[14px] font-semibold text-om-ink">{__('Machines')}</h3>
+                <span className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-om-faint">{__('Live')}</span>
+            </div>
+            {machines.length === 0 ? (
+                <p className="text-sm text-om-faint text-center py-3">{__('No assigned machines.')}</p>
+            ) : (
+                <div className="space-y-3">
+                    {machines.map((machine) => {
+                        const state = machine.current_state ?? 'UNKNOWN';
+                        const pillStatus = MACHINE_PILL_STATUS[state] ?? MACHINE_PILL_STATUS.UNKNOWN;
+
+                        return (
+                            <div key={machine.id} className="rounded-om-sm bg-om-panel p-3">
+                                <div className="flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <p className="font-medium text-om-ink truncate">{machine.name}</p>
+                                        <p className="font-mono text-xs text-om-faint truncate">{machine.code}</p>
+                                    </div>
+                                    <StatusPill status={pillStatus} label={state} />
+                                </div>
+                                <div className="mt-2 flex flex-wrap gap-2 text-xs text-om-muted">
+                                    <span>{__('Steps:')} {machine.steps_count}</span>
+                                    {machine.active_steps_count > 0 && (
+                                        <span className="text-om-accent">{__('Active:')} {machine.active_steps_count}</span>
+                                    )}
+                                    {machine.line_name && <span>{machine.line_name}</span>}
+                                </div>
+                                {machine.state_started_at && (
+                                    <p className="mt-1 text-xs text-om-faint">
+                                        {__('Since')} {fmtDateTime(machine.state_started_at)}
+                                        {machine.state_source ? ` · ${__(machine.state_source)}` : ''}
+                                    </p>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}
+
 export default function SupervisorWorkOrderShow() {
     const { workOrder } = usePage().props;
     const [showDoneModal, setShowDoneModal] = useState(false);
 
     const post = (verb) => router.post(`/supervisor/work-orders/${workOrder.id}/${verb}`, {}, { preserveScroll: true });
+
+    useEffect(() => {
+        const timer = setInterval(() => {
+            router.reload({ only: ['workOrder'], preserveScroll: true, preserveState: true });
+        }, 5000);
+
+        return () => clearInterval(timer);
+    }, [workOrder.id]);
 
     const status = workOrder.status;
     const isTerminal = TERMINAL.includes(status);
@@ -383,6 +446,8 @@ export default function SupervisorWorkOrderShow() {
                                 </div>
                             </div>
                         </div>
+
+                        <OrderMachinesPanel machines={workOrder.machines ?? []} />
 
                         {/* Issues */}
                         <div className="bg-om-card border border-om-line rounded-om p-5">

--- a/backend/tests/Feature/Supervisor/WorkOrderMachinesTest.php
+++ b/backend/tests/Feature/Supervisor/WorkOrderMachinesTest.php
@@ -29,6 +29,25 @@ class WorkOrderMachinesTest extends TestCase
         $this->supervisor->assignRole('Supervisor');
     }
 
+    public function test_guest_is_redirected_from_order_machines_view(): void
+    {
+        $workOrder = WorkOrder::factory()->create();
+
+        $this->get(route('supervisor.work-orders.show', $workOrder))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_user_without_supervisor_role_cannot_open_order_machines_view(): void
+    {
+        $workOrder = WorkOrder::factory()->create();
+        $operator = User::factory()->create();
+        $operator->assignRole('Operator');
+
+        $this->actingAs($operator)
+            ->get(route('supervisor.work-orders.show', $workOrder))
+            ->assertForbidden();
+    }
+
     public function test_supervisor_sees_order_machines_with_current_statuses(): void
     {
         $line = Line::factory()->create(['name' => 'Assembly']);

--- a/backend/tests/Feature/Supervisor/WorkOrderMachinesTest.php
+++ b/backend/tests/Feature/Supervisor/WorkOrderMachinesTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature\Supervisor;
+
+use App\Models\Batch;
+use App\Models\BatchStep;
+use App\Models\Line;
+use App\Models\User;
+use App\Models\WorkOrder;
+use App\Models\Workstation;
+use App\Models\WorkstationState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WorkOrderMachinesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $supervisor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+        $this->supervisor = User::factory()->create();
+        $this->supervisor->assignRole('Supervisor');
+    }
+
+    public function test_supervisor_sees_order_machines_with_current_statuses(): void
+    {
+        $line = Line::factory()->create(['name' => 'Assembly']);
+        $workOrder = WorkOrder::factory()->create(['line_id' => $line->id]);
+        $batch = Batch::factory()->create(['work_order_id' => $workOrder->id]);
+
+        $runningStation = Workstation::factory()->create([
+            'line_id' => $line->id,
+            'code' => 'CUT-01',
+            'name' => 'Cutter 01',
+        ]);
+        $idleStation = Workstation::factory()->create([
+            'line_id' => $line->id,
+            'code' => 'PACK-01',
+            'name' => 'Packing 01',
+        ]);
+
+        BatchStep::factory()->create([
+            'batch_id' => $batch->id,
+            'step_number' => 1,
+            'workstation_id' => $runningStation->id,
+            'status' => BatchStep::STATUS_IN_PROGRESS,
+        ]);
+        BatchStep::factory()->create([
+            'batch_id' => $batch->id,
+            'step_number' => 2,
+            'workstation_id' => $runningStation->id,
+            'status' => BatchStep::STATUS_READY,
+        ]);
+        BatchStep::factory()->create([
+            'batch_id' => $batch->id,
+            'step_number' => 3,
+            'workstation_id' => $idleStation->id,
+            'status' => BatchStep::STATUS_PENDING,
+        ]);
+
+        WorkstationState::create([
+            'workstation_id' => $runningStation->id,
+            'state' => WorkstationState::RUNNING,
+            'started_at' => now()->subMinutes(12),
+            'ended_at' => null,
+            'source' => 'machine',
+        ]);
+        WorkstationState::create([
+            'workstation_id' => $idleStation->id,
+            'state' => WorkstationState::IDLE,
+            'started_at' => now()->subMinutes(5),
+            'ended_at' => null,
+            'source' => 'manual',
+        ]);
+
+        $this->actingAs($this->supervisor)
+            ->get(route('supervisor.work-orders.show', $workOrder))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('supervisor/work-orders/Show')
+                ->has('workOrder.machines', 2)
+                ->where('workOrder.machines.0.code', 'CUT-01')
+                ->where('workOrder.machines.0.current_state', WorkstationState::RUNNING)
+                ->where('workOrder.machines.0.steps_count', 2)
+                ->where('workOrder.machines.0.active_steps_count', 2)
+                ->where('workOrder.machines.1.code', 'PACK-01')
+                ->where('workOrder.machines.1.current_state', WorkstationState::IDLE)
+                ->where('workOrder.machines.1.steps_count', 1)
+                ->where('workOrder.machines.1.active_steps_count', 0)
+            );
+    }
+
+    public function test_supervisor_sees_empty_machine_list_when_order_has_no_assigned_machines(): void
+    {
+        $workOrder = WorkOrder::factory()->create();
+        $batch = Batch::factory()->create(['work_order_id' => $workOrder->id]);
+
+        BatchStep::factory()->create([
+            'batch_id' => $batch->id,
+            'step_number' => 1,
+            'workstation_id' => null,
+        ]);
+
+        $this->actingAs($this->supervisor)
+            ->get(route('supervisor.work-orders.show', $workOrder))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('supervisor/work-orders/Show')
+                ->has('workOrder.machines', 0)
+            );
+    }
+
+    public function test_supervisor_sees_machine_assigned_to_batch_even_without_step_assignment(): void
+    {
+        $line = Line::factory()->create();
+        $workOrder = WorkOrder::factory()->create(['line_id' => $line->id]);
+        $workstation = Workstation::factory()->create([
+            'line_id' => $line->id,
+            'code' => 'CELL-01',
+            'name' => 'Cell 01',
+        ]);
+
+        Batch::factory()->create([
+            'work_order_id' => $workOrder->id,
+            'workstation_id' => $workstation->id,
+        ]);
+
+        WorkstationState::create([
+            'workstation_id' => $workstation->id,
+            'state' => WorkstationState::SETUP,
+            'started_at' => now()->subMinute(),
+            'ended_at' => null,
+            'source' => 'manual',
+        ]);
+
+        $this->actingAs($this->supervisor)
+            ->get(route('supervisor.work-orders.show', $workOrder))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('supervisor/work-orders/Show')
+                ->has('workOrder.machines', 1)
+                ->where('workOrder.machines.0.code', 'CELL-01')
+                ->where('workOrder.machines.0.current_state', WorkstationState::SETUP)
+                ->where('workOrder.machines.0.steps_count', 0)
+                ->where('workOrder.machines.0.active_steps_count', 0)
+            );
+    }
+}


### PR DESCRIPTION
Adds a supervisor-facing machines panel on the work order view.

Changes:
- lists machines assigned to an order through batches and batch steps
- shows current machine state where available
- refreshes the order view periodically to reflect status changes
- covers assigned machines and no-machine orders with feature tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live **Machines** panel to supervisor work order details, showing each workstation’s current status, step counts, line info, and “since” time.
  * Automatically refreshes the work order view periodically to keep machine status up to date.

* **Bug Fixes**
  * Improved how machine status and step counters are calculated and displayed, including consistent results when workstation/step assignments are incomplete.
  * Better empty-state behavior when no machines are available.

* **Tests**
  * Added feature coverage for supervisor access and correct machines data across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->