### PR TITLE
fix: correct unassign-operator URL on Line show page

### DIFF
--- a/backend/resources/js/Pages/admin/lines/Show.jsx
+++ b/backend/resources/js/Pages/admin/lines/Show.jsx
@@ -317,7 +317,7 @@ function OperatorsCard({ line, availableOperators }) {
 
     const unassign = (userId, userName) => {
         confirm({ title: `Remove ${userName} from this line?` }, () => {
-            router.delete(`/admin/lines/${line.id}/operators/${userId}`, { preserveScroll: true });
+            router.delete(`/admin/lines/${line.id}/unassign-operator/${userId}`, { preserveScroll: true });
         });
     };
 


### PR DESCRIPTION
## Summary

Clicking "Remove" on an operator assigned to a Line (Admin → Structure → Production Lines → a Line → Operators card) always 404'd instead of removing them.

## Root cause

`resources/js/Pages/admin/lines/Show.jsx`'s `unassign()` handler called:
```js
router.delete(`/admin/lines/${line.id}/operators/${userId}`, { preserveScroll: true });
```
but that path was never registered. The actual route (`routes/web.php`) is:
```php
Route::delete('/lines/{line}/unassign-operator/{user}', [LineManagementController::class, 'unassignOperator'])->name('lines.unassign-operator');
```
i.e. `/admin/lines/{line}/unassign-operator/{user}`, not `/admin/lines/{line}/operators/{user}`. The backend method (`LineManagementController::unassignOperator`) is correct and complete — this was a pure frontend URL typo, with no matching route ever existing for the path the button actually called.

## Fix

Corrected the URL in `Show.jsx` to match the registered route. One line.

## Test plan

- [x] `npm run build` succeeds.
- [x] Rebuilt and ran the full stack locally (`docker compose build && docker compose up -d`) on top of current `develop`.
- [x] Manually reproduced pre-fix (404 on remove), applied the fix, and confirmed the operator is now correctly detached from the line with no error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected operator unassignment so it uses the appropriate endpoint and completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->