### PR TITLE
docs: training program for administrators, developers and operators

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,17 @@ Welcome to the OpenMES documentation. Choose a guide based on your role or use c
 
 ---
 
+## Training
+
+| Document | Audience | Description |
+|---|---|---|
+| [Training Program](training-program.md) | Trainers & site leads | Onboarding curricula for operators, administrators, and developers |
+| [Operator track](training/operator.md) | Production operators | Shop-floor workflow objectives, exercises, checklist |
+| [Administrator track](training/administrator.md) | Admins & configurators | Installation and configuration objectives, exercises, checklist |
+| [Developer track](training/developer.md) | Developers & integrators | Modules, hooks, API extensibility objectives, exercises, checklist |
+
+---
+
 ## Project
 
 | Document | Description |
@@ -37,6 +48,7 @@ Welcome to the OpenMES documentation. Choose a guide based on your role or use c
 ## Quick Navigation
 
 - **New to OpenMES?** → Start with the [Admin Guide](admin-guide.md) to set up the system
+- **Onboarding a plant team?** → Use the [Training Program](training-program.md)
 - **Setting up tablets?** → See [PWA Installation](../README.md#-pwa-installation-tablets) in the main README
 - **Building integrations?** → See the [API Documentation](API_DOCUMENTATION.md)
 - **Writing a module?** → See [HOOKS.md](../HOOKS.md) and [Technical Documentation](development.md)

--- a/docs/training-program.md
+++ b/docs/training-program.md
@@ -1,0 +1,72 @@
+# Training Program
+
+This program onboards three audiences onto OpenMES: **operators**, **administrators**, and **developers**. Each track defines learning objectives, a session outline, reference materials in this repo, and a competency checklist suitable for handover.
+
+Use the tracks for instructor-led workshops, self-paced study, or site go-live preparation. Detailed how-to content lives in the linked role guides — these tracks are curricula, not replacements for those guides.
+
+---
+
+## Table of Contents
+
+- [Tracks at a Glance](#tracks-at-a-glance)
+- [How to Deliver Training](#how-to-deliver-training)
+- [Shared Prerequisites](#shared-prerequisites)
+- [Track Documents](#track-documents)
+- [Handover Package](#handover-package)
+
+---
+
+## Tracks at a Glance
+
+| Track | Audience | Focus | Primary materials |
+|---|---|---|---|
+| [Operator](training/operator.md) | Shop-floor operators | Daily line workflows, batches, issues, tablets | [Operator Guide](operator-guide.md) |
+| [Administrator](training/administrator.md) | System admins & supervisors configuring the plant | Install, structure, users, products, orders, settings | [Admin Guide](admin-guide.md), [Supervisor Guide](supervisor-guide.md) |
+| [Developer](training/developer.md) | Integrators & contributors | Architecture, modules, hooks, API | [Technical Documentation](development.md), [HOOKS.md](../HOOKS.md), [API Documentation](API_DOCUMENTATION.md) |
+
+Suggested durations (adjust to plant complexity):
+
+| Track | Self-paced | Workshop |
+|---|---|---|
+| Operator | 1–2 hours | Half day (with floor practice) |
+| Administrator | 3–5 hours | 1 day |
+| Developer | 4–8 hours | 1–2 days |
+
+---
+
+## How to Deliver Training
+
+1. **Prepare an environment** — Docker Compose install (see [Admin Guide → Installation](admin-guide.md#installation)) or a staging site with sample data.
+2. **Assign accounts** — create one trainee user per role; operators must be assigned to at least one line.
+3. **Follow the track outline** — cover objectives in order; pause for hands-on exercises before advancing.
+4. **Sign off with the checklist** — each track ends with a competency checklist for the trainer and trainee.
+
+Supervisors who only monitor production (accept orders, Andon, reports) can take the **Operator** track for shop-floor context, then the **Administrator** sections on work orders and monitoring — or the full [Supervisor Guide](supervisor-guide.md) as a short add-on.
+
+---
+
+## Shared Prerequisites
+
+- Access to an OpenMES URL (local Docker or staging)
+- Browser (Chrome/Edge/Safari); tablets optional for the operator track
+- For the developer track: Git, Docker, PHP 8.3 tooling as described in [development.md](development.md)
+
+---
+
+## Track Documents
+
+- [Operator training track](training/operator.md) — shop-floor workflows
+- [Administrator training track](training/administrator.md) — configuration and plant setup
+- [Developer training track](training/developer.md) — extensibility and hooks
+
+---
+
+## Handover Package
+
+When handing OpenMES to a new site team, include:
+
+1. This training program and the three track documents
+2. Role guides: [operator](operator-guide.md), [supervisor](supervisor-guide.md), [admin](admin-guide.md)
+3. Technical refs: [development](development.md), [HOOKS.md](../HOOKS.md), [API](API_DOCUMENTATION.md), [machine connectivity](machine-connectivity.md) if signals are in scope
+4. Completed competency checklists (one per trainee)
+5. Site-specific notes: URL, line codes, product types, process templates, and who owns admin accounts

--- a/docs/training/administrator.md
+++ b/docs/training/administrator.md
@@ -1,0 +1,146 @@
+# Administrator Training Track
+
+Training outline for system administrators (and configuration-focused supervisors) who install, configure, and maintain OpenMES for a plant.
+
+**Parent program:** [Training Program](../training-program.md)
+
+---
+
+## Table of Contents
+
+- [Learning Objectives](#learning-objectives)
+- [Prerequisites](#prerequisites)
+- [Session Outline](#session-outline)
+- [Reference Materials](#reference-materials)
+- [Hands-on Exercises](#hands-on-exercises)
+- [Competency Checklist](#competency-checklist)
+
+---
+
+## Learning Objectives
+
+After this track, the trainee can:
+
+1. Install or validate a Docker-based OpenMES deployment and complete first-run setup
+2. Model the plant: factories, divisions, lines, workstations
+3. Create users, assign roles, and map operators/supervisors to lines
+4. Configure product types and process templates
+5. Create and import work orders; explain the pending → accepted flow
+6. Adjust system settings that affect the floor (production period, overproduction, sequential steps)
+7. Enable or install modules and manage API tokens when integrations are needed
+8. Perform basic maintenance awareness (audit logs, updates, sample data)
+
+---
+
+## Prerequisites
+
+- Admin account (or ability to complete the installer and create one)
+- Host with Docker and Docker Compose for a lab install, **or** a staging site already running
+- Optional: sample CSV for order import practice
+
+---
+
+## Session Outline
+
+### 1. Installation and first steps (30–45 min)
+
+- Prerequisites (Docker, Git)
+- `docker-compose up -d` and web installer (site, database, admin account)
+- Production hardening notes (`APP_DEBUG`, HTTPS, protect `.env`)
+- Post-install checklist: lines, users, assignments, products, templates, orders
+
+**Materials:** [Admin Guide → Installation](../admin-guide.md#installation), [First Steps After Installation](../admin-guide.md#first-steps-after-installation)
+
+### 2. Users and roles (20–30 min)
+
+- Roles: Admin, Supervisor, Operator
+- Create users; assign lines for Operator/Supervisor
+- Password reset policy (no self-service — admin/supervisor handles it)
+
+**Materials:** [User Management](../admin-guide.md#user-management)
+
+### 3. Production structure (30–40 min)
+
+- Factory → Division → Line → Workstation hierarchy
+- Create an active line; add workstations
+- Why operators only see assigned lines
+
+**Materials:** [Production Structure](../admin-guide.md#production-structure)
+
+### 4. Products and process templates (30–40 min)
+
+- Product types as categories
+- Process templates: ordered steps, optional required roles
+- Link templates to product types for order creation
+
+**Materials:** [Product Configuration](../admin-guide.md#product-configuration)
+
+### 5. Work orders and supervisor handoff (30–40 min)
+
+- Manual order creation (number, qty, line, type, template, due date, priority)
+- CSV/Excel import: required fields, strategies, saved mapping profiles
+- Pending orders must be **Accepted** by a supervisor before operators see them
+- Pause / resume / reject awareness via supervisor workflows
+
+**Materials:** [Work Orders](../admin-guide.md#work-orders), [Supervisor Guide → Managing Work Orders](../supervisor-guide.md#managing-work-orders)
+
+### 6. System settings and modules (30–40 min)
+
+- Production period, overproduction, sequential step enforcement
+- Enable/disable modules; install from ZIP when applicable
+- API tokens for integrations
+- Shifts, HR basics, audit logs, updates overview
+
+**Materials:** [System Settings](../admin-guide.md#system-settings), [Modules](../admin-guide.md#modules), [API Tokens](../admin-guide.md#api-tokens), [Audit Logs](../admin-guide.md#audit-logs), [Updates](../admin-guide.md#updates)
+
+### 7. Day-two operations (20 min)
+
+- Monitoring: supervisor dashboard, issues, reports (for admin awareness)
+- Machine/MQTT connectivity only if the site uses signal capture — point to refs, do not deep-dive unless in scope
+
+**Materials:** [Supervisor Guide](../supervisor-guide.md), optional [Machine Connectivity](../machine-connectivity.md), [MQTT Connectivity](../mqtt-connectivity.md)
+
+---
+
+## Reference Materials
+
+| Resource | Use |
+|---|---|
+| [Admin Guide](../admin-guide.md) | Primary configuration reference |
+| [Supervisor Guide](../supervisor-guide.md) | Order lifecycle and Andon after config |
+| [Operator Guide](../operator-guide.md) | Validate that config works on the floor |
+| [Training Program](../training-program.md) | Handover package checklist |
+| Main [README](../../README.md) | Deployment and PWA overview |
+
+---
+
+## Hands-on Exercises
+
+1. **Greenfield checklist** — From a clean (or reset) lab, complete post-install steps through one active line and two users (operator + supervisor).
+2. **Template build** — Create a product type and a 3–5 step process template; assign the template to the type.
+3. **Order path** — Create a pending order, accept it as supervisor, complete one batch as operator.
+4. **Import** — Import a small CSV with insert-only strategy; confirm duplicates are skipped on re-import.
+5. **Setting toggle** — Change sequential-steps or overproduction setting and demonstrate the floor effect to trainees.
+6. **Module awareness** — List enabled modules and describe how to enable/disable one in a non-production lab.
+
+---
+
+## Competency Checklist
+
+Trainee: _________________  Date: _________  Trainer: _________________
+
+| # | Skill | Pass |
+|---|---|---|
+| 1 | Installs or verifies Docker deployment / installer completion | ☐ |
+| 2 | Creates structure (at least one active line) | ☐ |
+| 3 | Creates users and assigns roles and lines | ☐ |
+| 4 | Configures product type + process template | ☐ |
+| 5 | Creates or imports work orders correctly | ☐ |
+| 6 | Explains pending → accepted → operator queue flow | ☐ |
+| 7 | Locates and adjusts key system settings | ☐ |
+| 8 | Describes module enablement and when to use API tokens | ☐ |
+
+Site-specific configuration notes (URLs, naming conventions, ERP import profiles):
+
+_________________________________________________________________
+_________________________________________________________________

--- a/docs/training/developer.md
+++ b/docs/training/developer.md
@@ -1,0 +1,140 @@
+# Developer Training Track
+
+Training outline for developers and integrators who extend OpenMES (modules, hooks, APIs) or contribute to the core.
+
+**Parent program:** [Training Program](../training-program.md)
+
+---
+
+## Table of Contents
+
+- [Learning Objectives](#learning-objectives)
+- [Prerequisites](#prerequisites)
+- [Session Outline](#session-outline)
+- [Reference Materials](#reference-materials)
+- [Hands-on Exercises](#hands-on-exercises)
+- [Competency Checklist](#competency-checklist)
+
+---
+
+## Learning Objectives
+
+After this track, the trainee can:
+
+1. Describe the tech stack and repository layout (Laravel backend, Blade/Alpine/Livewire UI, modules directory)
+2. Run a local development environment and know where tests and formatting live
+3. Explain RBAC roles and where operator / supervisor / admin surfaces live
+4. Scaffold or outline a module (`module.json`, service provider, routes, migrations)
+5. Register event listeners against the hook/event system without patching core controllers
+6. Use the REST API documentation for integrations (auth, common resources)
+7. Follow contribution conventions (branching, Conventional Commits, PR expectations)
+
+---
+
+## Prerequisites
+
+- Comfortable with PHP and Git; Laravel familiarity recommended
+- Docker (or a working local PHP/PostgreSQL setup per [development.md](../development.md))
+- Read access to this repository; fork for contribution practice
+
+---
+
+## Session Outline
+
+### 1. Architecture overview (30–40 min)
+
+- Stack table: Laravel 12, PHP 8.3, PostgreSQL, Sanctum, Spatie Permission, Vite, Docker
+- Repo map: `backend/`, `modules/`, `docs/`, compose files
+- Request paths: web (Blade/Livewire) vs `api/v1`
+- Tenant / role model at a high level
+
+**Materials:** [Technical Documentation → Tech Stack](../development.md#tech-stack), [Repository Structure](../development.md#repository-structure), [Architecture Overview](../development.md#architecture-overview)
+
+### 2. Local development setup (30–45 min)
+
+- Clone, compose, installer or `.env` setup
+- `composer install`, frontend assets, running the app
+- Where feature/unit tests live; `php artisan test`
+- Code style (`pint`) and [Contributing](../CONTRIBUTING.md) expectations
+
+**Materials:** [Local Development Setup](../development.md#local-development-setup), [Testing](../development.md#testing), [Code Style](../development.md#code-style), [Contributing](../CONTRIBUTING.md)
+
+### 3. Module system (45–60 min)
+
+- Module directory layout and `module.json`
+- Service provider registration and sidebar navigation
+- Module migrations and extending core models safely
+- Prefer modules over core forks for site-specific behaviour
+
+**Materials:** [Module System](../development.md#module-system), [HOOKS.md → Creating a Module](../../HOOKS.md#creating-a-module)
+
+### 4. Hooks and events (45–60 min)
+
+- Laravel events as the extension point
+- Register listeners in the module service provider
+- Survey major hook groups: work orders, batches, batch steps, users, lines, process templates, CSV import
+- Best practices: keep listeners focused; avoid breaking the transaction path
+
+**Materials:** [Hook System](../development.md#hook-system), [HOOKS.md](../../HOOKS.md) (available hooks and examples)
+
+### 5. API and integrations (30–45 min)
+
+- Sanctum session vs token usage for API clients
+- Navigate [API Documentation](../API_DOCUMENTATION.md) for common resources
+- Admin-managed API tokens (see admin track) for external systems
+- Optional: machine signal pipeline overview if building protocol adapters
+
+**Materials:** [API Development](../development.md#api-development), [API Documentation](../API_DOCUMENTATION.md), optional [Machine Connectivity](../machine-connectivity.md)
+
+### 6. Contribution workflow (15–20 min)
+
+- Fork, branch from `main`, focused PRs
+- Conventional Commits (`feat`, `fix`, `docs`, …)
+- Tests and docs for user-visible behaviour
+- Point contributors at open docs/code issues only after they can run the suite
+
+**Materials:** [Contributing → Submitting Changes](../CONTRIBUTING.md#submitting-changes), [Commit Message Convention](../CONTRIBUTING.md#commit-message-convention)
+
+---
+
+## Reference Materials
+
+| Resource | Use |
+|---|---|
+| [Technical Documentation](../development.md) | Architecture, modules, local setup |
+| [HOOKS.md](../../HOOKS.md) | Event catalogue and module examples |
+| [API Documentation](../API_DOCUMENTATION.md) | REST reference |
+| [Contributing](../CONTRIBUTING.md) | Process and PR norms |
+| [Admin Guide → Modules / API Tokens](../admin-guide.md#modules) | Runtime enablement operators of the platform use |
+| [Operator](../operator-guide.md) / [Supervisor](../supervisor-guide.md) guides | Domain language for realistic extension scenarios |
+
+---
+
+## Hands-on Exercises
+
+1. **Map the code** — From a work-order accept action on the UI, locate the controller/service and name one related event if present.
+2. **Dev boot** — Bring up the stack locally and run a focused subset of tests successfully.
+3. **Module skeleton** — Create (or sketch) a module with `module.json` and a service provider that registers one no-op listener.
+4. **Hook listener** — Listen for a work-order or batch completion event and write to the log (lab only).
+5. **API read** — With a token or session, call one documented read endpoint and show the JSON shape.
+6. **Docs PR practice (optional)** — Open a docs-only branch fixing a typo to rehearse the contribution path.
+
+---
+
+## Competency Checklist
+
+Trainee: _________________  Date: _________  Trainer: _________________
+
+| # | Skill | Pass |
+|---|---|---|
+| 1 | Explains stack and where backend / modules / docs live | ☐ |
+| 2 | Runs local (or Docker) development environment | ☐ |
+| 3 | Describes module layout and registration | ☐ |
+| 4 | Registers an event listener via hooks (no core fork) | ☐ |
+| 5 | Finds and uses API docs for an integration scenario | ☐ |
+| 6 | States contribution steps (branch, tests, Conventional Commits, PR) | ☐ |
+
+Extension goals for this site (modules, ERP, signals):
+
+_________________________________________________________________
+_________________________________________________________________

--- a/docs/training/operator.md
+++ b/docs/training/operator.md
@@ -1,0 +1,130 @@
+# Operator Training Track
+
+Training outline for production floor operators using OpenMES on workstations or tablets.
+
+**Parent program:** [Training Program](../training-program.md)
+
+---
+
+## Table of Contents
+
+- [Learning Objectives](#learning-objectives)
+- [Prerequisites](#prerequisites)
+- [Session Outline](#session-outline)
+- [Reference Materials](#reference-materials)
+- [Hands-on Exercises](#hands-on-exercises)
+- [Competency Checklist](#competency-checklist)
+
+---
+
+## Learning Objectives
+
+After this track, the trainee can:
+
+1. Log in and select the correct production line
+2. Read and navigate the work queue (status, priority, progress)
+3. Start a batch, complete process steps in order, and finish a run
+4. Report an issue (Andon) with the right type and description
+5. Update line status (running, changeover, breakdown, stop)
+6. Install and use OpenMES as a PWA on a tablet, including basic offline behaviour
+
+---
+
+## Prerequisites
+
+- Operator user account assigned to at least one active line
+- At least one **Accepted** or **In Progress** work order on that line (trainer prepares this)
+- Optional: tablet for the PWA section
+
+---
+
+## Session Outline
+
+### 1. Orientation (10–15 min)
+
+- What OpenMES is used for on the shop floor
+- Roles: operator vs supervisor vs admin (operators do not change system config)
+- Where to get the site URL and who resets passwords
+
+### 2. Login and line selection (10 min)
+
+- Open the OpenMES URL and log in
+- Choose the assigned line from the line selection screen
+- What to do if the line is missing (contact supervisor)
+
+**Materials:** [Operator Guide → Logging In](../operator-guide.md#logging-in), [Selecting Your Line](../operator-guide.md#selecting-your-line)
+
+### 3. Work queue (15 min)
+
+- Read order number, product, quantity, due date, status, progress
+- Sort/priority expectations for the shift
+- Open an order detail page
+
+**Materials:** [Your Work Queue](../operator-guide.md#your-work-queue), screenshot [operator-queue.png](../screenshots/operator-queue.png)
+
+### 4. Daily production workflow (30–40 min)
+
+- Start a batch and enter planned quantity
+- Complete steps in sequence (unless sequential enforcement is off)
+- Add optional step comments
+- Confirm batch completion and quantity update
+
+**Materials:** [Working on a Production Order](../operator-guide.md#working-on-a-production-order), [operator-workstation.png](../screenshots/operator-workstation.png)
+
+### 5. Problems and line status (20 min)
+
+- Report issue: type, description, submit
+- Understand critical issues may block the order
+- Set line status accurately during the shift
+
+**Materials:** [Reporting a Problem](../operator-guide.md#reporting-a-problem), [Line Status Updates](../operator-guide.md#line-status-updates)
+
+### 6. Tablets and PWA (15–20 min, optional)
+
+- Install on iPad or Android
+- Offline banner, queued actions, sync on reconnect
+- Shop-floor tips (touch targets, landscape, session timeout)
+
+**Materials:** [Using OpenMES on a Tablet (PWA)](../operator-guide.md#using-openmes-on-a-tablet-pwa), [Tips for the Shop Floor](../operator-guide.md#tips-for-the-shop-floor)
+
+---
+
+## Reference Materials
+
+| Resource | Use |
+|---|---|
+| [Operator Guide](../operator-guide.md) | Primary how-to for all shop-floor tasks |
+| [Supervisor Guide](../supervisor-guide.md) | Context only — how issues and accept/pause look upstream |
+| [Screenshots](../screenshots/) | Visual reference for queue and workstation screens |
+| Site URL / line list | Provided by the plant administrator |
+
+---
+
+## Hands-on Exercises
+
+1. **Queue drill** — Log in, select line, identify the highest-priority open order and open it.
+2. **Full batch** — Start a batch for a small quantity, complete every step, confirm the order progress updates.
+3. **Issue report** — Submit a non-critical test issue, then ask a supervisor to show it on their dashboard (or have the trainer resolve it).
+4. **Status change** — Set the line to Changeover, then back to Running.
+5. **PWA (optional)** — Install the app on a tablet and complete one step while noting online/offline indicators.
+
+---
+
+## Competency Checklist
+
+Trainee: _________________  Date: _________  Trainer: _________________
+
+| # | Skill | Pass |
+|---|---|---|
+| 1 | Logs in and selects the correct line | ☐ |
+| 2 | Explains queue fields (order, qty, due, status, progress) | ☐ |
+| 3 | Starts a batch with a sensible quantity | ☐ |
+| 4 | Completes steps and finishes a batch | ☐ |
+| 5 | Reports an issue with correct type and description | ☐ |
+| 6 | Updates line status appropriately | ☐ |
+| 7 | (Optional) Uses PWA install and understands offline sync | ☐ |
+
+Notes / site-specific procedures:
+
+_________________________________________________________________
+_________________________________________________________________


### PR DESCRIPTION
## Summary
Repo-stored training program with separate tracks for operators (shop-floor workflows), administrators (configuration), and developers (modules/hooks/API). Each track has learning objectives, outlines, linked materials, exercises, and competency checklists. Surfaced from `docs/index.md`.

## Type of change
- [x] Documentation

## Related issue
Fixes #93

## Testing
- [x] Docs-only (markdown); no PHP/product code
- [x] Reviewed against issue acceptance criteria (three role tracks, objectives/materials, shop-floor / config / extensibility coverage)
- [x] Markdown links resolve within the repo

### AI/LLM disclosure
- AI coding tools were used to help draft this change and PR description.
- I reviewed the complete change and understand the reasoning before submitting.