### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-16
+
 ### Added
 - **Simulated machines, so the shift monitor can be driven without hardware** *(dev / demo)* — three Modbus TCP machines and their pollers, on an opt-in compose profile:
 

--- a/backend/config/version.php
+++ b/backend/config/version.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'current' => 'v0.19.0',
+    'current' => 'v0.20.0',
     'archive_url' => env('UPDATE_ARCHIVE_URL', 'https://github.com/Mes-Open/OpenMes/archive/refs/tags/{version}.zip'),
 ];


### PR DESCRIPTION
Stamps the release: `CHANGELOG.md` `[Unreleased]` → `## [0.20.0] - 2026-08-16` (+ fresh empty `[Unreleased]`), and `backend/config/version.php` → `v0.20.0`.

After this merges to `develop`, the release flow is: merge `develop` → `main`, tag `v0.20.0` on `main`, and publish the GitHub Release with the drafted notes.

**What v0.20.0 contains** (highlights):
- **#243 (@Svannte)** — Live Shift Monitor + Line Overview, simulated machines, work-order detail rebuilt with in-place routing, work-order list overhaul (infinite scroll, bulk actions, deadline countdowns, status badges, stepper, breadcrumbs, Lucide icons), Alerts as real tables, supervisor section split, 10 shift-monitor fixes.
- **#182** controlled production stops & change requests · **#99** partial consumption/returns/reclassification · **#52** ISA-95 step workstation types & standard/actual times.
- **#179** engineering CAD documents · **#212** warehouse + ERP master-data/stock sync.
- Localisation (202 strings, Vietnamese) + plant timezone in the install wizard.

All additive / non-breaking.