### PR TITLE
fix(e2e): close unterminated test.describe in material-hold-release spec

### DIFF
--- a/tests/e2e/material-hold-release.spec.ts
+++ b/tests/e2e/material-hold-release.spec.ts
@@ -116,3 +116,4 @@ test('material lot can be put on quality hold and released (#107)', async ({ pag
 
   await page.screenshot({ path: 'test-results/107-lot-released.png', fullPage: true });
 });
+});


### PR DESCRIPTION
The Playwright spec `tests/e2e/material-hold-release.spec.ts` was missing the final `});` that closes its `test.describe(...)` block. Playwright fails to parse the file (`Unexpected token (119:0)`), and since collection aborts on the first unparseable spec, **the whole E2E suite couldn't run** (0 tests collected). E2E specs aren't in the CI `Laravel tests` gate, so this landed on develop unnoticed (commit 7fe83c21).

Found while running the full E2E suite against a fresh develop checkout. One-line fix: add the missing `});`. Verified — the file now parses and `playwright test --list` shows its test.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)