### PR TITLE
chore(release): v0.17.1 — align desktop version + changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.17.1] - 2026-07-22
+## [0.17.1] - 2026-07-23
 
 ### Fixed
 - **New MQTT connections weren't picked up until a manual listener restart** *([#174](https://github.com/Mes-Open/OpenMes/issues/174))*: `mqtt:listen` was a single-connection process pinned to one `--connection=<id>` at startup, so creating a connection in **Admin → Connectivity → MQTT** left it stuck at `disconnected` — the DB row existed but nothing was subscribed against it until you restarted the listener with that ID. It is now a **supervisor**: one process services **all** active MQTT connections at once (non-blocking `loopOnce()` per client) and **reconciles against the database every few seconds** — a newly created/activated connection is connected + subscribed automatically, a deactivated/deleted one is disconnected, and a connection whose broker settings or topics changed is reconnected with the new config. The `mqtt-listener` container now runs `mqtt:listen` with no pinned ID by default (pass `--connection=<id>` to supervise just one).

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmes-desktop",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.17.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "openmes-desktop"
-version = "0.1.1"
+version = "0.17.1"
 dependencies = [
  "libc",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmes-desktop"
-version = "0.1.1"
+version = "0.17.1"
 description = "OpenMES Desktop — lokalny serwer MES w aplikacji desktopowej"
 authors = ["OpenMES"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "openmes-desktop",
-  "version": "0.1.1",
+  "version": "0.17.1",
   "identifier": "com.openmes.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release-prep for **v0.17.1** (the MQTT hotfix already on main via #199).

## Changes
- **Desktop app version 0.1.1 → 0.17.1** across `tauri.conf.json`, `package.json`, `Cargo.toml`, `Cargo.lock` — aligns the desktop shell version with the product version. (Note: the release workflow already injects the version from the tag via `--config`, so the built installers would be `0.17.1` regardless; this just keeps the repo's stated version honest instead of `0.1.1`.)
- **CHANGELOG `[0.17.1]` date → 2026-07-23** (release date).

No functional/code changes. Full suite green (1922).

## After merge
Tag **`v0.17.1`** on main → the release workflow builds & publishes the GitHub Release: web ZIP + desktop installers (`.exe`/`.dmg`/`.deb`/`.rpm`, versioned 0.17.1) + Android `.apk`.

> `main` is ruleset-protected — over to you to merge; then I'll push the `v0.17.1` tag (or you can).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the desktop application version to 0.17.1.
  * Updated the release date for version 0.17.1 to July 23, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->