### PR TITLE
fix(routes): drop dangling __e2e__ block; 404 (not 500) on non-numeric report ids

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Http\Controllers\InstallController;
-use App\Http\Controllers\TestControl\TenantController as E2eTenantController;
 use App\Http\Controllers\Web\Admin\AnomalyReasonController;
 use App\Http\Controllers\Web\Admin\AreaController;
 use App\Http\Controllers\Web\Admin\AuditLogController as AdminAuditLogController;
@@ -360,12 +359,12 @@ Route::middleware('auth')->group(function () {
         // Reports — Work Order History (read-only historical analysis)
         Route::get('/reports', [AdminReportController::class, 'index'])->name('reports');
         Route::get('/reports/export', [AdminReportController::class, 'export'])->name('reports.export');
-        Route::get('/reports/{workOrder}', [AdminReportController::class, 'show'])->name('reports.show');
+        Route::get('/reports/{workOrder}', [AdminReportController::class, 'show'])->name('reports.show')->whereNumber('workOrder');
 
         // Reports — Production Cost (materials + labor + additional, per work order)
         Route::get('/cost-reports', [ProductionCostReportController::class, 'index'])->name('cost-reports.index');
         Route::get('/cost-reports/export', [ProductionCostReportController::class, 'export'])->name('cost-reports.export');
-        Route::get('/cost-reports/{workOrder}', [ProductionCostReportController::class, 'show'])->name('cost-reports.show');
+        Route::get('/cost-reports/{workOrder}', [ProductionCostReportController::class, 'show'])->name('cost-reports.show')->whereNumber('workOrder');
 
         // Alerts
         Route::get('/alerts', [\App\Http\Controllers\Web\Admin\AlertController::class, 'index'])->name('alerts');
@@ -814,18 +813,3 @@ Route::middleware('auth')->group(function () {
         });
     });
 });
-
-/*
- * E2E test-control surface — isolated-tenant lifecycle for the Playwright suite
- * (../../e2e). Hard-gated by EnsureE2eEnabled: 404 unless config('e2e.enabled')
- * AND non-production. Called by the test runner without a session, so these are
- * CSRF-exempt (see bootstrap/app.php validateCsrfTokens except).
- */
-Route::prefix('__e2e__')
-    ->middleware(\App\Http\Middleware\EnsureE2eEnabled::class)
-    ->group(function () {
-        Route::post('/tenant', [E2eTenantController::class, 'store']);
-        Route::post('/tenant/{tenant}/reset', [E2eTenantController::class, 'reset']);
-        Route::post('/tenant/{tenant}/bump-work-order', [E2eTenantController::class, 'bumpWorkOrder']);
-        Route::delete('/tenant/{tenant}', [E2eTenantController::class, 'destroy']);
-    });


### PR DESCRIPTION
## Summary

Two fixes found while smoke-testing a fresh `develop` checkout (all CRUD/views otherwise render and work):

### 1. Dangling `__e2e__` test-control routes (breaks `route:list`)
`backend/routes/web.php` registered an `__e2e__` route group referencing **three classes that don't exist in the repo**:
- `App\Http\Controllers\TestControl\TenantController`
- `App\Http\Middleware\EnsureE2eEnabled`
- `config/e2e.php`

They leaked in via `feat: custom fields wip` (the supporting files were never committed). Consequences:
- **`php artisan route:list` crashes** with `Class "…\TestControl\TenantController" does not exist`.
- Hitting `/__e2e__/*` would **500** (missing middleware/controller) instead of the intended 404.
- Production still boots (`route:cache` only serializes route strings, and the group is guarded), so this is latent — but it's broken, dead code on `develop`.

No Playwright spec references `__e2e__`, so the group is removed (import + block). If the isolated-tenant harness is wanted, it should be reintroduced **complete** (routes + controller + middleware + config) in its own PR.

### 2. `reports.show` / `cost-reports.show` 500 on a non-numeric id
`/admin/reports/{workOrder}` took the raw param, so `/admin/reports/net-requirements` (a mistyped/guessed URL) reached the controller with a string id and **500'd** on an invalid-integer query. Both show routes are now constrained with `->whereNumber('workOrder')`, so a non-numeric id **404s** cleanly.

## Testing

- **`php artisan route:list` now works** (verified — was crashing before).
- Full backend suite green (**1896 tests**, pre-commit gate).
- No remaining references to the removed classes anywhere in `backend/`.
- The CRUD/view smoke sweep that surfaced these (91 admin pages) is otherwise all-green: everything displays, adds and persists (live-synced).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
