### PR TITLE
hotfix(mqtt): auto-pick up new connections + fix Live Message Log crash — v0.17.1 (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-22
+
+### Fixed
+- **New MQTT connections weren't picked up until a manual listener restart** *([#174](https://github.com/Mes-Open/OpenMes/issues/174))*: `mqtt:listen` was a single-connection process pinned to one `--connection=<id>` at startup, so creating a connection in **Admin → Connectivity → MQTT** left it stuck at `disconnected` — the DB row existed but nothing was subscribed against it until you restarted the listener with that ID. It is now a **supervisor**: one process services **all** active MQTT connections at once (non-blocking `loopOnce()` per client) and **reconciles against the database every few seconds** — a newly created/activated connection is connected + subscribed automatically, a deactivated/deleted one is disconnected, and a connection whose broker settings or topics changed is reconnected with the new config. The `mqtt-listener` container now runs `mqtt:listen` with no pinned ID by default (pass `--connection=<id>` to supervise just one).
+- **MQTT connection detail — Live Message Log went blank after the first message** *([#174](https://github.com/Mes-Open/OpenMes/issues/174))*: the message log's time formatter was a local `formatTime` that shadowed the imported i18n helper and **recursed into itself**, so the panel rendered fine while empty ("Waiting for messages…") but blew the call stack the moment a message arrived — blanking the log. Renamed the local helper so it calls the imported formatter instead of itself.
+
 ## [0.17.0] - 2026-07-19
 
 ### Added

--- a/backend/app/Console/Commands/MqttListenCommand.php
+++ b/backend/app/Console/Commands/MqttListenCommand.php
@@ -10,143 +10,221 @@ use PhpMqtt\Client\ConnectionSettings;
 use PhpMqtt\Client\Exceptions\MqttClientException;
 use PhpMqtt\Client\MqttClient;
 
+/**
+ * Supervisor for MQTT machine connections. A single process services **all**
+ * active MQTT connections at once (non-blocking `loopOnce()` per client) and
+ * periodically reconciles against the database:
+ *
+ *   - a newly-created / newly-activated connection is connected + subscribed
+ *     automatically (no restart needed — #174),
+ *   - a deactivated / deleted connection is disconnected,
+ *   - a connection whose broker or topics changed is reconnected with the new
+ *     config on the next reconcile tick.
+ *
+ * Pass --connection=<id> to supervise a single connection (used by the
+ * per-connection `mqtt-listener` container); omit it to supervise every active
+ * MQTT connection in one process.
+ */
 class MqttListenCommand extends Command
 {
     protected $signature = 'mqtt:listen
-        {--connection= : ID of a specific machine_connection to listen on (omit for all active)}
+        {--connection= : Supervise only this machine_connection id (omit to supervise all active)}
         {--dry-run     : Connect and log received messages without dispatching jobs}';
 
-    protected $description = 'Start MQTT listener daemon — subscribes to all active MQTT connections';
+    protected $description = 'Start the MQTT listener supervisor — subscribes to all active MQTT connections and picks up new ones live';
+
+    /** How often (seconds) to reconcile managed clients against the database. */
+    private const RECONCILE_SECONDS = 5;
 
     private bool $shouldStop = false;
 
+    /** @var array<int, array{client: MqttClient, sig: string, conn: MachineConnection}> */
+    private array $managed = [];
+
     public function handle(): int
     {
-        if (!class_exists(MqttClient::class)) {
+        if (! class_exists(MqttClient::class)) {
             $this->error('Package php-mqtt/client is not installed.');
             $this->line('Run: composer require php-mqtt/client');
+
             return self::FAILURE;
         }
 
-        $connectionId = $this->option('connection');
-        $dryRun       = $this->option('dry-run');
+        $only = $this->option('connection');
+        $dryRun = (bool) $this->option('dry-run');
 
-        $query = MachineConnection::with('mqttConnection')
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGTERM, fn () => $this->shouldStop = true);
+            pcntl_signal(SIGINT, fn () => $this->shouldStop = true);
+        }
+
+        $this->info($only
+            ? "Starting MQTT supervisor for connection [{$only}]"
+            : 'Starting MQTT supervisor for all active connections');
+        $this->line('Reconciling every '.self::RECONCILE_SECONDS.'s — new connections are picked up automatically.');
+
+        $lastReconcile = 0.0;
+
+        while (! $this->shouldStop) {
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+
+            $now = microtime(true);
+            if ($now - $lastReconcile >= self::RECONCILE_SECONDS) {
+                $this->reconcile($only, $dryRun);
+                $lastReconcile = $now;
+            }
+
+            if (empty($this->managed)) {
+                // Nothing to service yet — wait, then reconcile again.
+                usleep(200_000);
+
+                continue;
+            }
+
+            foreach ($this->managed as $id => $entry) {
+                try {
+                    $entry['client']->loopOnce(microtime(true), false);
+                } catch (\Throwable $e) {
+                    $this->error("[{$id}] loop error: {$e->getMessage()}");
+                    Log::warning('MQTT client loop error', ['connection_id' => $id, 'error' => $e->getMessage()]);
+                    $entry['conn']->markError($e->getMessage());
+                    $this->teardown($id); // dropped → retried on the next reconcile
+                }
+            }
+
+            usleep(50_000); // 50ms breather so the round-robin doesn't busy-spin
+        }
+
+        $this->shutdown();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Bring the set of live clients in line with the active MQTT connections in
+     * the database: connect new ones, drop removed/deactivated ones, reconnect
+     * ones whose config changed.
+     */
+    private function reconcile(?string $only, bool $dryRun): void
+    {
+        $query = MachineConnection::with(['mqttConnection', 'activeTopics'])
             ->where('protocol', 'mqtt')
             ->where('is_active', true);
 
-        if ($connectionId) {
-            $query->where('id', $connectionId);
+        if ($only) {
+            $query->where('id', $only);
         }
 
-        $connections = $query->get();
+        $active = $query->get()->keyBy('id');
 
-        if ($connections->isEmpty()) {
-            $this->warn('No active MQTT connections found.');
-            return self::SUCCESS;
-        }
-
-        if ($connections->count() > 1) {
-            $this->error('This command handles one connection at a time.');
-            $this->line('Use --connection=<id> or run separate processes per connection.');
-            $this->line('Active connections:');
-            foreach ($connections as $conn) {
-                $this->line("  [{$conn->id}] {$conn->name}");
+        // Drop clients whose connection is no longer active/present.
+        foreach (array_keys($this->managed) as $id) {
+            if (! $active->has($id)) {
+                $this->line("[{$id}] no longer active — disconnecting.");
+                $conn = $this->managed[$id]['conn'];
+                $this->teardown($id);
+                $conn->markDisconnected('Connection deactivated or removed');
             }
-            return self::FAILURE;
         }
 
-        $machineConn = $connections->first();
-        $mqttConfig  = $machineConn->mqttConnection;
+        // Connect new connections and reconnect changed ones.
+        foreach ($active as $id => $conn) {
+            $cfg = $conn->mqttConnection;
+            if (! $cfg) {
+                $conn->markError('No MQTT configuration defined');
 
-        if (!$mqttConfig) {
-            $this->error("No MQTT configuration found for connection [{$machineConn->id}] {$machineConn->name}");
-            $machineConn->markError('No MQTT configuration defined');
-            return self::FAILURE;
-        }
+                continue;
+            }
 
-        // Register SIGTERM / SIGINT handlers for graceful shutdown
-        if (function_exists('pcntl_signal')) {
-            pcntl_signal(SIGTERM, fn() => $this->shouldStop = true);
-            pcntl_signal(SIGINT, fn() => $this->shouldStop = true);
-        }
+            $sig = $this->signature($conn);
 
-        $this->info("Starting MQTT listener for [{$machineConn->id}] {$machineConn->name}");
-        $this->line("  Broker: {$mqttConfig->broker_host}:{$mqttConfig->broker_port}");
-
-        while (!$this->shouldStop) {
-            $client = null;
-            try {
-                $machineConn->update(['status' => 'connecting', 'status_message' => null]);
-
-                $client   = $this->buildClient($mqttConfig);
-                $settings = $this->buildSettings($mqttConfig);
-
-                $client->connect($settings, $mqttConfig->clean_session);
-                $machineConn->markConnected();
-                $this->info('[' . now()->toTimeString() . '] Connected.');
-
-                // Subscribe to all active topics for this connection
-                $topics = $machineConn->activeTopics()->get();
-                foreach ($topics as $topic) {
-                    $client->subscribe(
-                        $topic->topic_pattern,
-                        function (string $incomingTopic, string $message) use ($machineConn, $dryRun) {
-                            if (function_exists('pcntl_signal_dispatch')) {
-                                pcntl_signal_dispatch();
-                            }
-
-                            $receivedAt = now()->toIso8601String();
-                            $this->line("[{$receivedAt}] {$incomingTopic}: " . substr($message, 0, 120));
-
-                            if (!$dryRun) {
-                                ProcessMqttMessageJob::dispatch(
-                                    $machineConn->id,
-                                    $incomingTopic,
-                                    $message,
-                                    $receivedAt,
-                                );
-                            }
-                        },
-                        $mqttConfig->qos_default,
-                    );
-                    $this->line("  Subscribed: {$topic->topic_pattern}");
+            if (isset($this->managed[$id])) {
+                if ($this->managed[$id]['sig'] === $sig) {
+                    continue; // unchanged — leave the live client alone
                 }
+                $this->line("[{$id}] config changed — reconnecting.");
+                $this->teardown($id);
+            }
 
-                // Main loop — exits on exception or stop signal
-                $client->loop(true, true);
-
+            try {
+                $conn->update(['status' => 'connecting', 'status_message' => null]);
+                $client = $this->connectAndSubscribe($conn, $cfg, $dryRun);
+                $this->managed[$id] = ['client' => $client, 'sig' => $sig, 'conn' => $conn];
+                $conn->markConnected();
+                $this->info("[{$id}] {$conn->name} connected → {$cfg->broker_host}:{$cfg->broker_port}");
             } catch (MqttClientException $e) {
-                $message = 'MQTT error: ' . $e->getMessage();
-                $this->error($message);
-                Log::error($message, ['connection_id' => $machineConn->id]);
-                $machineConn->markError($e->getMessage());
+                $this->error("[{$id}] connect failed: {$e->getMessage()}");
+                Log::error('MQTT connect failed', ['connection_id' => $id, 'error' => $e->getMessage()]);
+                $conn->markError($e->getMessage());
             } catch (\Throwable $e) {
-                $this->error('Unexpected error: ' . $e->getMessage());
-                Log::error('MQTT listener crashed', ['error' => $e->getMessage(), 'connection_id' => $machineConn->id]);
-                $machineConn->markError($e->getMessage());
-            } finally {
-                try {
-                    $client?->disconnect();
-                } catch (\Throwable) {}
+                $this->error("[{$id}] unexpected error: {$e->getMessage()}");
+                Log::error('MQTT listener error', ['connection_id' => $id, 'error' => $e->getMessage()]);
+                $conn->markError($e->getMessage());
             }
+        }
+    }
 
-            if ($this->shouldStop) {
-                break;
-            }
+    private function connectAndSubscribe(MachineConnection $conn, mixed $cfg, bool $dryRun): MqttClient
+    {
+        $client = $this->buildClient($cfg);
+        $client->connect($this->buildSettings($cfg), $cfg->clean_session);
 
-            $delay = $mqttConfig->reconnect_delay_seconds;
-            $this->line("Reconnecting in {$delay}s...");
-            sleep($delay);
+        foreach ($conn->activeTopics as $topic) {
+            $client->subscribe(
+                $topic->topic_pattern,
+                function (string $incomingTopic, string $message) use ($conn, $dryRun) {
+                    $receivedAt = now()->toIso8601String();
+                    $this->line("[{$conn->id}] {$incomingTopic}: ".substr($message, 0, 120));
 
-            // Reload config in case it was updated
-            $machineConn->refresh();
-            $mqttConfig = $machineConn->mqttConnection;
+                    if (! $dryRun) {
+                        ProcessMqttMessageJob::dispatch($conn->id, $incomingTopic, $message, $receivedAt);
+                    }
+                },
+                $cfg->qos_default,
+            );
+            $this->line("[{$conn->id}]   subscribed: {$topic->topic_pattern}");
         }
 
-        $machineConn->markDisconnected('Listener stopped');
-        $this->info('MQTT listener stopped.');
-        return self::SUCCESS;
+        return $client;
+    }
+
+    /**
+     * A fingerprint of everything that requires a reconnect when it changes:
+     * broker connection settings + the active topic subscriptions.
+     */
+    private function signature(MachineConnection $conn): string
+    {
+        $cfg = $conn->mqttConnection;
+        $topics = $conn->activeTopics->pluck('topic_pattern')->sort()->values()->implode('|');
+
+        return md5(implode('~', [
+            $cfg->broker_host, $cfg->broker_port, $cfg->username, $cfg->getPassword(),
+            $cfg->use_tls ? '1' : '0', $cfg->qos_default, $cfg->keep_alive_seconds,
+            $cfg->clean_session ? '1' : '0', $topics,
+        ]));
+    }
+
+    private function teardown(int $id): void
+    {
+        $entry = $this->managed[$id] ?? null;
+        if ($entry) {
+            try {
+                $entry['client']->disconnect();
+            } catch (\Throwable) {
+            }
+        }
+        unset($this->managed[$id]);
+    }
+
+    private function shutdown(): void
+    {
+        foreach ($this->managed as $id => $entry) {
+            $entry['conn']->markDisconnected('Listener stopped');
+            $this->teardown($id);
+        }
+        $this->info('MQTT supervisor stopped.');
     }
 
     private function buildClient(mixed $cfg): MqttClient
@@ -161,7 +239,7 @@ class MqttListenCommand extends Command
 
     private function buildSettings(mixed $cfg): ConnectionSettings
     {
-        $settings = (new ConnectionSettings())
+        $settings = (new ConnectionSettings)
             ->setKeepAliveInterval($cfg->keep_alive_seconds)
             ->setConnectTimeout($cfg->connect_timeout)
             ->setReconnectAutomatically(false);
@@ -178,7 +256,6 @@ class MqttListenCommand extends Command
         if ($cfg->use_tls) {
             $settings->setUseTls(true);
             if ($cfg->ca_cert) {
-                // Write CA cert to temp file
                 $caFile = tempnam(sys_get_temp_dir(), 'mqtt_ca_');
                 file_put_contents($caFile, $cfg->ca_cert);
                 $settings->setTlsCertificateAuthorityFile($caFile);

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.17.0',
+    'current' => 'v0.17.1',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];

--- a/backend/resources/js/Pages/admin/connectivity/mqtt/Show.jsx
+++ b/backend/resources/js/Pages/admin/connectivity/mqtt/Show.jsx
@@ -613,7 +613,9 @@ function LiveMessageLog({ initialMessages, initialLastId, messagesUrl }) {
         }
     }, [messages, autoScroll]);
 
-    const formatTime = (iso) => {
+    // NB: must not be named `formatTime` — that would shadow the imported helper
+    // and recurse into itself, blowing the stack the moment a message renders.
+    const fmtTime = (iso) => {
         if (!iso) return '';
         try { return formatTime(new Date(iso), { hour12: false }); } catch { return iso; }
     };
@@ -654,7 +656,7 @@ function LiveMessageLog({ initialMessages, initialLastId, messagesUrl }) {
                     {/* Historic messages (server-side, dimmed) */}
                     {[...initialMessages].reverse().map((msg) => (
                         <div key={`init-${msg.id}`} className="flex gap-3 items-start opacity-60">
-                            <span className="text-om-muted shrink-0 tabular-nums">{formatTime(msg.received_at)}</span>
+                            <span className="text-om-muted shrink-0 tabular-nums">{fmtTime(msg.received_at)}</span>
                             <span className={`w-1.5 h-1.5 rounded-full mt-1 shrink-0 ${statusDot(msg.processing_status)}`} />
                             <span className="text-blue-300 shrink-0 max-w-xs truncate">{msg.topic}</span>
                             <span className="text-om-faintest break-all">{String(msg.raw_payload ?? '').substring(0, 200)}</span>
@@ -664,7 +666,7 @@ function LiveMessageLog({ initialMessages, initialLastId, messagesUrl }) {
                     {/* Live messages */}
                     {messages.map((msg) => (
                         <div key={msg.id} className="flex gap-3 items-start">
-                            <span className="text-om-muted shrink-0 tabular-nums">{formatTime(msg.received_at)}</span>
+                            <span className="text-om-muted shrink-0 tabular-nums">{fmtTime(msg.received_at)}</span>
                             <span className={`w-1.5 h-1.5 rounded-full mt-1 shrink-0 ${statusDot(msg.processing_status)}`} />
                             <span className="text-blue-300 shrink-0 max-w-xs truncate">{msg.topic}</span>
                             <span className="text-om-faintest break-all">{String(msg.raw_payload ?? '').substring(0, 200)}</span>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,9 +138,10 @@ services:
       - openmmes-network
 
   # ── MQTT listener daemon ──────────────────────────────────────────────────
-  # One instance per active MQTT machine_connection.
-  # Set MQTT_CONNECTION_ID to the ID from the admin panel.
-  # Example: MQTT_CONNECTION_ID=1 docker compose up -d mqtt-listener
+  # One supervisor process services ALL active MQTT machine_connections and
+  # picks up newly-created / newly-activated ones automatically (no restart).
+  # To pin it to a single connection instead, set MQTT_CONNECTION_ID and add
+  # `--connection=${MQTT_CONNECTION_ID}` back to the command below.
   mqtt-listener:
     image: ghcr.io/mes-open/openmes:${OPENMES_VERSION:-latest}
     # Default to building from the cloned source so `docker compose up` always
@@ -154,7 +155,7 @@ services:
       dockerfile: backend/Dockerfile
     container_name: ${OPENMES_NAME_PREFIX:-openmmes}-mqtt-listener
     command:
-      ["php", "artisan", "mqtt:listen", "--connection=${MQTT_CONNECTION_ID:-1}"]
+      ["php", "artisan", "mqtt:listen"]
     environment:
       APP_ENV: ${APP_ENV:-production}
       APP_KEY: ${APP_KEY}

--- a/docs/mqtt-connectivity.md
+++ b/docs/mqtt-connectivity.md
@@ -6,13 +6,13 @@ The MQTT machine connectivity module is available since **v0.4.0** under **Admin
 
 ## Running the MQTT listener in production
 
-Each MQTT connection requires a dedicated listener process. The listener is a separate Docker service (`mqtt-listener`) defined in `docker-compose.yml`.
+A **single** `mqtt-listener` service (defined in `docker-compose.yml`) supervises **all** active MQTT connections at once. It reconciles against the database every few seconds, so when you **create or activate a new connection in the admin panel it is picked up automatically** — no restart, no per-connection container.
 
-### Start a listener for connection ID 1
+### Start the listener
 
 ```bash
 cd /opt/openmmes   # or wherever your docker-compose.yml is
-MQTT_CONNECTION_ID=1 docker compose up -d mqtt-listener
+docker compose up -d mqtt-listener
 ```
 
 ### Check listener logs
@@ -27,7 +27,13 @@ docker logs openmmes-mqtt-listener -f
 docker compose stop mqtt-listener
 ```
 
-> **Multiple connections**: run separate listener containers per connection. The current setup supports one at a time via `MQTT_CONNECTION_ID`. For multiple simultaneous listeners, duplicate the service block in `docker-compose.yml` with different container names and connection IDs.
+What the supervisor does on each reconcile tick:
+
+- **new / newly-activated** connection → connect + subscribe automatically;
+- **deactivated / deleted** connection → disconnect;
+- **changed** broker settings or topics on an existing connection → reconnect with the new config.
+
+> **Pin to one connection** (optional): to run a dedicated process for a single connection, pass `--connection=<id>` (e.g. `php artisan mqtt:listen --connection=2`, or add it back to the `mqtt-listener` command with `MQTT_CONNECTION_ID`). Omitting it supervises everything, which is the recommended default.
 
 ---
 


### PR DESCRIPTION
**Hotfix to `main`** for the two MQTT issues reported in #174 by @digiajay. Both verified end-to-end against a live Mosquitto broker exactly as reported. Minimal, self-contained diff on top of v0.17.0 (6 files) + a **v0.17.1** patch bump.

## 1. New MQTT connections weren't picked up until a manual restart
`mqtt:listen` was a single-connection process pinned to one `--connection=<id>` at startup, so creating a connection in **Admin → Connectivity → MQTT** left it stuck at `disconnected` — nothing subscribed against it until the listener was restarted with that ID.

**Fix:** `mqtt:listen` is now a **supervisor** — one process services **all** active MQTT connections (non-blocking `loopOnce()` per client) and **reconciles against the DB every 5s**: new/activated → connect + subscribe automatically; deactivated/deleted → disconnect; changed broker/topics → reconnect. The `mqtt-listener` container runs with no pinned ID by default (pass `--connection=<id>` for single-connection mode). Docs updated.

## 2. Live Message Log went blank after the first message
A local `const formatTime` shadowed the imported i18n helper and **recursed into itself** — fine while empty, but the first rendered message blew the call stack and blanked the panel. Renamed to `fmtTime` so it calls the imported formatter.

## E2E test (as the reporter did)
On a running instance + Mosquitto (TCP 1883 / WS 9001):
1. Started the supervisor (no `--connection`).
2. **Created a brand-new MQTT connection** in the app → within one reconcile tick it logged `connected → …:1883` and flipped to **Connected** in the UI, no restart. ✅
3. **Published** a message → received by the supervisor, persisted to `machine_messages` (`ok`). ✅
4. Opened the connection detail page → **Live Message Log rendered the message** with a formatted timestamp and did **not** blank. ✅

## Release
- Version bump: **v0.17.0 → v0.17.1** (`backend/config/version.php`) + CHANGELOG `[0.17.1]` section.
- Full suite green on the main base (1922). Pint clean; frontend builds.

> `main` is ruleset-protected — over to you to merge & tag `v0.17.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT monitoring now supervises all active connections from a single listener.
  * New or updated connections are connected, subscribed, and refreshed automatically without restarting the service.
* **Bug Fixes**
  * Fixed the Live Message Log becoming blank when displaying timestamps.
* **Documentation**
  * Updated MQTT setup and operating instructions for the new supervision model.
* **Release**
  * Updated the application version to 0.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->