### PR TITLE
fix(crud): friendly message instead of 404 when deleting an already-r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Deleting an already-removed record dumped a bare 404 instead of a message**: deleting an admin CRUD record that was already gone — soft-deleted in another tab, a stale list, or a double submit — hit route-model binding, which excludes soft-deleted rows, and returned a raw 404 with no feedback. A `DELETE` to `/admin/*` whose record no longer exists now bounces back to the list with an informational flash ("That item was already removed.") instead — the delete's intent is already satisfied. Handled centrally in `bootstrap/app.php` for **every** admin resource in one place; a normal single delete still shows "deleted successfully".
+
 ## [0.18.0] - 2026-07-25
 
 ### Added

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -66,6 +66,22 @@ $app = Application::configure(basePath: dirname(__DIR__))
             return redirect()->route('login')->withErrors(['session' => 'Your session has expired. Please log in again.']);
         });
 
+        // A DELETE for an admin record that's already gone — soft-deleted in
+        // another tab, a stale list, a double submit — should not dump a bare 404.
+        // The delete's intent is already satisfied, so bounce back to the list with
+        // an informational message instead. Covers every admin CRUD resource in one
+        // place. Only when the 404 came from route-model binding failing to resolve
+        // the record itself (the framework wraps the original ModelNotFoundException
+        // as the previous exception) — so deliberate security-scoping abort(404)s
+        // inside controllers (foreign/IDOR paths) keep their 404.
+        $exceptions->render(function (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $e, \Illuminate\Http\Request $request) {
+            $fromBinding = $e->getPrevious() instanceof \Illuminate\Database\Eloquent\ModelNotFoundException;
+
+            if ($fromBinding && $request->isMethod('DELETE') && $request->is('admin/*')) {
+                return back()->with('info', __('That item was already removed.'));
+            }
+        });
+
         // Render a friendly Inertia "Error" page for error statuses in
         // production, so the app chrome (sidebar) stays put and the user can
         // navigate away instead of landing on a bare error screen. API/JSON

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -4656,7 +4656,6 @@
     "No shift configured": "No shift configured",
     "Not found": "Not found",
     "ONE SEQUENCE PER PRODUCT TYPE · DEFAULT IS THE GLOBAL FALLBACK": "ONE SEQUENCE PER PRODUCT TYPE · DEFAULT IS THE GLOBAL FALLBACK",
-    "Offline": "Offline",
     "Open API in browser": "Open API in browser",
     "PARAM": "PARAM",
     "PICK A SUPERVISOR": "PICK A SUPERVISOR",
@@ -4891,7 +4890,6 @@
     "Import work orders": "Import work orders",
     "Read production completions": "Read production completions",
     "Read quality & issue reports": "Read quality & issue reports",
-    "ERP integration": "ERP integration",
     "REST API to import work orders from an ERP (SAP, Comarch, enova365, Dynamics) and export production and quality data back, secured by API keys.": "REST API to import work orders from an ERP (SAP, Comarch, enova365, Dynamics) and export production and quality data back, secured by API keys.",
     "Step 1 — Modules": "Step 1 — Modules",
     "Choose your modules": "Choose your modules",
@@ -4943,5 +4941,6 @@
     "You have been logged out successfully.": "You have been logged out successfully.",
     "Too many attempts. Please wait :seconds seconds.": "Too many attempts. Please wait :seconds seconds.",
     "Adding :material here would create a circular BOM reference.": "Adding :material here would create a circular BOM reference.",
-    "That template already consumes :material, so it cannot also produce it.": "That template already consumes :material, so it cannot also produce it."
+    "That template already consumes :material, so it cannot also produce it.": "That template already consumes :material, so it cannot also produce it.",
+    "That item was already removed.": "That item was already removed."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -1930,7 +1930,7 @@
     "Add one to control how lot numbers are generated.": "Dodaj sekwencję, aby kontrolować generowanie numerów LOT.",
     "No label template configured for type :type. Configure one in Packaging → Label Templates.": "Brak skonfigurowanego szablonu etykiety dla typu :type. Skonfiguruj go w Pakowanie → Szablony etykiet.",
     "No workstations are wired to a machine connection yet.": "Żadne stanowisko nie jest jeszcze podłączone do połączenia maszynowego.",
-    "ERP integration": "Integracja z ERP",
+    "ERP integration": "Integracja ERP",
     "Generate this many days before due": "Generuj tyle dni przed terminem",
     "No lines mapped under this site yet.": "Brak linii przypisanych do tego zakładu.",
     "Work patterns": "Wzorce pracy",
@@ -4890,7 +4890,6 @@
     "Import work orders": "Import zleceń produkcyjnych",
     "Read production completions": "Odczyt danych o wykonaniu produkcji",
     "Read quality & issue reports": "Odczyt raportów jakości i niezgodności",
-    "ERP integration": "Integracja ERP",
     "REST API to import work orders from an ERP (SAP, Comarch, enova365, Dynamics) and export production and quality data back, secured by API keys.": "REST API do importu zleceń produkcyjnych z ERP (SAP, Comarch, enova365, Dynamics) i eksportu danych o produkcji i jakości z powrotem, zabezpieczone kluczami API.",
     "Step 1 — Modules": "Krok 1 — Moduły",
     "Choose your modules": "Wybierz moduły",
@@ -4942,5 +4941,6 @@
     "You have been logged out successfully.": "Zostałeś wylogowany.",
     "Too many attempts. Please wait :seconds seconds.": "Zbyt wiele prób. Odczekaj :seconds s.",
     "Adding :material here would create a circular BOM reference.": "Dodanie :material w tym miejscu utworzyłoby cykliczne odwołanie w BOM.",
-    "That template already consumes :material, so it cannot also produce it.": "Ten szablon już zużywa :material, więc nie może go jednocześnie produkować."
+    "That template already consumes :material, so it cannot also produce it.": "Ten szablon już zużywa :material, więc nie może go jednocześnie produkować.",
+    "That item was already removed.": "Ten element został już usunięty."
 }

--- a/backend/tests/Feature/Web/StaleDeleteTest.php
+++ b/backend/tests/Feature/Web/StaleDeleteTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Deleting an admin record that is already gone (soft-deleted in another tab, a
+ * stale list, a double submit) must not dump a bare 404 — the delete's intent is
+ * already satisfied, so the app bounces back to the list with an info message.
+ * Handled centrally in bootstrap/app.php for every admin CRUD resource.
+ */
+class StaleDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    public function test_deleting_an_already_removed_record_redirects_with_a_message_not_404(): void
+    {
+        $customer = Customer::factory()->create();
+        $customer->delete(); // already soft-deleted
+
+        // A second delete (stale list / other tab) must not 404.
+        $this->actingAs($this->admin)
+            ->from('/admin/customers')
+            ->delete("/admin/customers/{$customer->id}")
+            ->assertRedirect('/admin/customers')
+            ->assertSessionHas('info');
+    }
+
+    public function test_a_real_delete_still_works(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $this->actingAs($this->admin)
+            ->from('/admin/customers')
+            ->delete("/admin/customers/{$customer->id}")
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertSoftDeleted($customer);
+    }
+}


### PR DESCRIPTION
New release :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when attempting to delete an item that was already removed.
  * Users are redirected to the relevant list with an informational message instead of seeing a 404 error.
  * Normal deletions continue to show a success message.

* **Documentation**
  * Added an unreleased changelog entry describing the improved deletion behavior.

* **Localization**
  * Added translations for the already-removed item notification and updated Polish wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->