### PR TITLE
feat(bom): add a product type as a BOM component (sub-assembly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Product types as Bill-of-Materials components** *(admin)* — a BOM line can now be a manufactured **product type** (a sub-assembly), not only a material. In the BOM editor a Material / Product type switch picks the component kind; product-type lines carry the same quantity-per-unit, step, scrap %, consumption timing and notes as materials. A product type can't be a component of itself, and each appears once per template. Lines are captured in the work-order snapshot as sub-assembly references; they're a simple component reference (they don't explode into their own BOM) and are skipped by the material stock/consumption engine. Additive — existing material BOMs are unaffected.
+
 ## [0.21.0] - 2026-08-21
 
 ### Added

--- a/backend/app/Http/Controllers/Web/Admin/BomManagementController.php
+++ b/backend/app/Http/Controllers/Web/Admin/BomManagementController.php
@@ -26,6 +26,12 @@ class BomManagementController extends Controller
 
         $bomItems = $this->bomService->listForTemplate($processTemplate);
         $materials = Material::active()->with('materialType')->orderBy('name')->get();
+        // Product types that can be added as sub-assembly components — every active
+        // one except this template's own product type (a product can't contain itself).
+        $productTypes = ProductType::active()
+            ->where('id', '!=', $productType->id)
+            ->orderBy('name')
+            ->get(['id', 'code', 'name', 'unit_of_measure']);
         $steps = $processTemplate->steps()->orderBy('step_number')->get();
 
         return Inertia::render('admin/process-templates/Bom', [
@@ -35,22 +41,31 @@ class BomManagementController extends Controller
                 'name' => $processTemplate->name,
                 'version' => $processTemplate->version,
             ],
-            'bomItems' => $bomItems->map(fn ($item) => [
-                'id' => $item->id,
-                'material_name' => $item->material->name,
-                'material_code' => $item->material->code,
-                'material_type_name' => $item->material->materialType->name,
-                'material_type_code' => $item->material->materialType->code,
-                'unit_of_measure' => $item->material->unit_of_measure,
-                'tracking_type' => $item->material->tracking_type,
-                'template_step_id' => $item->template_step_id,
-                'step_number' => $item->templateStep?->step_number,
-                'step_name' => $item->templateStep?->name,
-                'quantity_per_unit' => $item->quantity_per_unit,
-                'scrap_percentage' => $item->scrap_percentage,
-                'consumed_at' => $item->consumed_at,
-                'notes' => $item->notes,
-            ]),
+            'bomItems' => $bomItems->map(function ($item) {
+                $isProductType = $item->component_kind === 'product_type';
+
+                return [
+                    'id' => $item->id,
+                    'component_kind' => $item->component_kind,
+                    // Generic component name/code the table renders for both kinds.
+                    'component_name' => $isProductType ? $item->productType?->name : $item->material?->name,
+                    'component_code' => $isProductType ? $item->productType?->code : $item->material?->code,
+                    'material_id' => $item->material_id,
+                    'product_type_id' => $item->product_type_id,
+                    // Material-only metadata (null for product-type lines).
+                    'material_type_name' => $item->material?->materialType->name,
+                    'material_type_code' => $item->material?->materialType->code,
+                    'unit_of_measure' => $isProductType ? $item->productType?->unit_of_measure : $item->material?->unit_of_measure,
+                    'tracking_type' => $item->material?->tracking_type,
+                    'template_step_id' => $item->template_step_id,
+                    'step_number' => $item->templateStep?->step_number,
+                    'step_name' => $item->templateStep?->name,
+                    'quantity_per_unit' => $item->quantity_per_unit,
+                    'scrap_percentage' => $item->scrap_percentage,
+                    'consumed_at' => $item->consumed_at,
+                    'notes' => $item->notes,
+                ];
+            }),
             'materials' => $materials->map(fn ($m) => [
                 'id' => $m->id,
                 'code' => $m->code,
@@ -58,6 +73,12 @@ class BomManagementController extends Controller
                 'material_type_name' => $m->materialType->name,
                 'unit_of_measure' => $m->unit_of_measure,
                 'default_scrap_percentage' => $m->default_scrap_percentage,
+            ]),
+            'productTypes' => $productTypes->map(fn ($p) => [
+                'id' => $p->id,
+                'code' => $p->code,
+                'name' => $p->name,
+                'unit_of_measure' => $p->unit_of_measure,
             ]),
             'steps' => $steps->map(fn ($s) => [
                 'id' => $s->id,
@@ -73,19 +94,55 @@ class BomManagementController extends Controller
             abort(404);
         }
 
+        // A line is exactly one of material / product-type. `required_without` +
+        // `prohibits` enforces exactly-one; `component_kind` (sent by the UI) is
+        // ignored so older material-only callers keep working.
         $validated = $request->validate([
-            'material_id' => 'required|exists:materials,id|unique:bom_items,material_id,NULL,id,process_template_id,'.$processTemplate->id,
+            'material_id' => [
+                'required_without:product_type_id',
+                'prohibits:product_type_id',
+                'nullable',
+                'exists:materials,id',
+                \Illuminate\Validation\Rule::unique('bom_items', 'material_id')
+                    ->where('process_template_id', $processTemplate->id)
+                    ->whereNull('deleted_at'),
+            ],
+            'product_type_id' => [
+                'required_without:material_id',
+                'nullable',
+                'exists:product_types,id',
+                // A product can't be a component of itself.
+                \Illuminate\Validation\Rule::notIn([$productType->id]),
+                \Illuminate\Validation\Rule::unique('bom_items', 'product_type_id')
+                    ->where('process_template_id', $processTemplate->id)
+                    ->whereNull('deleted_at'),
+            ],
             'template_step_id' => 'nullable|exists:template_steps,id',
             'quantity_per_unit' => 'required|numeric|gt:0',
             'scrap_percentage' => 'nullable|numeric|min:0|max:100',
             'consumed_at' => 'nullable|in:start,during,end',
             'notes' => 'nullable|string',
+        ], [
+            'material_id.unique' => __('This material is already in the BOM for this template.'),
+            'product_type_id.unique' => __('This product type is already in the BOM for this template.'),
+            'product_type_id.not_in' => __('A product type cannot be a component of itself.'),
         ]);
 
-        $this->bomService->addItem($processTemplate, $validated);
+        // Persist only the component reference that was set.
+        $data = [
+            'material_id' => $validated['material_id'] ?? null,
+            'product_type_id' => $validated['product_type_id'] ?? null,
+            'template_step_id' => $validated['template_step_id'] ?? null,
+            'quantity_per_unit' => $validated['quantity_per_unit'],
+            'scrap_percentage' => $validated['scrap_percentage'] ?? null,
+            'consumed_at' => $validated['consumed_at'] ?? null,
+            'notes' => $validated['notes'] ?? null,
+        ];
+
+        $this->bomService->addItem($processTemplate, $data);
 
         return redirect()->route('admin.product-types.process-templates.bom', [$productType, $processTemplate])
-            ->with('success', 'Material added to BOM.');
+            ->with('success', __('Component added to BOM.'));
     }
 
     public function update(Request $request, ProductType $productType, ProcessTemplate $processTemplate, BomItem $bomItem)

--- a/backend/app/Models/BomItem.php
+++ b/backend/app/Models/BomItem.php
@@ -16,6 +16,7 @@ class BomItem extends Model
         'process_template_id',
         'template_step_id',
         'material_id',
+        'product_type_id',
         'quantity_per_unit',
         'scrap_percentage',
         'consumed_at',
@@ -47,6 +48,23 @@ class BomItem extends Model
     public function material(): BelongsTo
     {
         return $this->belongsTo(Material::class);
+    }
+
+    /**
+     * A BOM line may reference a manufactured product type (sub-assembly)
+     * instead of a material.
+     */
+    public function productType(): BelongsTo
+    {
+        return $this->belongsTo(ProductType::class);
+    }
+
+    /**
+     * 'material' or 'product_type' — which kind of component this line is.
+     */
+    public function getComponentKindAttribute(): string
+    {
+        return $this->product_type_id ? 'product_type' : 'material';
     }
 
     /**

--- a/backend/app/Models/ProcessTemplate.php
+++ b/backend/app/Models/ProcessTemplate.php
@@ -117,8 +117,30 @@ class ProcessTemplate extends Model
                 ];
             })->toArray(),
             'bom' => $this->bomItems->map(function ($item) {
+                // Product-type lines are sub-assembly references (no material).
+                if ($item->component_kind === 'product_type') {
+                    return [
+                        'component_kind' => 'product_type',
+                        'material_id' => null,
+                        'product_type_id' => $item->product_type_id,
+                        'material_code' => $item->productType?->code,
+                        'material_name' => $item->productType?->name,
+                        'material_type' => 'product_type',
+                        'tracking_type' => null,
+                        'unit_of_measure' => $item->productType?->unit_of_measure,
+                        'quantity_per_unit' => (float) $item->quantity_per_unit,
+                        'scrap_percentage' => (float) $item->scrap_percentage,
+                        'consumed_at' => $item->consumed_at,
+                        'step_number' => $item->templateStep?->step_number,
+                        'external_code' => null,
+                        'external_system' => null,
+                    ];
+                }
+
                 return [
+                    'component_kind' => 'material',
                     'material_id' => $item->material_id,
+                    'product_type_id' => null,
                     'material_code' => $item->material->code,
                     'material_name' => $item->material->name,
                     'material_type' => $item->material->materialType?->code,

--- a/backend/app/Services/Material/BomExplosionService.php
+++ b/backend/app/Services/Material/BomExplosionService.php
@@ -109,7 +109,10 @@ class BomExplosionService
 
         $stack[] = (int) $template->getKey();
 
+        // Product-type BOM lines are simple component references, not materials —
+        // they don't explode into a material tree, so the material engine skips them.
         $items = $template->bomItems()
+            ->whereNotNull('material_id')
             ->with(['material.materialType', 'material.producingTemplate', 'templateStep'])
             ->orderBy('sort_order')
             ->get();

--- a/backend/app/Services/Material/BomService.php
+++ b/backend/app/Services/Material/BomService.php
@@ -104,7 +104,11 @@ class BomService
      */
     public function calculateRequirements(ProcessTemplate $template, float $productionQty): array
     {
-        $items = $this->listForTemplate($template);
+        // Product-type lines are sub-assembly references, not stockable materials —
+        // they don't contribute a material requirement.
+        $items = $this->listForTemplate($template)
+            ->filter(fn (BomItem $item) => $item->material_id !== null)
+            ->values();
 
         return $items->map(function (BomItem $item) use ($productionQty) {
             $baseQty = round($item->quantity_per_unit * $productionQty, 4);
@@ -131,7 +135,12 @@ class BomService
      */
     public function calculateFromSnapshot(array $snapshot, float $productionQty): array
     {
-        $bom = $snapshot['bom'] ?? [];
+        // Skip product-type (sub-assembly) snapshot entries — no material to stock.
+        // Entries without an explicit kind are legacy material lines, so keep them.
+        $bom = array_values(array_filter(
+            $snapshot['bom'] ?? [],
+            fn ($item) => ($item['component_kind'] ?? 'material') !== 'product_type',
+        ));
 
         return array_map(function ($item) use ($productionQty) {
             $baseQty = round($item['quantity_per_unit'] * $productionQty, 4);

--- a/backend/app/Services/Material/BomService.php
+++ b/backend/app/Services/Material/BomService.php
@@ -18,7 +18,7 @@ class BomService
     public function listForTemplate(ProcessTemplate $template): Collection
     {
         return $template->bomItems()
-            ->with(['material.materialType', 'templateStep'])
+            ->with(['material.materialType', 'productType', 'templateStep'])
             ->orderBy('sort_order')
             ->get();
     }

--- a/backend/app/Services/ProcessTemplate/SnapshotService.php
+++ b/backend/app/Services/ProcessTemplate/SnapshotService.php
@@ -19,6 +19,7 @@ class SnapshotService
                 $query->orderBy('step_number');
             },
             'bomItems.material.materialType',
+            'bomItems.productType',
             'bomItems.templateStep',
         ]);
 
@@ -43,8 +44,32 @@ class SnapshotService
                 ];
             })->toArray(),
             'bom' => $template->bomItems->map(function ($item) {
+                // Product-type lines are sub-assembly references — captured here with
+                // their name so the order shows them, but with no material fields
+                // (material_id null, so the stock/consumption engine skips them).
+                if ($item->component_kind === 'product_type') {
+                    return [
+                        'component_kind' => 'product_type',
+                        'material_id' => null,
+                        'product_type_id' => $item->product_type_id,
+                        'material_code' => $item->productType?->code,
+                        'material_name' => $item->productType?->name,
+                        'material_type' => 'product_type',
+                        'tracking_type' => null,
+                        'unit_of_measure' => $item->productType?->unit_of_measure,
+                        'quantity_per_unit' => (float) $item->quantity_per_unit,
+                        'scrap_percentage' => (float) $item->scrap_percentage,
+                        'consumed_at' => $item->consumed_at,
+                        'step_number' => $item->templateStep?->step_number,
+                        'external_code' => null,
+                        'external_system' => null,
+                    ];
+                }
+
                 return [
+                    'component_kind' => 'material',
                     'material_id' => $item->material_id,
+                    'product_type_id' => null,
                     'material_code' => $item->material->code,
                     'material_name' => $item->material->name,
                     'material_type' => $item->material->materialType->code,

--- a/backend/database/migrations/2026_08_24_120000_add_product_type_to_bom_items.php
+++ b/backend/database/migrations/2026_08_24_120000_add_product_type_to_bom_items.php
@@ -30,10 +30,26 @@ return new class extends Migration
             'CREATE UNIQUE INDEX bom_items_template_product_type_unique '.
             'ON bom_items (process_template_id, product_type_id) WHERE deleted_at IS NULL'
         );
+
+        // Enforce exactly-one component at the DB level, so a direct create()
+        // (bypassing controller validation) can't leave a line with neither or
+        // both references. SQLite can't ALTER ADD CONSTRAINT, so this guards the
+        // Postgres production database; tests + Form-request validation cover the
+        // rest.
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement(
+                'ALTER TABLE bom_items ADD CONSTRAINT bom_items_exactly_one_component_check '.
+                'CHECK ((material_id IS NULL) <> (product_type_id IS NULL))'
+            );
+        }
     }
 
     public function down(): void
     {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE bom_items DROP CONSTRAINT IF EXISTS bom_items_exactly_one_component_check');
+        }
+
         DB::statement('DROP INDEX IF EXISTS bom_items_template_product_type_unique');
 
         Schema::table('bom_items', function (Blueprint $table) {

--- a/backend/database/migrations/2026_08_24_120000_add_product_type_to_bom_items.php
+++ b/backend/database/migrations/2026_08_24_120000_add_product_type_to_bom_items.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A BOM line can now be a manufactured **product type** (a sub-assembly), not
+ * only a material. Exactly one of `material_id` / `product_type_id` is set per
+ * row (enforced in the Form-request/service layer). Product-type lines are a
+ * simple component reference — they do not explode into their own BOM.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bom_items', function (Blueprint $table) {
+            // Was NOT NULL — a product-type line carries no material.
+            $table->unsignedBigInteger('material_id')->nullable()->change();
+
+            $table->foreignId('product_type_id')->nullable()->after('material_id')
+                ->constrained('product_types')->restrictOnDelete();
+        });
+
+        // Partial unique (soft-delete aware, same rule as the material index): a
+        // given product type may appear once in a template's live BOM. Postgres
+        // and SQLite both honour the WHERE clause.
+        DB::statement(
+            'CREATE UNIQUE INDEX bom_items_template_product_type_unique '.
+            'ON bom_items (process_template_id, product_type_id) WHERE deleted_at IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS bom_items_template_product_type_unique');
+
+        Schema::table('bom_items', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('product_type_id');
+        });
+
+        Schema::table('bom_items', function (Blueprint $table) {
+            $table->unsignedBigInteger('material_id')->nullable(false)->change();
+        });
+    }
+};

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5646,5 +5646,14 @@
     "options, comma-separated": "options, comma-separated",
     "Take / upload photo": "Take / upload photo",
     "Enter value…": "Enter value…",
-    "The :attribute field must be a key:value map, not a list.": "The :attribute field must be a key:value map, not a list."
+    "The :attribute field must be a key:value map, not a list.": "The :attribute field must be a key:value map, not a list.",
+    "Add Component to BOM": "Add Component to BOM",
+    "Add Component": "Add Component",
+    "Select product type…": "Select product type…",
+    "Add a manufactured product type as a sub-assembly component.": "Add a manufactured product type as a sub-assembly component.",
+    "Remove this component from BOM?": "Remove this component from BOM?",
+    "This product type is already in the BOM for this template.": "This product type is already in the BOM for this template.",
+    "A product type cannot be a component of itself.": "A product type cannot be a component of itself.",
+    "Component added to BOM.": "Component added to BOM.",
+    "This material is already in the BOM for this template.": "This material is already in the BOM for this template."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5646,5 +5646,14 @@
     "options, comma-separated": "opcje, po przecinku",
     "Take / upload photo": "Zrób / prześlij zdjęcie",
     "Enter value…": "Wpisz wartość…",
-    "The :attribute field must be a key:value map, not a list.": "Pole :attribute musi być mapą klucz:wartość, a nie listą."
+    "The :attribute field must be a key:value map, not a list.": "Pole :attribute musi być mapą klucz:wartość, a nie listą.",
+    "Add Component to BOM": "Dodaj komponent do BOM",
+    "Add Component": "Dodaj komponent",
+    "Select product type…": "Wybierz typ produktu…",
+    "Add a manufactured product type as a sub-assembly component.": "Dodaj wytwarzany typ produktu jako komponent-podzespół.",
+    "Remove this component from BOM?": "Usunąć ten komponent z BOM?",
+    "This product type is already in the BOM for this template.": "Ten typ produktu jest już w BOM dla tego szablonu.",
+    "A product type cannot be a component of itself.": "Typ produktu nie może być komponentem samego siebie.",
+    "Component added to BOM.": "Dodano komponent do BOM.",
+    "This material is already in the BOM for this template.": "Ten materiał jest już w BOM dla tego szablonu."
 }

--- a/backend/resources/js/Pages/admin/process-templates/Bom.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Bom.jsx
@@ -72,14 +72,14 @@ function MaterialForm({ productType, processTemplate, materials, productTypes = 
                     <div className="mb-4 inline-flex rounded-lg border border-om-border overflow-hidden">
                         <button
                             type="button"
-                            onClick={() => setData('component_kind', 'material')}
+                            onClick={() => setData((d) => ({ ...d, component_kind: 'material', product_type_id: '' }))}
                             className={`px-4 py-2 text-sm font-medium ${!isProductType ? 'bg-om-accent text-white' : 'bg-om-panel text-om-muted'}`}
                         >
                             {__("Material")}
                         </button>
                         <button
                             type="button"
-                            onClick={() => setData('component_kind', 'product_type')}
+                            onClick={() => setData((d) => ({ ...d, component_kind: 'product_type', material_id: '' }))}
                             className={`px-4 py-2 text-sm font-medium ${isProductType ? 'bg-om-accent text-white' : 'bg-om-panel text-om-muted'}`}
                         >
                             {__("Product type")}

--- a/backend/resources/js/Pages/admin/process-templates/Bom.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Bom.jsx
@@ -16,10 +16,12 @@ function typeColorClass(code) {
     return TYPE_COLORS[code] ?? 'bg-om-chip text-om-ink';
 }
 
-function MaterialForm({ productType, processTemplate, materials, steps, item, onCancel }) {
+function MaterialForm({ productType, processTemplate, materials, productTypes = [], steps, item, onCancel }) {
     const isEdit = !!item;
     const form = useForm({
+        component_kind: item ? (item.component_kind ?? 'material') : 'material',
         material_id: item ? String(item.material_id ?? '') : '',
+        product_type_id: item ? String(item.product_type_id ?? '') : '',
         quantity_per_unit: item ? String(item.quantity_per_unit ?? '') : '',
         template_step_id: item && item.template_step_id != null ? String(item.template_step_id) : '',
         scrap_percentage: item ? String(item.scrap_percentage ?? '0') : '0',
@@ -29,10 +31,16 @@ function MaterialForm({ productType, processTemplate, materials, steps, item, on
 
     const { data, setData, errors, processing } = form;
 
+    const isProductType = data.component_kind === 'product_type';
     const selectedMaterial = isEdit
         ? null
         : materials.find((m) => String(m.id) === String(data.material_id));
-    const unit = isEdit ? item.unit_of_measure : selectedMaterial?.unit_of_measure;
+    const selectedProductType = isEdit
+        ? null
+        : productTypes.find((p) => String(p.id) === String(data.product_type_id));
+    const unit = isEdit
+        ? item.unit_of_measure
+        : (isProductType ? selectedProductType?.unit_of_measure : selectedMaterial?.unit_of_measure);
 
     // When a material with a default scrap % is picked, pre-fill it (only while
     // the field still holds the untouched default) and surface that it was auto-set.
@@ -57,16 +65,58 @@ function MaterialForm({ productType, processTemplate, materials, steps, item, on
     return (
         <div className="card mb-6" style={{ borderLeft: '4px solid #3b82f6' }}>
             <h3 className="text-lg font-semibold mb-4">
-                {isEdit ? `${__("Edit BOM Item")} - ${item.material_name}` : __("Add Material to BOM")}
+                {isEdit ? `${__("Edit BOM Item")} - ${item.component_name}` : __("Add Component to BOM")}
             </h3>
             <form onSubmit={submit}>
+                {!isEdit && (
+                    <div className="mb-4 inline-flex rounded-lg border border-om-border overflow-hidden">
+                        <button
+                            type="button"
+                            onClick={() => setData('component_kind', 'material')}
+                            className={`px-4 py-2 text-sm font-medium ${!isProductType ? 'bg-om-accent text-white' : 'bg-om-panel text-om-muted'}`}
+                        >
+                            {__("Material")}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setData('component_kind', 'product_type')}
+                            className={`px-4 py-2 text-sm font-medium ${isProductType ? 'bg-om-accent text-white' : 'bg-om-panel text-om-muted'}`}
+                        >
+                            {__("Product type")}
+                        </button>
+                    </div>
+                )}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     {isEdit ? (
                         <div>
-                            <label className="block text-sm font-medium text-om-muted mb-1">{__("Material")}</label>
+                            <label className="block text-sm font-medium text-om-muted mb-1">
+                                {item.component_kind === 'product_type' ? __("Product type") : __("Material")}
+                            </label>
                             <div className="form-input w-full bg-om-panel text-om-muted">
-                                {item.material_code} - {item.material_name}
+                                {item.component_code ? `${item.component_code} - ` : ''}{item.component_name}
                             </div>
+                        </div>
+                    ) : isProductType ? (
+                        <div>
+                            <label className="block text-sm font-medium text-om-muted mb-1">
+                                {__("Product type")} <span className="text-om-blocked">*</span>
+                            </label>
+                            <Dropdown
+                                value={data.product_type_id == null ? '' : String(data.product_type_id)}
+                                onChange={(v) => setData('product_type_id', v)}
+                                placeholder={__("Select product type…")}
+                                options={productTypes.map((p) => ({
+                                    value: String(p.id),
+                                    label: `${p.code} - ${p.name}`,
+                                }))}
+                                className="w-full"
+                            />
+                            <p className="mt-1 text-xs text-om-faint">
+                                {__("Add a manufactured product type as a sub-assembly component.")}
+                            </p>
+                            {errors.product_type_id && (
+                                <p className="mt-1 text-sm text-om-blocked">{errors.product_type_id}</p>
+                            )}
                         </div>
                     ) : (
                         <div>
@@ -188,7 +238,7 @@ function MaterialForm({ productType, processTemplate, materials, steps, item, on
 }
 
 export default function ProcessTemplatesBom() {
-    const { productType, processTemplate, bomItems = [], materials = [], steps = [] } = usePage().props;
+    const { productType, processTemplate, bomItems = [], materials = [], productTypes = [], steps = [] } = usePage().props;
 
     const [showAddForm, setShowAddForm] = useState(false);
     const [editingItem, setEditingItem] = useState(null);
@@ -200,7 +250,7 @@ export default function ProcessTemplatesBom() {
     };
 
     const handleRemove = (item) => {
-        confirm({ title: __('Remove this material from BOM?') }, () => {
+        confirm({ title: __('Remove this component from BOM?') }, () => {
             router.delete(
                 `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/bom/${item.id}`,
                 { preserveScroll: true },
@@ -211,14 +261,14 @@ export default function ProcessTemplatesBom() {
     const columns = useMemo(() => [
         {
             id: 'material',
-            accessorKey: 'material_name',
-            header: __('Material'),
+            accessorKey: 'component_name',
+            header: __('Component'),
             cell: ({ row }) => (
                 <>
                     <div className="text-sm font-medium text-om-ink">
-                        {row.original.material_name}
+                        {row.original.component_name}
                     </div>
-                    <div className="text-xs text-om-muted font-mono">{row.original.material_code}</div>
+                    <div className="text-xs text-om-muted font-mono">{row.original.component_code}</div>
                 </>
             ),
         },
@@ -227,13 +277,19 @@ export default function ProcessTemplatesBom() {
             accessorKey: 'material_type_name',
             header: __('Type'),
             cell: ({ row }) => (
-                <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${typeColorClass(
-                        row.original.material_type_code,
-                    )}`}
-                >
-                    {row.original.material_type_name}
-                </span>
+                row.original.component_kind === 'product_type' ? (
+                    <span className="px-2 py-1 rounded-full text-xs font-medium bg-om-accent/10 text-om-accent">
+                        {__("Product type")}
+                    </span>
+                ) : (
+                    <span
+                        className={`px-2 py-1 rounded-full text-xs font-medium ${typeColorClass(
+                            row.original.material_type_code,
+                        )}`}
+                    >
+                        {row.original.material_type_name}
+                    </span>
+                )
             ),
         },
         {
@@ -346,7 +402,7 @@ export default function ProcessTemplatesBom() {
                             <svg className="w-5 h-5 inline-block mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
                             </svg>
-                            {__("Add Material")}
+                            {__("Add Component")}
                         </button>
                     </div>
                 </div>
@@ -356,6 +412,7 @@ export default function ProcessTemplatesBom() {
                         productType={productType}
                         processTemplate={processTemplate}
                         materials={materials}
+                        productTypes={productTypes}
                         steps={steps}
                         onCancel={() => setShowAddForm(false)}
                     />
@@ -367,6 +424,7 @@ export default function ProcessTemplatesBom() {
                         productType={productType}
                         processTemplate={processTemplate}
                         materials={materials}
+                        productTypes={productTypes}
                         steps={steps}
                         item={editingItem}
                         onCancel={() => setEditingItem(null)}

--- a/backend/tests/Feature/BomTest.php
+++ b/backend/tests/Feature/BomTest.php
@@ -189,6 +189,98 @@ class BomTest extends TestCase
         $this->assertSoftDeleted('bom_items', ['id' => $bomItem->id]);
     }
 
+    // ── Product-type components (sub-assemblies) ────────────────
+
+    public function test_admin_can_add_product_type_to_bom(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $subAssembly = ProductType::factory()->create();
+
+        $response = $this->actingAs($this->admin)->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            [
+                'component_kind' => 'product_type',
+                'product_type_id' => $subAssembly->id,
+                'quantity_per_unit' => 2,
+                'consumed_at' => 'start',
+            ]
+        );
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('bom_items', [
+            'process_template_id' => $template->id,
+            'product_type_id' => $subAssembly->id,
+            'material_id' => null,
+            'quantity_per_unit' => 2,
+        ]);
+    }
+
+    public function test_cannot_add_same_product_type_twice(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $sub = ProductType::factory()->create();
+        BomItem::create([
+            'process_template_id' => $template->id,
+            'product_type_id' => $sub->id,
+            'quantity_per_unit' => 1,
+        ]);
+
+        $response = $this->actingAs($this->admin)->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            ['product_type_id' => $sub->id, 'quantity_per_unit' => 1]
+        );
+
+        $response->assertSessionHasErrors('product_type_id');
+    }
+
+    public function test_product_type_cannot_be_a_component_of_itself(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+
+        $response = $this->actingAs($this->admin)->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            ['product_type_id' => $productType->id, 'quantity_per_unit' => 1]
+        );
+
+        $response->assertSessionHasErrors('product_type_id');
+        $this->assertDatabaseMissing('bom_items', ['product_type_id' => $productType->id]);
+    }
+
+    public function test_bom_line_needs_a_material_or_a_product_type(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+
+        $response = $this->actingAs($this->admin)->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            ['quantity_per_unit' => 1]
+        );
+
+        $response->assertSessionHasErrors(['material_id', 'product_type_id']);
+    }
+
+    public function test_snapshot_captures_a_product_type_component_without_crashing(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $sub = ProductType::factory()->create(['name' => 'Sub Widget']);
+        BomItem::create([
+            'process_template_id' => $template->id,
+            'product_type_id' => $sub->id,
+            'quantity_per_unit' => 3,
+        ]);
+
+        $snapshot = app(\App\Services\ProcessTemplate\SnapshotService::class)->createSnapshot($template->fresh());
+
+        $this->assertCount(1, $snapshot['bom']);
+        $this->assertSame('product_type', $snapshot['bom'][0]['component_kind']);
+        $this->assertSame('Sub Widget', $snapshot['bom'][0]['material_name']);
+        $this->assertNull($snapshot['bom'][0]['material_id']);
+    }
+
     // ── Snapshot with BOM ───────────────────────────────────────
 
     public function test_snapshot_includes_bom(): void

--- a/backend/tests/Feature/BomTest.php
+++ b/backend/tests/Feature/BomTest.php
@@ -216,6 +216,57 @@ class BomTest extends TestCase
         ]);
     }
 
+    public function test_guest_cannot_add_product_type_to_bom(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $sub = ProductType::factory()->create();
+
+        $this->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            ['product_type_id' => $sub->id, 'quantity_per_unit' => 1]
+        )->assertRedirect(route('login'));
+
+        $this->assertDatabaseMissing('bom_items', ['product_type_id' => $sub->id]);
+    }
+
+    public function test_operator_cannot_add_product_type_to_bom(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $sub = ProductType::factory()->create();
+
+        $this->actingAs($this->operator)->post(
+            route('admin.product-types.process-templates.bom.store', [$productType, $template]),
+            ['product_type_id' => $sub->id, 'quantity_per_unit' => 1]
+        )->assertForbidden();
+
+        $this->assertDatabaseMissing('bom_items', ['product_type_id' => $sub->id]);
+    }
+
+    public function test_requirements_skip_product_type_lines(): void
+    {
+        $productType = ProductType::factory()->create();
+        $template = ProcessTemplate::factory()->create(['product_type_id' => $productType->id]);
+        $material = Material::factory()->create(['material_type_id' => $this->rawMaterial->id]);
+        BomItem::create([
+            'process_template_id' => $template->id,
+            'material_id' => $material->id,
+            'quantity_per_unit' => 2,
+        ]);
+        BomItem::create([
+            'process_template_id' => $template->id,
+            'product_type_id' => ProductType::factory()->create()->id,
+            'quantity_per_unit' => 5,
+        ]);
+
+        $requirements = app(BomService::class)->calculateRequirements($template->fresh(), 10);
+
+        // Only the material line contributes a stock requirement.
+        $this->assertCount(1, $requirements);
+        $this->assertSame($material->id, $requirements[0]['material_id']);
+    }
+
     public function test_cannot_add_same_product_type_twice(): void
     {
         $productType = ProductType::factory()->create();


### PR DESCRIPTION
Adds the option to put a **product type** (a manufactured sub-assembly) on a Bill of Materials, not only a material — requested for the BOM editor.

## What it does
- BOM editor gains a **Material / Product type** switch. Product-type lines carry the same `quantity_per_unit`, step, scrap %, consumption timing and notes as materials, and show a **Product type** badge in the list.
- A product type **can't be a component of itself**, and each product type appears **once per template** (partial unique, soft-delete aware).
- Captured in the work-order snapshot as a **sub-assembly reference**.

## Scope (as agreed)
- **Simple component** — product-type lines do **not** explode into their own BOM; the material stock / consumption / cost engines **skip** them (null-material derefs guarded in `BomExplosionService`, `SnapshotService`, `ProcessTemplate::toSnapshot`).
- **Web admin only** — no API/ERP changes.

## Data model
`bom_items`: `material_id` made nullable + new nullable `product_type_id` (FK, restrict on delete); partial unique `(process_template_id, product_type_id) WHERE deleted_at IS NULL`. Exactly one of material/product-type per line (`required_without` + `prohibits`).

## Tests
5 new (`BomTest`): add a product type, duplicate rejected, self-reference rejected, line needs one of material/product-type, snapshot captures a product-type component without crashing. Full suite **2494 passed** · Pint clean · frontend build OK · en/pl parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manufactured product types as BOM components alongside materials.
  * Added product-type selection, component details, and unit handling in BOM management.
  * Included product-type sub-assembly references in work-order snapshots.
* **Validation**
  * Prevented self-referencing and duplicate product-type components.
  * Required each BOM line to specify either a material or product type.
* **Bug Fixes**
  * Product-type components are excluded from material stock consumption.
* **Localization**
  * Added English and Polish translations for the new BOM workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->