### PR TITLE
chore(db): upgrade bundled PostgreSQL 17 → 18 (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   - **Right where you already work.** An **Engineering documents** panel on the Material and Product type pages lists every attached file with type and status badges. Authorized users get upload, download and lifecycle controls; everyone else sees a read-only list.
   - Access is permission-gated (**view** vs **manage engineering documents**), documents are **soft-deletable** with full audit + Trash, and the feature ships with backend and frontend test coverage.
 
+### Changed
+- **PostgreSQL 18** *([#96](https://github.com/Mes-Open/OpenMes/issues/96))* — the bundled database image moves from `postgres:17-alpine` to `postgres:18-alpine`. Logical-replication settings (`wal_level=logical`, replication slots/senders) and the app-level immutable audit log are unchanged and verified on 18. **Fresh installs** pick this up automatically. **Existing deployments:** a major PostgreSQL version cannot reuse a 17 data directory in place — dump on 17 and restore into 18 (`pg_dumpall` / `pg_restore`) during a maintenance window before pulling the new image. Minimum supported server stays PostgreSQL 14+.
+
 ## [0.19.0] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Laravel](https://img.shields.io/badge/Laravel-12-FF2D20?logo=laravel&logoColor=white)](https://laravel.com)
 [![Livewire](https://img.shields.io/badge/Livewire-4-4E56A6?logo=livewire&logoColor=white)](https://livewire.laravel.com)
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17+-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18+-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org)
 [![ISA-95](https://img.shields.io/badge/ISA--95-compatible-blueviolet)](./docs/isa95.md)
 
 **🚀 [Try the live demo → demo-2.getopenmes.com](https://demo.getopenmes.com/register)**
@@ -221,7 +221,7 @@ OpenMES uses a **dead-simple** Laravel monolith architecture:
 - **Frontend**: Tailwind CSS 4 + Alpine.js for interactivity
 - **Real-time**: Livewire 4 for dynamic components
 - **Charts**: Chart.js for analytics
-- **Database**: PostgreSQL 17+ with immutable audit logs
+- **Database**: PostgreSQL 18+ with immutable audit logs
 - **Deployment**: Docker Compose (2 containers only!)
 
 ### Why This Architecture?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: ${OPENMES_NAME_PREFIX:-openmmes}-postgres
     command:
       - "postgres"
@@ -15,7 +15,13 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-openmmes_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-openmmes_secret}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # PostgreSQL 18+ images store data in a major-version subdirectory and
+      # expect the mount ONE level up (at /var/lib/postgresql, not /…/data);
+      # mounting the old /…/data path makes the 18 image refuse to start.
+      # (docker-library/postgres#1259.) Existing pre-18 deployments must
+      # dump/restore into a fresh volume — see the PostgreSQL 18 note in the
+      # CHANGELOG — the data does not carry over in place.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test:
         [

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ This document is intended for developers who want to contribute to OpenMES, buil
 | Backend | Laravel 12, PHP 8.3 |
 | Frontend | Blade templates, Alpine.js, Tailwind CSS 4 |
 | Reactive components | Livewire 4 |
-| Database | PostgreSQL 14+ |
+| Database | PostgreSQL 18 (ships this; 14+ supported) |
 | Auth | Laravel Sanctum (session + token) |
 | Roles | Spatie Laravel Permission |
 | Asset pipeline | Vite |


### PR DESCRIPTION
Closes #96 (image/config/docs scope — in-place data-migration runbook intentionally out of scope per request; fresh installs + dump/restore only).

## Changes
- `docker-compose.yml`: `postgres:17-alpine` → **`postgres:18-alpine`**.
- `docker-compose.yml`: data volume mount `/var/lib/postgresql/data` → **`/var/lib/postgresql`**. The PG18 official image stores data in a major-version subdirectory and **refuses to start** against the old `/…/data` mount ([docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)) — the tag bump alone is not enough.
- README badge + `docs/development.md` bumped to PostgreSQL 18 (minimum supported stays **14+**).
- CHANGELOG entry incl. the existing-deployment note (dump on 17 → restore into 18; a major version can't reuse the 17 data dir in place).

## Verified end-to-end on a fresh PG18 stack
- `postgres:18.4-alpine` boots with the logical-replication flags → `wal_level=logical` ✓
- Full migration set + seeders + admin account run cleanly ✓ (incl. #179 `engineering_documents`)
- `PGDATA` = `/var/lib/postgresql/18/docker` (new version subdir) ✓
- App-level immutable `audit_logs` intact ✓ (audit immutability is app-level, not a DB trigger — unaffected by the PG version)

## Out of scope (per request)
The in-place `pg_upgrade` runbook for migrating an existing 17 data volume. Existing deployments dump/restore into a fresh volume; the changed mount path is compatible with that.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)