### PR TITLE
fix(ui): use the configured timezone in the header clock, and let it …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Plant timezone is changeable after installation** *(admin)* — Settings → System → General now carries a timezone picker (region + zone), writing the same `system_settings` row the installer's step does; the wizard already promised this was possible. The chosen zone is re-applied per request and before each queued job, so on Octane a change reaches every worker immediately instead of waiting for a container restart. Saving reloads the page so every displayed time switches over at once.
 - **Product types as Bill-of-Materials components** *(admin)* — a BOM line can now be a manufactured **product type** (a sub-assembly), not only a material. In the BOM editor a Material / Product type switch picks the component kind; product-type lines carry the same quantity-per-unit, step, scrap %, consumption timing and notes as materials. A product type can't be a component of itself, and each appears once per template. Lines are captured in the work-order snapshot as sub-assembly references; they're a simple component reference (they don't explode into their own BOM) and are skipped by the material stock/consumption engine. Additive — existing material BOMs are unaffected.
+
+### Fixed
+- **Header clock ignored the configured timezone** *(all users)* — the live clock top-right was hardcoded to `Europe/Warsaw`, so on any install with a different timezone it was the one timestamp in the UI that disagreed with all the others. It now goes through the same `formatDate`/`formatTime` helpers as the rest of the app.
 
 ## [0.21.0] - 2026-08-21
 

--- a/backend/app/Http/Controllers/Web/SettingsController.php
+++ b/backend/app/Http/Controllers/Web/SettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateRoleTabAccessRequest;
+use App\Http\Requests\UpdateSystemSettingsRequest;
 use App\Support\TabRegistry;
 use App\Support\TimezoneRegistry;
 use Illuminate\Http\Request;
@@ -329,41 +330,9 @@ class SettingsController extends Controller
     /**
      * Update system settings (admin only).
      */
-    public function updateSystemSettings(Request $request)
+    public function updateSystemSettings(UpdateSystemSettingsRequest $request)
     {
-        $validated = $request->validate([
-            'production_period' => 'required|in:none,weekly,monthly',
-            'allow_overproduction' => 'nullable|boolean',
-            'force_sequential_steps' => 'nullable|boolean',
-            'workstation_routing_enabled' => 'nullable|boolean',
-            'backflush_on_pallet_creation' => 'nullable|boolean',
-            'workflow_mode' => 'required|in:status,board_status',
-            'pin_login_enabled' => 'nullable|boolean',
-            // Single source of truth — the language switcher's configured locales.
-            'language' => ['nullable', Rule::in(array_keys(config('app.available_locales', [])))],
-            // Plant timezone. Persisted by TimezoneRegistry, not through the
-            // JSON $map below — it stores the identifier raw.
-            'app_timezone' => ['nullable', 'string', Rule::in(TimezoneRegistry::identifiers())],
-            'schedule_view_mode' => 'required|in:weekly,daily,monthly',
-            'schedule_shifts_per_day' => 'required|integer|in:1,2,3,4',
-            'schedule_horizon_weeks' => 'required|integer|min:1|max:52',
-            'schedule_show_weekends' => 'nullable|boolean',
-            'realtime_mode' => 'required|in:polling,off',
-            'production_tracking_mode' => 'required|in:per_operation,cumulative,hybrid',
-            'cors_allowed_origins' => 'nullable|string|max:1000',
-            'cors_allowed_methods' => 'nullable|string|max:200',
-            'cors_max_age' => 'nullable|integer|min:0|max:86400',
-            'production_qty_edit_policy' => 'required|in:none,timed,full',
-            'production_qty_edit_window_minutes' => 'required_if:production_qty_edit_policy,timed|integer|min:1|max:60',
-            'scanner_mode' => 'required|in:hid,manual',
-            'standard_weekly_hours' => 'nullable|numeric|min:1|max:168',
-            'default_currency' => 'nullable|string|size:3',
-            'default_pay_type' => 'nullable|in:hourly,weekly,piece_rate',
-            'default_pay_rate' => 'nullable|numeric|min:0',
-            // Optional feature modules (#144).
-            'enabled_modules' => 'nullable|array',
-            'enabled_modules.*' => ['string', Rule::in(\App\Support\ModuleRegistry::optionalKeys())],
-        ]);
+        $validated = $request->validated();
 
         $shiftsPerDay = (int) $validated['schedule_shifts_per_day'];
         $slotDuration = $shiftsPerDay > 0 ? (int) (24 / $shiftsPerDay) : 8;

--- a/backend/app/Http/Controllers/Web/SettingsController.php
+++ b/backend/app/Http/Controllers/Web/SettingsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateRoleTabAccessRequest;
 use App\Support\TabRegistry;
+use App\Support\TimezoneRegistry;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -125,6 +126,9 @@ class SettingsController extends Controller
             'default_currency' => json_decode($rows['default_currency']?->value ?? '"PLN"', true) ?? 'PLN',
             'default_pay_type' => json_decode($rows['default_pay_type']?->value ?? '"hourly"', true) ?? 'hourly',
             'default_pay_rate' => json_decode($rows['default_pay_rate']?->value ?? 'null', true),
+            // Stored raw (not JSON) by TimezoneRegistry, and falls back to
+            // whatever APP_TIMEZONE resolved to when nothing is stored yet.
+            'app_timezone' => TimezoneRegistry::current(),
         ];
 
         // Same source as the validation rule and the language switcher.
@@ -156,6 +160,9 @@ class SettingsController extends Controller
         return Inertia::render('settings/System', [
             'settings' => $settings,
             'availableLocales' => $availableLocales,
+            // Every IANA identifier, grouped by region — same source the
+            // installer's timezone step uses.
+            'timezones' => TimezoneRegistry::grouped(),
             'appUrl' => config('app.url'),
             'modules' => \App\Support\ModuleRegistry::forForm(),
             'backups' => $backups,
@@ -334,6 +341,9 @@ class SettingsController extends Controller
             'pin_login_enabled' => 'nullable|boolean',
             // Single source of truth — the language switcher's configured locales.
             'language' => ['nullable', Rule::in(array_keys(config('app.available_locales', [])))],
+            // Plant timezone. Persisted by TimezoneRegistry, not through the
+            // JSON $map below — it stores the identifier raw.
+            'app_timezone' => ['nullable', 'string', Rule::in(TimezoneRegistry::identifiers())],
             'schedule_view_mode' => 'required|in:weekly,daily,monthly',
             'schedule_shifts_per_day' => 'required|integer|in:1,2,3,4',
             'schedule_horizon_weeks' => 'required|integer|min:1|max:52',
@@ -398,6 +408,13 @@ class SettingsController extends Controller
                 ['key' => $key],
                 ['value' => json_encode($value)]
             );
+        }
+
+        // Plant timezone — only when submitted, and applied immediately so the
+        // redirect that follows already renders in the new zone.
+        if (! empty($validated['app_timezone'])) {
+            TimezoneRegistry::save($validated['app_timezone']);
+            TimezoneRegistry::apply();
         }
 
         // Optional feature modules (#144) — only when the section was submitted,

--- a/backend/app/Http/Middleware/ApplyPlantTimezone.php
+++ b/backend/app/Http/Middleware/ApplyPlantTimezone.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\TimezoneRegistry;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Re-applies the plant timezone (system_settings → config('app.timezone') +
+ * date_default_timezone_set) for every request.
+ *
+ * AppServiceProvider::boot() already applies it, but under Octane that runs once
+ * per worker: without this, changing the zone in Settings would only reach the
+ * worker that handled the save, and every other worker would keep rendering
+ * timestamps in the old zone until the container restarted. Runs before the
+ * controller — and before HandleInertiaRequests reads config('app.timezone') for
+ * the frontend `timezone` prop.
+ */
+class ApplyPlantTimezone
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        TimezoneRegistry::refresh();
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Requests/UpdateSystemSettingsRequest.php
+++ b/backend/app/Http/Requests/UpdateSystemSettingsRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Support\ModuleRegistry;
+use App\Support\TimezoneRegistry;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Admin-only system settings (Settings -> System).
+ *
+ * One ruleset for a form that spans several tabs: sections the user did not
+ * touch simply are not submitted, which is why most fields are `nullable` and
+ * why the controller writes each group only when it is present.
+ */
+class UpdateSystemSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // The route is already behind `auth` + `role:Admin`; repeated here so the
+        // ruleset cannot be reused from an ungated route by accident.
+        return $this->user()?->hasRole('Admin') ?? false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'production_period' => 'required|in:none,weekly,monthly',
+            'allow_overproduction' => 'nullable|boolean',
+            'force_sequential_steps' => 'nullable|boolean',
+            'workstation_routing_enabled' => 'nullable|boolean',
+            'backflush_on_pallet_creation' => 'nullable|boolean',
+            'workflow_mode' => 'required|in:status,board_status',
+            'pin_login_enabled' => 'nullable|boolean',
+            // Single source of truth — the language switcher's configured locales.
+            'language' => ['nullable', Rule::in(array_keys(config('app.available_locales', [])))],
+            // Plant timezone. Persisted by TimezoneRegistry, not through the
+            // controller's JSON map — it stores the identifier raw.
+            'app_timezone' => ['nullable', 'string', Rule::in(TimezoneRegistry::identifiers())],
+            'schedule_view_mode' => 'required|in:weekly,daily,monthly',
+            'schedule_shifts_per_day' => 'required|integer|in:1,2,3,4',
+            'schedule_horizon_weeks' => 'required|integer|min:1|max:52',
+            'schedule_show_weekends' => 'nullable|boolean',
+            'realtime_mode' => 'required|in:polling,off',
+            'production_tracking_mode' => 'required|in:per_operation,cumulative,hybrid',
+            'cors_allowed_origins' => 'nullable|string|max:1000',
+            'cors_allowed_methods' => 'nullable|string|max:200',
+            'cors_max_age' => 'nullable|integer|min:0|max:86400',
+            'production_qty_edit_policy' => 'required|in:none,timed,full',
+            'production_qty_edit_window_minutes' => 'required_if:production_qty_edit_policy,timed|integer|min:1|max:60',
+            'scanner_mode' => 'required|in:hid,manual',
+            'standard_weekly_hours' => 'nullable|numeric|min:1|max:168',
+            'default_currency' => 'nullable|string|size:3',
+            'default_pay_type' => 'nullable|in:hourly,weekly,piece_rate',
+            'default_pay_rate' => 'nullable|numeric|min:0',
+            // Optional feature modules (#144).
+            'enabled_modules' => 'nullable|array',
+            'enabled_modules.*' => ['string', Rule::in(ModuleRegistry::optionalKeys())],
+        ];
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -59,6 +60,11 @@ class AppServiceProvider extends ServiceProvider
         // install the env route cannot be changed without editing compose files.
         // Absent setting = keep whatever APP_TIMEZONE resolved to.
         \App\Support\TimezoneRegistry::apply();
+
+        // A queue worker is long-lived too, so the boot-time apply() above would
+        // pin it to the zone that was configured when it started. Re-read before
+        // each job; web requests get the same treatment in ApplyPlantTimezone.
+        Queue::looping(fn () => \App\Support\TimezoneRegistry::refresh());
 
         // Reverb sync: register model → collection broadcast listeners.
         \App\Sync\CollectionBroadcaster::boot();

--- a/backend/app/Support/TimezoneRegistry.php
+++ b/backend/app/Support/TimezoneRegistry.php
@@ -135,6 +135,22 @@ class TimezoneRegistry
         return self::stored() ?? (string) config('app.timezone', 'UTC');
     }
 
+    /**
+     * Re-read the setting and apply it, discarding the per-process cache first.
+     *
+     * `apply()` alone runs in `AppServiceProvider::boot()`, which on Octane (and
+     * in a long-lived queue worker) happens once per worker, not once per
+     * request — so a zone changed in Settings would keep rendering the old one in
+     * every already-booted worker until a restart. Called per request/job, this
+     * costs one lookup on a unique key of a tiny table and keeps every worker
+     * honest.
+     */
+    public static function refresh(): void
+    {
+        self::flush();
+        self::apply();
+    }
+
     /** Test seam — the cache is per process and would leak between tests. */
     public static function flush(): void
     {

--- a/backend/app/Support/TimezoneRegistry.php
+++ b/backend/app/Support/TimezoneRegistry.php
@@ -33,6 +33,15 @@ class TimezoneRegistry
     private static ?string $cached = null;
 
     /**
+     * The zone the process booted on — APP_TIMEZONE, or config's UTC default —
+     * captured before any stored setting overwrote it. Kept for the whole process
+     * so that removing the setting (a system reset) puts a long-lived worker back
+     * on the env value instead of stranding it on the zone it happened to apply
+     * earlier.
+     */
+    private static ?string $fallback = null;
+
+    /**
      * The configured plant timezone, or null when the installation has not chosen
      * one (fresh install, or the DB is not reachable yet during install).
      */
@@ -58,7 +67,8 @@ class TimezoneRegistry
     }
 
     /**
-     * Apply the stored timezone to the running application.
+     * Apply the stored timezone — or, with nothing stored, the zone this process
+     * booted on — to the running application.
      *
      * Both halves are needed: `config('app.timezone')` is what the Inertia
      * `timezone` prop and anything reading config sees, and
@@ -66,11 +76,11 @@ class TimezoneRegistry
      */
     public static function apply(): void
     {
-        $timezone = self::stored();
+        // First call wins: at that point config still holds the env value, which
+        // is what "no setting stored" has to fall back to on every later call.
+        self::$fallback ??= (string) config('app.timezone', 'UTC');
 
-        if ($timezone === null) {
-            return;
-        }
+        $timezone = self::stored() ?? self::$fallback;
 
         config(['app.timezone' => $timezone]);
         date_default_timezone_set($timezone);
@@ -147,13 +157,22 @@ class TimezoneRegistry
      */
     public static function refresh(): void
     {
-        self::flush();
+        // Only the stored value — not $fallback, which is the env baseline this
+        // process booted on and is exactly what apply() needs when the setting
+        // has been removed since.
+        self::$cached = null;
+
         self::apply();
     }
 
-    /** Test seam — the cache is per process and would leak between tests. */
+    /**
+     * Test seam — both the cached value and the boot fallback are per process and
+     * would leak between tests. Production code wants refresh(), which keeps the
+     * fallback.
+     */
     public static function flush(): void
     {
         self::$cached = null;
+        self::$fallback = null;
     }
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -35,6 +35,10 @@ $app = Application::configure(basePath: dirname(__DIR__))
         // Append request logging at the end of the web stack so $request->user()
         // is populated by SubstituteBindings/StartSession/Authenticate before us.
         $middleware->web(append: [
+            // Plant timezone before anything renders a date: on Octane the
+            // provider that applies it boots once per worker, so a zone changed
+            // in Settings only reaches this worker via this middleware.
+            \App\Http\Middleware\ApplyPlantTimezone::class,
             // SetLocale first so app()->getLocale() is correct by the time
             // HandleInertiaRequests::share() reads it.
             \App\Http\Middleware\SetLocale::class,
@@ -45,6 +49,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
         // Also log API requests; the middleware resolves the user from the
         // sanctum guard when the default web guard isn't populated.
         $middleware->api(append: [
+            \App\Http\Middleware\ApplyPlantTimezone::class,
             \App\Http\Middleware\LogRequest::class,
         ]);
 

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5655,5 +5655,9 @@
     "This product type is already in the BOM for this template.": "This product type is already in the BOM for this template.",
     "A product type cannot be a component of itself.": "A product type cannot be a component of itself.",
     "Component added to BOM.": "Component added to BOM.",
-    "This material is already in the BOM for this template.": "This material is already in the BOM for this template."
+    "This material is already in the BOM for this template.": "This material is already in the BOM for this template.",
+    "Region": "Region",
+    "Select timezone": "Select timezone",
+    "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.",
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Changing the timezone reloads the page so every displayed time switches over at once."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5655,5 +5655,9 @@
     "This product type is already in the BOM for this template.": "Ten typ produktu jest już w BOM dla tego szablonu.",
     "A product type cannot be a component of itself.": "Typ produktu nie może być komponentem samego siebie.",
     "Component added to BOM.": "Dodano komponent do BOM.",
-    "This material is already in the BOM for this template.": "Ten materiał jest już w BOM dla tego szablonu."
+    "This material is already in the BOM for this template.": "Ten materiał jest już w BOM dla tego szablonu.",
+    "Region": "Region",
+    "Select timezone": "Wybierz strefę czasową",
+    "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Strefa czasowa zakładu. Wszystkie znaczniki czasu, granice raportów i zmian w aplikacji są w niej wyrażone.",
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Zmiana strefy czasowej przeładowuje stronę, aby wszystkie wyświetlane godziny zmieniły się naraz."
 }

--- a/backend/resources/js/Pages/settings/System.jsx
+++ b/backend/resources/js/Pages/settings/System.jsx
@@ -46,9 +46,51 @@ function SelectCard({ value, current, onChange, label, desc, disabled }) {
     );
 }
 
+/**
+ * Region + zone pair rather than one 400-entry menu: Dropdown has no type-ahead,
+ * so scrolling every IANA identifier to reach "America/Argentina/Buenos_Aires"
+ * is the difference between a usable control and an unusable one. The form still
+ * holds one value — the full identifier.
+ */
+function TimezonePicker({ groups, value, onChange }) {
+    const regions = Object.keys(groups);
+    // "Europe/Warsaw" -> "Europe"; "UTC" is grouped under "Other" server-side.
+    const regionOf = (tz) => (tz && tz.includes('/') ? tz.split('/')[0] : 'Other');
+    const [region, setRegion] = useState(() => regionOf(value));
+    const zones = groups[region] ?? [];
+
+    // Picking a region moves the selection to that region's first zone, so the
+    // two controls never disagree about what is saved.
+    const changeRegion = (next) => {
+        setRegion(next);
+        const first = (groups[next] ?? [])[0];
+        if (first && regionOf(value) !== next) onChange(first);
+    };
+
+    return (
+        <div className="flex flex-wrap gap-2">
+            <Dropdown
+                options={regions.map((r) => ({ value: r, label: r }))}
+                value={region}
+                onChange={changeRegion}
+                aria-label={__('Region')}
+                className="w-full max-w-[12rem]"
+            />
+            <Dropdown
+                options={zones.map((tz) => ({ value: tz, label: tz.includes('/') ? tz.slice(tz.indexOf('/') + 1).replace(/_/g, ' ') : tz }))}
+                value={zones.includes(value) ? value : ''}
+                placeholder={__('Select timezone')}
+                onChange={onChange}
+                aria-label={__('Timezone')}
+                className="w-full max-w-xs"
+            />
+        </div>
+    );
+}
+
 export default function System() {
     const toast = useToast();
-    const { settings, availableLocales, appUrl, modules = [], backups } = usePage().props;
+    const { settings, availableLocales, timezones = {}, appUrl, modules = [], backups } = usePage().props;
 
     const [tab, setTab] = useState('general');
     const [sampleConfirm, setSampleConfirm] = useState(false);
@@ -76,6 +118,7 @@ export default function System() {
         workflow_mode: settings.workflow_mode ?? 'status',
         pin_login_enabled: settings.pin_login_enabled ?? false,
         language: settings.language ?? 'en',
+        app_timezone: settings.app_timezone ?? 'UTC',
         schedule_view_mode: settings.schedule_view_mode ?? 'weekly',
         schedule_shifts_per_day: settings.schedule_shifts_per_day ?? 1,
         schedule_horizon_weeks: settings.schedule_horizon_weeks ?? 6,
@@ -101,13 +144,15 @@ export default function System() {
 
     function handleSubmit(e) {
         e.preventDefault();
-        // Language is loaded once at bootstrap (see lib/i18n), so a change only
-        // takes effect after a full reload — an Inertia (SPA) redirect won't
-        // swap the locale chunk. Reload when the language actually changed.
-        const languageChanged = data.language !== settings.language;
+        // Language and timezone are both read once at bootstrap (see lib/i18n:
+        // loadLocale / setTimezone), so a change only takes effect after a full
+        // reload — an Inertia (SPA) redirect swaps neither the locale chunk nor
+        // the zone the format* helpers use. Reload when either actually changed.
+        const needsReload = data.language !== settings.language
+            || data.app_timezone !== settings.app_timezone;
         post('/settings/system', {
             onSuccess: () => {
-                if (languageChanged) window.location.reload();
+                if (needsReload) window.location.reload();
             },
         });
     }
@@ -336,6 +381,22 @@ export default function System() {
                             <p className={`${HELP_CLASS} mt-2`}>
                                 {__('Want to add a new language? Create a JSON file in')} <code className="bg-om-chip px-1 rounded font-mono text-[12px] text-om-ink">lang/</code> {__('directory.')}
                                 {' '}{__('See')} <code className="bg-om-chip px-1 rounded font-mono text-[12px] text-om-ink">lang/en.json</code> {__('as reference.')}
+                            </p>
+                        </div>
+
+                        <div className="border-t border-om-line pt-4 mt-4">
+                            <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-om-ink mb-1">{__('Timezone')}</h2>
+                            <p className={`${HELP_CLASS} mb-2`}>
+                                {__('Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.')}
+                            </p>
+                            <TimezonePicker
+                                groups={timezones}
+                                value={data.app_timezone}
+                                onChange={(v) => setData('app_timezone', v)}
+                            />
+                            {errors.app_timezone && <p className="text-om-blocked text-[12px] mt-1">{errors.app_timezone}</p>}
+                            <p className={`${HELP_CLASS} mt-2`}>
+                                {__('Changing the timezone reloads the page so every displayed time switches over at once.')}
                             </p>
                         </div>
 

--- a/backend/resources/js/layouts/AppLayout.jsx
+++ b/backend/resources/js/layouts/AppLayout.jsx
@@ -8,7 +8,7 @@ import Tooltip from '../components/Tooltip';
 import HoverPanel from '../components/HoverPanel';
 import { ToastProvider } from '@openmes/ui';
 import { LiveShapesProvider } from '../components/LiveShapesProvider';
-import { __ } from '../lib/i18n';
+import { __, formatDate, formatTime } from '../lib/i18n';
 import { Breadcrumbs, Icon as UiIcon } from '@openmes/ui';
 
 // ── Module menu hooks ────────────────────────────────────────────────────────
@@ -336,7 +336,7 @@ export default function AppLayout({ children }) {
                     </div>
                 </header>
 
-                {/* Desktop clock (top-right) — ported from app.blade.php's Europe/Warsaw clock */}
+                {/* Desktop clock (top-right) — ported from app.blade.php's clock */}
                 <DesktopClock
                     collapsed={collapsed}
                     onToggleCollapsed={toggleCollapsed}
@@ -377,9 +377,10 @@ function FlashMessages() {
 
 /**
  * Desktop-only live clock shown top-right on every page (parity with the
- * Europe/Warsaw clock the Blade app.blade.php rendered above <main>). Isolated
+ * clock the Blade app.blade.php rendered above <main>). Isolated
  * so its per-second tick only re-renders this component, not the whole layout.
- * Formatted in the active locale; timezone pinned to Europe/Warsaw like the original.
+ * Formatted in the active locale and the app timezone (the `timezone` Inertia prop),
+ * via the same i18n helpers every other timestamp in the UI goes through.
  */
 function NavTrail({ items, show }) {
     if (!show || items.length === 0) return null;
@@ -387,21 +388,23 @@ function NavTrail({ items, show }) {
 }
 
 function DesktopClock({ collapsed, onToggleCollapsed, navTrail = [], showNavTrail = false }) {
-    const { locale } = usePage().props;
+    const { locale, timezone } = usePage().props;
     const fmt = () => {
         const now = new Date();
-        const tz = { timeZone: 'Europe/Warsaw' };
         return {
-            date: now.toLocaleDateString(locale || 'en', { ...tz, weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' }),
-            time: now.toLocaleTimeString(locale || 'en', { ...tz, hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+            date: formatDate(now, { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' }),
+            time: formatTime(now, { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
         };
     };
     const [t, setT] = useState(fmt);
     useEffect(() => {
+        // Re-render immediately when the locale or timezone changes, rather than
+        // waiting up to a second for the next tick to pick the new format up.
+        setT(fmt());
         const id = setInterval(() => setT(fmt()), 1000);
         return () => clearInterval(id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [locale]);
+    }, [locale, timezone]);
     return (
         // `h-11` and the hairline both match the sidebar's logo header, so the two
         // bars read as one band across the top with one rule under it, instead of

--- a/backend/resources/views/install/environment.blade.php
+++ b/backend/resources/views/install/environment.blade.php
@@ -74,7 +74,7 @@
                         Used for every timestamp, report boundary and shift edge. Set the
                         timezone of the plant, not of the server — otherwise a day's report
                         covers different hours than the shift that was worked. You can change
-                        it later without reinstalling.
+                        it later in Settings &rarr; System, without reinstalling.
                     </p>
                 </div>
 

--- a/backend/tests/Feature/Web/SystemSettingsTimezoneTest.php
+++ b/backend/tests/Feature/Web/SystemSettingsTimezoneTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use App\Support\TimezoneRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Changing the plant timezone after installation.
+ *
+ * The installer's own step is covered by InstallTimezoneTest; this pins the
+ * post-install half the wizard promises ("you can change it later without
+ * reinstalling"): an admin-only field on Settings → System that writes the same
+ * `system_settings` row, plus the per-request re-apply that stops a long-lived
+ * Octane/queue worker from serving the zone it booted with.
+ */
+class SystemSettingsTimezoneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        TimezoneRegistry::flush();
+
+        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        Role::firstOrCreate(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => 'Operator', 'guard_name' => 'web']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('Admin');
+    }
+
+    protected function tearDown(): void
+    {
+        TimezoneRegistry::flush();
+        date_default_timezone_set('UTC');
+
+        parent::tearDown();
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'production_period' => 'none',
+            'workflow_mode' => 'status',
+            'schedule_view_mode' => 'weekly',
+            'schedule_shifts_per_day' => 1,
+            'schedule_horizon_weeks' => 6,
+            'realtime_mode' => 'polling',
+            'production_tracking_mode' => 'per_operation',
+            'production_qty_edit_policy' => 'none',
+            'scanner_mode' => 'hid',
+        ], $overrides);
+    }
+
+    public function test_admin_can_change_the_plant_timezone(): void
+    {
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload(['app_timezone' => 'America/Argentina/Buenos_Aires']))
+            ->assertSessionHasNoErrors();
+
+        // Stored raw, not JSON-encoded — TimezoneRegistry reads it as a plain
+        // identifier, so an accidental json_encode() here would break `stored()`.
+        $this->assertDatabaseHas('system_settings', [
+            'key' => TimezoneRegistry::SETTING_KEY,
+            'value' => 'America/Argentina/Buenos_Aires',
+        ]);
+        $this->assertSame('America/Argentina/Buenos_Aires', TimezoneRegistry::stored());
+    }
+
+    public function test_saving_applies_the_zone_to_the_running_request(): void
+    {
+        config(['app.timezone' => 'UTC']);
+
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload(['app_timezone' => 'Asia/Tokyo']));
+
+        $this->assertSame('Asia/Tokyo', config('app.timezone'));
+        $this->assertSame('Asia/Tokyo', date_default_timezone_get());
+    }
+
+    public function test_an_unknown_timezone_is_refused(): void
+    {
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload(['app_timezone' => 'Mars/Olympus_Mons']))
+            ->assertSessionHasErrors('app_timezone');
+
+        $this->assertNull(TimezoneRegistry::stored());
+    }
+
+    public function test_omitting_the_field_leaves_the_stored_zone_alone(): void
+    {
+        TimezoneRegistry::save('Asia/Tokyo');
+
+        $this->actingAs($this->admin)
+            ->post('/settings/system', $this->payload())
+            ->assertSessionHasNoErrors();
+
+        TimezoneRegistry::flush();
+        $this->assertSame('Asia/Tokyo', TimezoneRegistry::stored());
+    }
+
+    public function test_a_non_admin_cannot_change_the_timezone(): void
+    {
+        $operator = User::factory()->create();
+        $operator->assignRole('Operator');
+
+        $this->actingAs($operator)
+            ->post('/settings/system', $this->payload(['app_timezone' => 'Asia/Tokyo']))
+            ->assertForbidden();
+
+        $this->assertNull(TimezoneRegistry::stored());
+    }
+
+    public function test_a_guest_cannot_change_the_timezone(): void
+    {
+        $this->post('/settings/system', $this->payload(['app_timezone' => 'Asia/Tokyo']))
+            ->assertRedirect(route('login'));
+
+        $this->assertNull(TimezoneRegistry::stored());
+    }
+
+    public function test_the_page_offers_the_current_zone_and_the_full_region_list(): void
+    {
+        TimezoneRegistry::save('Asia/Tokyo');
+
+        $props = $this->actingAs($this->admin)
+            ->get('/settings/system')
+            ->assertOk()
+            ->getOriginalContent()->getData()['page']['props'];
+
+        $this->assertSame('Asia/Tokyo', $props['settings']['app_timezone']);
+        $this->assertArrayHasKey('Europe', $props['timezones']);
+        $this->assertContains('Europe/Warsaw', $props['timezones']['Europe']);
+    }
+
+    /**
+     * The reason ApplyPlantTimezone exists: AppServiceProvider::boot() applies the
+     * zone once per worker, so a worker that booted before the change would keep
+     * rendering the old one. Simulated here by leaving a stale cached value and a
+     * stale config behind, then making an ordinary request.
+     */
+    public function test_a_request_re_applies_a_zone_changed_by_another_worker(): void
+    {
+        TimezoneRegistry::save('Asia/Tokyo');
+        TimezoneRegistry::apply();
+
+        // What the "other worker" state looks like: the row says Tokyo, this
+        // process still believes it is on UTC.
+        config(['app.timezone' => 'UTC']);
+        date_default_timezone_set('UTC');
+
+        $props = $this->actingAs($this->admin)
+            ->get('/settings')
+            ->assertOk()
+            ->getOriginalContent()->getData()['page']['props'];
+
+        $this->assertSame('Asia/Tokyo', $props['timezone']);
+    }
+}

--- a/backend/tests/Feature/Web/SystemSettingsTimezoneTest.php
+++ b/backend/tests/Feature/Web/SystemSettingsTimezoneTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Web;
 use App\Models\User;
 use App\Support\TimezoneRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -162,5 +163,28 @@ class SystemSettingsTimezoneTest extends TestCase
             ->getOriginalContent()->getData()['page']['props'];
 
         $this->assertSame('Asia/Tokyo', $props['timezone']);
+    }
+
+    /**
+     * The other half of that: once the setting is gone (a system reset truncates
+     * `system_settings`), a worker that had already applied a zone must fall back
+     * to the one it booted on — APP_TIMEZONE — not stay on the removed value.
+     */
+    public function test_removing_the_setting_puts_a_worker_back_on_the_env_zone(): void
+    {
+        config(['app.timezone' => 'Europe/Warsaw']);
+        TimezoneRegistry::flush();
+        TimezoneRegistry::apply();          // boot: nothing stored yet
+
+        TimezoneRegistry::save('Asia/Tokyo');
+        TimezoneRegistry::apply();
+        $this->assertSame('Asia/Tokyo', config('app.timezone'));
+
+        DB::table('system_settings')->where('key', TimezoneRegistry::SETTING_KEY)->delete();
+
+        TimezoneRegistry::refresh();
+
+        $this->assertSame('Europe/Warsaw', config('app.timezone'));
+        $this->assertSame('Europe/Warsaw', date_default_timezone_get());
     }
 }


### PR DESCRIPTION
## Summary
The live clock in the app header (`AppLayout.jsx` → `DesktopClock`) was hardcoded to
`Europe/Warsaw`, so on any install with a different `APP_TIMEZONE` it was the single
timestamp in the UI that disagreed with all the others. It now goes through the
`formatDate`/`formatTime` helpers in `lib/i18n.js`, which already read the active zone.

Fixing that surfaced a second gap: the installer's timezone step promises *"you can
change it later without reinstalling"*, but nothing wrote `system_settings.app_timezone`
after install — changing the zone required editing the DB row by hand. So this PR also:

- adds a **timezone picker to Settings → System → General** (admin-only, region + zone
  pair because `Dropdown` has no type-ahead and there are ~420 IANA identifiers). It
  writes the same row the installer does, via `TimezoneRegistry::save()`. Saving reloads
  the page, since `lib/i18n` reads the zone once at bootstrap — same pattern as the
  language setting;
- re-applies the stored zone **per request** (`ApplyPlantTimezone` middleware, web + api)
  and **before each queued job** (`Queue::looping`). `AppServiceProvider::boot()` runs
  once per Octane/queue worker, so without this a change reached only the worker that
  handled the save, and every other worker kept rendering the old zone until restart.

No schema change — the setting reuses the existing `system_settings` row.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## Related issue
Closes #<!-- numer zgłoszenia o zahardkodowanej strefie -->

## Testing
New feature test `tests/Feature/Web/SystemSettingsTimezoneTest.php` covers: admin saves a
zone (stored raw, not JSON-encoded), the zone applies to the running request, unknown
identifier → validation error, omitting the field leaves the stored zone alone,
non-admin → 403, guest → redirect to login, the page exposes the current zone + region
list, and a regression guard for "another worker changed the zone" (stale config +
stale process cache → an ordinary request still renders the new zone).

- [ ] Tested manually in browser
- [x] `php artisan test` passes — full suite green via the pre-commit gate (2505 tests,
      8188 assertions). Note: a bare `php artisan test` OOMs locally in `CsvParserService`
      with the default `memory_limit`; verified the same fatal on clean `develop`, so it
      is environmental, not a regression.
- [ ] Tested as Operator / Supervisor / Admin role (if UI change) — covered by tests
      (admin / non-admin / guest), not clicked through manually

## Checklist
- [x] No `.env` secrets committed
- [x] Migration added if schema changed — n/a, no schema change
- [x] `$fillable` updated if new model columns added — n/a
- [x] No raw SQL with user input (use Eloquent / Query Builder)
- [x] CSRF protection in place for any new forms — existing `/settings/system` form
- [ ] `composer audit` clean — 45 advisories across 12 packages, all pre-existing on
      `develop`; this PR adds no dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added timezone selection to System settings with region-based options and guidance.
  - Timezone changes apply immediately across pages, reports, shifts, requests, and background processing.
  - Added localized English and Polish timezone labels and help text.

- **Bug Fixes**
  - Header clock now reflects the configured timezone and locale in real time.
  - Added validation for unsupported timezone selections.
  - Added duplicate-material BOM validation messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->