### PR TITLE
feat(steps): equipment key:value parameters per process-template step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Equipment parameters on process-template steps** *(admin / API)* — each step can now carry a free-form `key:value` recipe (temperature, humidity, pressure, sample size…) that an external client reads to drive equipment. Set them in the step editor (a key/value row editor beside the ISA-95 fields). A linked Process Segment supplies defaults; the step's own values override them key by key (`effectiveParameters()`). The values are frozen onto a work order's `process_snapshot` (so `GET /api/v1/work-orders/{id}` exposes the exact recipe each order was built with) **and** readable live from the current template (`GET /api/v1/process-templates/{id}`). Nullable and additive — existing steps and workflows are unaffected.
+
 ## [0.20.0] - 2026-08-16
 
 ### Added

--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
@@ -113,6 +113,7 @@ class ProcessTemplateManagementController extends Controller
                     'run_time_per_unit_minutes' => $s->run_time_per_unit_minutes,
                     'workstation_id' => $s->workstation_id,
                     'workstation_type_id' => $s->workstation_type_id,
+                    'parameters' => $s->parameters ?? [],
                     'process_segment_id' => $s->process_segment_id,
                     'is_optional' => (bool) $s->is_optional,
                     'variant_group' => $s->variant_group,

--- a/backend/app/Http/Requests/Api/V1/StoreTemplateStepRequest.php
+++ b/backend/app/Http/Requests/Api/V1/StoreTemplateStepRequest.php
@@ -21,6 +21,8 @@ class StoreTemplateStepRequest extends FormRequest
             'estimated_duration_minutes' => ['nullable', 'integer', 'min:0'],
             'setup_time_minutes' => ['nullable', 'integer', 'min:0'],
             'run_time_per_unit_minutes' => ['nullable', 'numeric', 'min:0'],
+            'parameters' => ['nullable', 'array'],
+            'parameters.*' => ['nullable', 'string', 'max:1000'],
             'required_operators' => ['nullable', 'integer', 'min:1'],
             'workstation_id' => ['nullable', 'integer', 'exists:workstations,id'],
             'workstation_type_id' => ['nullable', 'integer', Rule::exists('workstation_types', 'id')->where('is_active', true)->whereNull('deleted_at')],

--- a/backend/app/Http/Requests/Api/V1/UpdateTemplateStepRequest.php
+++ b/backend/app/Http/Requests/Api/V1/UpdateTemplateStepRequest.php
@@ -20,6 +20,8 @@ class UpdateTemplateStepRequest extends FormRequest
             'estimated_duration_minutes' => ['sometimes', 'nullable', 'integer', 'min:0'],
             'setup_time_minutes' => ['sometimes', 'nullable', 'integer', 'min:0'],
             'run_time_per_unit_minutes' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'parameters' => ['sometimes', 'nullable', 'array'],
+            'parameters.*' => ['nullable', 'string', 'max:1000'],
             'required_operators' => ['sometimes', 'nullable', 'integer', 'min:1'],
             'workstation_id' => ['sometimes', 'nullable', 'integer', 'exists:workstations,id'],
             'workstation_type_id' => ['sometimes', 'nullable', 'integer', Rule::exists('workstation_types', 'id')->where('is_active', true)->whereNull('deleted_at')],

--- a/backend/app/Http/Requests/Web/Admin/TemplateStepRequest.php
+++ b/backend/app/Http/Requests/Web/Admin/TemplateStepRequest.php
@@ -26,6 +26,9 @@ abstract class TemplateStepRequest extends FormRequest
             'estimated_duration_minutes' => 'nullable|integer|min:0',
             'setup_time_minutes' => 'nullable|integer|min:0',
             'run_time_per_unit_minutes' => 'nullable|numeric|min:0',
+            // Equipment key:value parameters (temperature, humidity, …) — a flat map.
+            'parameters' => 'nullable|array',
+            'parameters.*' => 'nullable|string|max:1000',
             'required_operators' => 'nullable|integer|min:1',
             'workstation_id' => 'nullable|exists:workstations,id',
             'workstation_type_id' => ['nullable', Rule::exists('workstation_types', 'id')->where('is_active', true)->whereNull('deleted_at')],

--- a/backend/app/Models/ProcessTemplate.php
+++ b/backend/app/Models/ProcessTemplate.php
@@ -104,6 +104,7 @@ class ProcessTemplate extends Model
                     'workstation_id' => $step->workstation_id,
                     'workstation_name' => $step->workstation?->name,
                     'workstation_type_id' => $step->effectiveWorkstationType(),
+                    'parameters' => $step->effectiveParameters(),
                     'is_optional' => (bool) $step->is_optional,
                     'variant_group' => $step->variant_group,
                     'is_default_variant' => (bool) $step->is_default_variant,

--- a/backend/app/Models/TemplateStep.php
+++ b/backend/app/Models/TemplateStep.php
@@ -29,6 +29,7 @@ class TemplateStep extends Model
         'workstation_type_id',
         'setup_time_minutes',
         'run_time_per_unit_minutes',
+        'parameters',
         'is_optional',
         'variant_group',
         'is_default_variant',
@@ -41,6 +42,7 @@ class TemplateStep extends Model
             'estimated_duration_minutes' => 'integer',
             'setup_time_minutes' => 'integer',
             'run_time_per_unit_minutes' => 'decimal:2',
+            'parameters' => 'array',
             'required_operators' => 'integer',
             'min_duration_minutes' => 'integer',
             'requires_confirmation' => 'boolean',
@@ -150,5 +152,21 @@ class TemplateStep extends Model
     public function effectiveWorkstationType(): ?int
     {
         return $this->workstation_type_id ?? $this->processSegment?->workstation_type_id;
+    }
+
+    /**
+     * Resolve the effective equipment parameters — the linked Process Segment
+     * supplies defaults, the step's own values override them key by key. Both
+     * absent yields an empty map. Used by the work-order snapshot so a client can
+     * read the recipe an external system needs to drive equipment.
+     *
+     * @return array<string, mixed>
+     */
+    public function effectiveParameters(): array
+    {
+        return array_merge(
+            $this->processSegment?->parameters ?? [],
+            $this->parameters ?? [],
+        );
     }
 }

--- a/backend/app/Services/ProcessTemplate/SnapshotService.php
+++ b/backend/app/Services/ProcessTemplate/SnapshotService.php
@@ -39,6 +39,7 @@ class SnapshotService
                     'required_operators' => $step->effectiveRequiredOperators(),
                     'workstation_id' => $step->workstation_id,
                     'workstation_type_id' => $step->effectiveWorkstationType(),
+                    'parameters' => $step->effectiveParameters(),
                 ];
             })->toArray(),
             'bom' => $template->bomItems->map(function ($item) {

--- a/backend/database/migrations/2026_08_18_100000_add_parameters_to_template_steps.php
+++ b/backend/database/migrations/2026_08_18_100000_add_parameters_to_template_steps.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Equipment parameters on a process-template step — a free-form key:value recipe
+ * (temperature, humidity, pressure, sample size…) that an external client reads
+ * via API to drive equipment. Mirrors process_segments.parameters. Nullable and
+ * additive; existing steps are unaffected.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('template_steps', function (Blueprint $table) {
+            $table->json('parameters')->nullable()->after('run_time_per_unit_minutes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('template_steps', function (Blueprint $table) {
+            $table->dropColumn('parameters');
+        });
+    }
+};

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5628,5 +5628,9 @@
     "Material returned to stock": "Material returned to stock",
     "Material reclassified": "Material reclassified",
     "Work order :code created.": "Work order :code created.",
-    "Customers & order data": "Customers & order data"
+    "Customers & order data": "Customers & order data",
+    "Equipment parameters": "Equipment parameters",
+    "Key:value settings the equipment needs (e.g. temperature, humidity). Read via API.": "Key:value settings the equipment needs (e.g. temperature, humidity). Read via API.",
+    "key (e.g. temperature_c)": "key (e.g. temperature_c)",
+    "+ Add parameter": "+ Add parameter"
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5628,5 +5628,9 @@
     "Material returned to stock": "Materiał zwrócony do magazynu",
     "Material reclassified": "Materiał przeklasyfikowany",
     "Work order :code created.": "Zlecenie :code utworzone.",
-    "Customers & order data": "Klienci i dane zamówień"
+    "Customers & order data": "Klienci i dane zamówień",
+    "Equipment parameters": "Parametry sprzętu",
+    "Key:value settings the equipment needs (e.g. temperature, humidity). Read via API.": "Ustawienia klucz:wartość potrzebne maszynie (np. temperatura, wilgotność). Odczyt przez API.",
+    "key (e.g. temperature_c)": "klucz (np. temperature_c)",
+    "+ Add parameter": "+ Dodaj parametr"
 }

--- a/backend/resources/js/Pages/admin/process-templates/Show.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Show.jsx
@@ -125,6 +125,64 @@ function Isa95StepFields({ data, setData, workstationTypes = [] }) {
     );
 }
 
+// Equipment key:value parameters for a step (temperature, humidity, …). Edited as
+// rows and stored as a flat object; a client reads it from the work-order snapshot
+// (or the live template) to drive equipment.
+function ParametersEditor({ value = {}, onChange }) {
+    const rows = Object.entries(value ?? {});
+
+    const emit = (pairs) => {
+        const obj = {};
+        for (const [k, v] of pairs) {
+            if (String(k).trim() !== '') obj[k] = v;
+        }
+        onChange(obj);
+    };
+    const setRow = (i, key, val) => emit(rows.map((r, idx) => (idx === i ? [key, val] : r)));
+    const addRow = () => onChange({ ...(value ?? {}), '': '' });
+    const removeRow = (i) => emit(rows.filter((_, idx) => idx !== i));
+
+    return (
+        <div className="md:col-span-2 bg-om-panel rounded-om-sm p-3 border border-om-line">
+            <label className="form-label">{__('Equipment parameters')}</label>
+            <p className="text-xs text-om-muted mb-2">
+                {__('Key:value settings the equipment needs (e.g. temperature, humidity). Read via API.')}
+            </p>
+            <div className="space-y-2">
+                {rows.map(([k, v], i) => (
+                    <div key={i} className="flex gap-2">
+                        <input
+                            type="text"
+                            value={k}
+                            onChange={(e) => setRow(i, e.target.value, v)}
+                            className="form-input w-1/2"
+                            placeholder={__('key (e.g. temperature_c)')}
+                        />
+                        <input
+                            type="text"
+                            value={v ?? ''}
+                            onChange={(e) => setRow(i, k, e.target.value)}
+                            className="form-input w-1/2"
+                            placeholder={__('value')}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => removeRow(i)}
+                            className="px-2 text-om-muted hover:text-om-blocked"
+                            title={__('Remove')}
+                        >
+                            ×
+                        </button>
+                    </div>
+                ))}
+            </div>
+            <button type="button" onClick={addRow} className="mt-2 text-xs text-om-accent hover:underline">
+                {__('+ Add parameter')}
+            </button>
+        </div>
+    );
+}
+
 /* ------------------------------------------------------------------ */
 /* Add-step inline form                                                  */
 /* ------------------------------------------------------------------ */
@@ -139,6 +197,7 @@ function AddStepForm({ productType, processTemplate, processSegments, workstatio
         required_operators: '',
         workstation_id: '',
         workstation_type_id: '',
+        parameters: {},
         process_segment_id: '',
         is_optional: false,
         variant_group: '',
@@ -264,6 +323,7 @@ function AddStepForm({ productType, processTemplate, processSegments, workstatio
                     </div>
 
                     <Isa95StepFields data={data} setData={setData} workstationTypes={workstationTypes} />
+                    <ParametersEditor value={data.parameters} onChange={(v) => setData('parameters', v)} />
                     <OptionalVariantFields data={data} setData={setData} errors={errors} />
                 </div>
 
@@ -294,6 +354,7 @@ function EditStepForm({ step, productType, processTemplate, processSegments, wor
         required_operators: step.required_operators != null ? String(step.required_operators) : '',
         workstation_id: step.workstation_id != null ? String(step.workstation_id) : '',
         workstation_type_id: step.workstation_type_id != null ? String(step.workstation_type_id) : '',
+        parameters: step.parameters ?? {},
         process_segment_id: step.process_segment_id != null ? String(step.process_segment_id) : '',
         is_optional: !!step.is_optional,
         variant_group: step.variant_group ?? '',
@@ -397,6 +458,7 @@ function EditStepForm({ step, productType, processTemplate, processSegments, wor
                 </div>
 
                 <Isa95StepFields data={data} setData={setData} workstationTypes={workstationTypes} />
+                <ParametersEditor value={data.parameters} onChange={(v) => setData('parameters', v)} />
                 <OptionalVariantFields data={data} setData={setData} errors={errors} />
             </div>
 

--- a/backend/tests/Feature/Api/ProcessTemplateApiTest.php
+++ b/backend/tests/Feature/Api/ProcessTemplateApiTest.php
@@ -14,8 +14,11 @@ class ProcessTemplateApiTest extends TestCase
     use RefreshDatabase;
 
     protected User $admin;
+
     protected User $operator;
+
     protected string $adminToken;
+
     protected string $operatorToken;
 
     protected function setUp(): void
@@ -32,8 +35,15 @@ class ProcessTemplateApiTest extends TestCase
         $this->operatorToken = $this->operator->createToken('test')->plainTextToken;
     }
 
-    private function authAdmin() { return $this->withHeader('Authorization', "Bearer {$this->adminToken}"); }
-    private function authOperator() { return $this->withHeader('Authorization', "Bearer {$this->operatorToken}"); }
+    private function authAdmin()
+    {
+        return $this->withHeader('Authorization', "Bearer {$this->adminToken}");
+    }
+
+    private function authOperator()
+    {
+        return $this->withHeader('Authorization', "Bearer {$this->operatorToken}");
+    }
 
     public function test_can_list_templates_for_product_type(): void
     {
@@ -82,6 +92,33 @@ class ProcessTemplateApiTest extends TestCase
         $response->assertStatus(201)
             ->assertJsonPath('data.name', 'Cut metal')
             ->assertJsonPath('data.step_number', 1);
+    }
+
+    public function test_admin_can_set_and_read_equipment_parameters_via_api(): void
+    {
+        $pt = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $pt->id]);
+
+        $this->authAdmin()->postJson("/api/v1/process-templates/{$template->id}/steps", [
+            'name' => 'Reflow oven',
+            'parameters' => ['temperature_c' => '250', 'humidity_pct' => '40'],
+        ])->assertStatus(201)
+            ->assertJsonPath('data.parameters.temperature_c', '250');
+
+        // Live read: the current template exposes the params for equipment control.
+        $this->authAdmin()->getJson("/api/v1/process-templates/{$template->id}")
+            ->assertOk()
+            ->assertJsonPath('data.steps.0.parameters.humidity_pct', '40');
+    }
+
+    public function test_parameters_must_be_an_object(): void
+    {
+        $pt = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $pt->id]);
+
+        $this->authAdmin()->postJson("/api/v1/process-templates/{$template->id}/steps", [
+            'name' => 'Bad', 'parameters' => 'not-an-array',
+        ])->assertStatus(422)->assertJsonValidationErrors('parameters');
     }
 
     public function test_step_numbers_auto_increment(): void

--- a/backend/tests/Feature/Web/Admin/ProcessTemplateStepWebTest.php
+++ b/backend/tests/Feature/Web/Admin/ProcessTemplateStepWebTest.php
@@ -95,6 +95,21 @@ class ProcessTemplateStepWebTest extends TestCase
         ]);
     }
 
+    public function test_admin_can_set_equipment_parameters_on_a_step(): void
+    {
+        [$pt, $tpl] = $this->template();
+
+        $this->actingAs($this->admin)
+            ->post($this->base($pt, $tpl).'/steps', [
+                'name' => 'Reflow oven',
+                'parameters' => ['temperature_c' => '250', 'humidity_pct' => '40'],
+            ])->assertRedirect();
+
+        $step = \App\Models\TemplateStep::where('process_template_id', $tpl->id)
+            ->where('name', 'Reflow oven')->firstOrFail();
+        $this->assertSame(['temperature_c' => '250', 'humidity_pct' => '40'], $step->parameters);
+    }
+
     public function test_admin_can_update_step(): void
     {
         [$pt, $tpl] = $this->template();

--- a/backend/tests/Unit/Services/SnapshotServiceTest.php
+++ b/backend/tests/Unit/Services/SnapshotServiceTest.php
@@ -78,6 +78,36 @@ class SnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('workstation_type_id', $step);
         $this->assertArrayHasKey('setup_time_minutes', $step);
         $this->assertArrayHasKey('run_time_per_unit_minutes', $step);
+        // Equipment parameters (Feature A).
+        $this->assertArrayHasKey('parameters', $step);
+    }
+
+    public function test_snapshot_step_carries_equipment_parameters(): void
+    {
+        $template = ProcessTemplate::factory()->withSteps(1)->create();
+        $template->steps()->first()->update(['parameters' => ['temperature_c' => '250']]);
+
+        $step = $this->service->createSnapshot($template->fresh())['steps'][0];
+
+        $this->assertSame(['temperature_c' => '250'], $step['parameters']);
+    }
+
+    public function test_snapshot_parameters_merge_segment_defaults_with_step_overrides(): void
+    {
+        $segment = \App\Models\ProcessSegment::factory()->create([
+            'parameters' => ['temperature_c' => '200', 'humidity_pct' => '40'],
+        ]);
+
+        $template = ProcessTemplate::factory()->withSteps(1)->create();
+        // Step overrides temperature, inherits humidity from the segment.
+        $template->steps()->first()->update([
+            'process_segment_id' => $segment->id,
+            'parameters' => ['temperature_c' => '250'],
+        ]);
+
+        $step = $this->service->createSnapshot($template->fresh())['steps'][0];
+
+        $this->assertSame(['temperature_c' => '250', 'humidity_pct' => '40'], $step['parameters']);
     }
 
     public function test_snapshot_step_carries_isa95_standard_times(): void


### PR DESCRIPTION
**Feature A** of the step-parameters / typed-outputs plan. Lets a process-template step carry a free-form `key:value` recipe (temperature, humidity, pressure, sample size…) that an external client reads via API to drive equipment.

## What & why
Recipes only captured durations/times before. Some steps are really defined by equipment settings. This adds a per-step parameter map — set by admins, read by machines.

## How
- **Schema/model:** nullable `json parameters` on `template_steps` (mirrors `process_segments.parameters`); `TemplateStep` fillable + `array` cast + `effectiveParameters()` — a linked **Process Segment supplies defaults**, the step's own values **override key by key** (same fallback idiom as `effectiveWorkstationType()` from #52).
- **Frozen (traceability):** both snapshot builders (`ProcessTemplate::toSnapshot` + `SnapshotService::createSnapshot`) carry `parameters` per step, so `GET /api/v1/work-orders/{id}` exposes the exact recipe an order was built with.
- **Live:** `GET /api/v1/process-templates/{id}` returns the current template's params (free once fillable+cast) — for a client that wants the latest settings.
- **Validation:** `nullable|array` (+ scalar values) added to the web and both API step Form Requests.
- **Admin UI:** a reusable `ParametersEditor` (key/value rows) in the add/edit step forms, beside the ISA-95 fields.

## Tests
Admin sets params (web); snapshot carry + **segment-default/step-override merge**; API set + **live read** + 422 on non-object. i18n en/pl parity (+4).

**Verification:** backend `php artisan test` — **2470 passed**; vitest — 35; `npm run build` — OK; Pint clean on changed files.

Additive / non-breaking. **Feature B** (typed operator outputs incl. picture) follows as a separate PR.