### PR TITLE
Release v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-07-13
+
+### Fixed
+- **Maintenance schedule install/upgrade could fail on a database with duplicate generated events** *(migrations)*: the migration that adds the unique `(schedule_id, scheduled_at)` guard to `maintenance_events` de-duplicated existing rows with `pluck(DB::raw('MIN(id)'))`. That looks up a row property literally named `MIN(id)`, which only SQLite produces - PostgreSQL names the aggregate column `min`, so the lookup returned `null`, the de-dup deleted nothing, and creating the unique index then aborted with a duplicate-key error on any database that already held duplicate auto-generated maintenance events. The de-dup now selects the aggregate under an explicit `id` alias (`selectRaw('MIN(id) AS id')`), so it works the same on PostgreSQL and SQLite.
+
 ## [0.16.1] - 2026-06-30
 
 ### Fixed

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.16.1',
+    'current' => 'v0.16.2',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];


### PR DESCRIPTION
## Summary
Fix: maintenance de-dup migration works on PostgreSQL (see CHANGELOG).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Related issue

## Testing
- [x] Tested manually in browser
- [ ] `php artisan test` passes
- [ ] Tested as Operator / Supervisor / Admin role (if UI change)

## Checklist
- [x] No `.env` secrets committed
- [ ] Migration added if schema changed
- [x] `$fillable` updated if new model columns added
- [x] No raw SQL with user input (use Eloquent / Query Builder)
- [x\ CSRF protection in place for any new forms
- [x] `composer audit` clean
