### PR TITLE
feat(process-templates): warn + audit-trail when editing an in-use template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Traceability when editing an in-use process template** *(admin)* — editing a template's steps (add / rename / delete / reorder) still mutates the current template in place, and running work orders correctly keep their frozen snapshot — but that used to happen silently. Now the template page shows a **warning banner** when the template backs active (non-finished) work orders, destructive step edits ask for confirmation while it's in use, and **every step change is written to the immutable audit log** (before/after shape) so the previous version is never lost. No change to how orders resolve their steps.
+
+### Added
 - **Plant timezone is changeable after installation** *(admin)* — Settings → System → General now carries a timezone picker (region + zone), writing the same `system_settings` row the installer's step does; the wizard already promised this was possible. The chosen zone is re-applied per request and before each queued job, so on Octane a change reaches every worker immediately instead of waiting for a container restart. Saving reloads the page so every displayed time switches over at once.
 - **Product types as Bill-of-Materials components** *(admin)* — a BOM line can now be a manufactured **product type** (a sub-assembly), not only a material. In the BOM editor a Material / Product type switch picks the component kind; product-type lines carry the same quantity-per-unit, step, scrap %, consumption timing and notes as materials. A product type can't be a component of itself, and each appears once per template. Lines are captured in the work-order snapshot as sub-assembly references; they're a simple component reference (they don't explode into their own BOM) and are skipped by the material stock/consumption engine. Additive — existing material BOMs are unaffected.
 

--- a/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
+++ b/backend/app/Http/Controllers/Web/Admin/ProcessTemplateManagementController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Web\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\Admin\StoreTemplateStepRequest;
 use App\Http\Requests\Web\Admin\UpdateTemplateStepRequest;
+use App\Models\AuditLog;
 use App\Models\ProcessTemplate;
 use App\Models\ProductType;
 use App\Models\TemplateStep;
@@ -103,6 +104,9 @@ class ProcessTemplateManagementController extends Controller
                 'name' => $processTemplate->name,
                 'version' => $processTemplate->version,
                 'is_active' => (bool) $processTemplate->is_active,
+                // Warn the admin: editing steps here won't touch these running
+                // orders (they keep their frozen snapshot) and isn't versioned.
+                'active_work_order_count' => $processTemplate->activeWorkOrderCount(),
                 'steps' => $processTemplate->steps->map(fn ($s) => [
                     'id' => $s->id,
                     'step_number' => $s->step_number,
@@ -285,7 +289,9 @@ class ProcessTemplateManagementController extends Controller
         $validated['step_number'] = $maxStepNumber + 1;
         $validated['process_template_id'] = $processTemplate->id;
 
-        TemplateStep::create($validated);
+        $step = TemplateStep::create($validated);
+
+        $this->recordStepAudit($processTemplate, 'template_step.added', null, $this->stepAuditFields($step));
 
         return redirect()->route('admin.product-types.process-templates.show', [$productType, $processTemplate])
             ->with('success', 'Step added successfully.');
@@ -301,7 +307,9 @@ class ProcessTemplateManagementController extends Controller
             abort(404);
         }
 
+        $before = $this->stepAuditFields($step);
         $step->update($this->stepPayload($request));
+        $this->recordStepAudit($processTemplate, 'template_step.updated', $before, $this->stepAuditFields($step->fresh()));
 
         return redirect()->route('admin.product-types.process-templates.show', [$productType, $processTemplate])
             ->with('success', 'Step updated successfully.');
@@ -325,6 +333,54 @@ class ProcessTemplateManagementController extends Controller
     }
 
     /**
+     * The step fields worth keeping in the audit trail (the shape that gets
+     * silently overwritten today).
+     *
+     * @return array<string, mixed>
+     */
+    private function stepAuditFields(TemplateStep $step): array
+    {
+        return $step->only([
+            'id', 'step_number', 'name', 'instruction', 'workstation_id',
+            'workstation_type_id', 'process_segment_id', 'estimated_duration_minutes',
+            'setup_time_minutes', 'run_time_per_unit_minutes', 'parameters',
+            'is_optional', 'variant_group', 'is_default_variant',
+        ]);
+    }
+
+    /**
+     * The template's current step order — `[step_number => name]` — for
+     * before/after reorder snapshots.
+     *
+     * @return array<int, string>
+     */
+    private function stepOrderSnapshot(ProcessTemplate $template): array
+    {
+        return $template->steps()->orderBy('step_number')->pluck('name', 'step_number')->all();
+    }
+
+    /**
+     * Record a template-step change to the immutable audit log, so the previous
+     * shape is never lost even though the edit mutates the row in place.
+     *
+     * @param  array<string, mixed>|null  $before
+     * @param  array<string, mixed>|null  $after
+     */
+    private function recordStepAudit(ProcessTemplate $template, string $action, ?array $before, ?array $after): void
+    {
+        AuditLog::create([
+            'user_id' => auth()->id(),
+            'entity_type' => ProcessTemplate::class,
+            'entity_id' => $template->id,
+            'action' => $action,
+            'before_state' => $before,
+            'after_state' => $after,
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+        ]);
+    }
+
+    /**
      * Delete a step from the process template
      */
     public function deleteStep(ProductType $productType, ProcessTemplate $processTemplate, TemplateStep $step)
@@ -335,6 +391,7 @@ class ProcessTemplateManagementController extends Controller
         }
 
         $stepNumber = $step->step_number;
+        $before = $this->stepAuditFields($step);
         $step->delete();
 
         // Renumber remaining steps
@@ -342,6 +399,8 @@ class ProcessTemplateManagementController extends Controller
             ->where('process_template_id', $processTemplate->id)
             ->where('step_number', '>', $stepNumber)
             ->decrement('step_number');
+
+        $this->recordStepAudit($processTemplate, 'template_step.deleted', $before, null);
 
         return redirect()->route('admin.product-types.process-templates.show', [$productType, $processTemplate])
             ->with('success', 'Step deleted successfully.');
@@ -373,6 +432,8 @@ class ProcessTemplateManagementController extends Controller
             return response()->json(['error' => 'Invalid step IDs'], 422);
         }
 
+        $before = $this->stepOrderSnapshot($processTemplate);
+
         // Use large offset first to avoid unique(process_template_id, step_number) violations
         DB::transaction(function () use ($stepIds) {
             $offset = 10000;
@@ -383,6 +444,8 @@ class ProcessTemplateManagementController extends Controller
                 DB::table('template_steps')->where('id', $id)->update(['step_number' => $i + 1]);
             }
         });
+
+        $this->recordStepAudit($processTemplate, 'template_steps.reordered', $before, $this->stepOrderSnapshot($processTemplate->fresh()));
 
         return response()->json(['success' => true]);
     }
@@ -408,11 +471,13 @@ class ProcessTemplateManagementController extends Controller
             ->first();
 
         if ($previousStep) {
+            $before = $this->stepOrderSnapshot($processTemplate);
             $origStep = $step->step_number;
             $origPrevious = $previousStep->step_number;
             DB::table('template_steps')->where('id', $step->id)->update(['step_number' => -1]);
             DB::table('template_steps')->where('id', $previousStep->id)->update(['step_number' => $origStep]);
             DB::table('template_steps')->where('id', $step->id)->update(['step_number' => $origPrevious]);
+            $this->recordStepAudit($processTemplate, 'template_steps.reordered', $before, $this->stepOrderSnapshot($processTemplate->fresh()));
         }
 
         return redirect()->route('admin.product-types.process-templates.show', [$productType, $processTemplate])
@@ -441,11 +506,13 @@ class ProcessTemplateManagementController extends Controller
             ->first();
 
         if ($nextStep) {
+            $before = $this->stepOrderSnapshot($processTemplate);
             $origStep = $step->step_number;
             $origNext = $nextStep->step_number;
             DB::table('template_steps')->where('id', $step->id)->update(['step_number' => -1]);
             DB::table('template_steps')->where('id', $nextStep->id)->update(['step_number' => $origStep]);
             DB::table('template_steps')->where('id', $step->id)->update(['step_number' => $origNext]);
+            $this->recordStepAudit($processTemplate, 'template_steps.reordered', $before, $this->stepOrderSnapshot($processTemplate->fresh()));
         }
 
         return redirect()->route('admin.product-types.process-templates.show', [$productType, $processTemplate])

--- a/backend/app/Models/ProcessTemplate.php
+++ b/backend/app/Models/ProcessTemplate.php
@@ -158,6 +158,24 @@ class ProcessTemplate extends Model
     }
 
     /**
+     * How many non-finished work orders currently reference this template —
+     * either as their primary process (`process_snapshot.template_id`) or as one
+     * of their selected BOMs (`work_order_boms`). Used to warn an admin that
+     * editing the steps here won't touch those running orders (they keep their
+     * frozen snapshot) and isn't versioned.
+     */
+    public function activeWorkOrderCount(): int
+    {
+        return \App\Models\WorkOrder::query()
+            ->whereNotIn('status', \App\Models\WorkOrder::TERMINAL_STATUSES)
+            ->where(function ($q) {
+                $q->where('process_snapshot->template_id', $this->id)
+                    ->orWhereHas('bomTemplates', fn ($b) => $b->where('process_templates.id', $this->id));
+            })
+            ->count();
+    }
+
+    /**
      * Scope to get only active templates.
      */
     public function scopeActive($query)

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5669,5 +5669,9 @@
     "Region": "Region",
     "Select timezone": "Select timezone",
     "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.",
-    "Changing the timezone reloads the page so every displayed time switches over at once.": "Changing the timezone reloads the page so every displayed time switches over at once."
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Changing the timezone reloads the page so every displayed time switches over at once.",
+    "This template backs :count active work order(s).": "This template backs :count active work order(s).",
+    "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.": "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.",
+    "Edit a template that is in use?": "Edit a template that is in use?",
+    "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5669,5 +5669,9 @@
     "Region": "Region",
     "Select timezone": "Wybierz strefę czasową",
     "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Strefa czasowa zakładu. Wszystkie znaczniki czasu, granice raportów i zmian w aplikacji są w niej wyrażone.",
-    "Changing the timezone reloads the page so every displayed time switches over at once.": "Zmiana strefy czasowej przeładowuje stronę, aby wszystkie wyświetlane godziny zmieniły się naraz."
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Zmiana strefy czasowej przeładowuje stronę, aby wszystkie wyświetlane godziny zmieniły się naraz.",
+    "This template backs :count active work order(s).": "Ten szablon obsługuje :count aktywnych zleceń.",
+    "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.": "Edycja kroków tutaj nie wpływa na trwające zlecenia — zachowują one zamrożony snapshot z chwili utworzenia. Zmiany nie są wersjonowane; poprzedni kształt pozostaje wyłącznie w dzienniku audytu. Dla kontrolowanej zmiany konkretnego zlecenia użyj jego wniosku o zmianę.",
+    "Edit a template that is in use?": "Edytować szablon będący w użyciu?",
+    "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "Ten szablon obsługuje :count aktywnych zleceń. Zachowują one zamrożony snapshot i pozostają nienaruszone, ale ta zmiana nie jest wersjonowana — poprzedni kształt zachowuje tylko dziennik audytu."
 }

--- a/backend/resources/js/Pages/admin/process-templates/Show.jsx
+++ b/backend/resources/js/Pages/admin/process-templates/Show.jsx
@@ -941,6 +941,7 @@ export default function ProcessTemplatesShow() {
     const { productType, processTemplate, workstations = [], processSegments = [], workstationTypes = [] } = usePage().props;
 
     const steps = processTemplate.steps ?? [];
+    const activeWoCount = processTemplate.active_work_order_count ?? 0;
     const allPhotos = processTemplate.photos ?? [];
     const photoByStep = {};
     allPhotos.forEach((p) => {
@@ -952,24 +953,42 @@ export default function ProcessTemplatesShow() {
     const [saveStatus, setSaveStatus] = useState(null); // 'saving' | 'saved' | 'error'
     const { confirm, dialog } = useConfirm();
 
+    // When the template is in use, gate destructive step edits behind a confirm
+    // that spells out the consequence (running orders keep their frozen snapshot;
+    // this change isn't versioned but is recorded in the audit log).
+    const inUseBody = __(
+        'This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.',
+        { count: activeWoCount },
+    );
+    const confirmIfInUse = (onConfirm) => {
+        if (activeWoCount > 0) {
+            confirm({ title: __('Edit a template that is in use?'), body: inUseBody }, onConfirm);
+        } else {
+            onConfirm();
+        }
+    };
+
     const handleMoveUp = (step) => {
-        router.post(
+        confirmIfInUse(() => router.post(
             `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/steps/${step.id}/move-up`,
             {},
             { preserveScroll: true },
-        );
+        ));
     };
 
     const handleMoveDown = (step) => {
-        router.post(
+        confirmIfInUse(() => router.post(
             `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/steps/${step.id}/move-down`,
             {},
             { preserveScroll: true },
-        );
+        ));
     };
 
     const handleDelete = (step) => {
-        confirm({ title: 'Delete this step?' }, () => {
+        confirm({
+            title: __('Delete this step?'),
+            body: activeWoCount > 0 ? inUseBody : undefined,
+        }, () => {
             router.delete(
                 `/admin/product-types/${productType.id}/process-templates/${processTemplate.id}/steps/${step.id}`,
                 { preserveScroll: true },
@@ -1113,6 +1132,23 @@ export default function ProcessTemplatesShow() {
                         workstationTypes={workstationTypes}
                         onCancel={() => setShowAddForm(false)}
                     />
+                )}
+
+                {/* In-use warning: editing steps here mutates the template in place. */}
+                {activeWoCount > 0 && (
+                    <div className="mb-4 flex items-start gap-3 rounded-lg border border-om-downtime/40 bg-om-downtime-bg px-4 py-3">
+                        <svg className="w-5 h-5 mt-0.5 shrink-0 text-om-downtime" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                        </svg>
+                        <div className="text-sm text-om-ink">
+                            <p className="font-semibold">
+                                {__('This template backs :count active work order(s).', { count: activeWoCount })}
+                            </p>
+                            <p className="text-om-muted mt-0.5">
+                                {__('Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.')}
+                            </p>
+                        </div>
+                    </div>
                 )}
 
                 {/* Steps List header */}

--- a/backend/tests/Feature/Web/Admin/ProcessTemplateEditGuardTest.php
+++ b/backend/tests/Feature/Web/Admin/ProcessTemplateEditGuardTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature\Web\Admin;
+
+use App\Models\AuditLog;
+use App\Models\ProcessTemplate;
+use App\Models\ProductType;
+use App\Models\TemplateStep;
+use App\Models\User;
+use App\Models\WorkOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Editing a ProcessTemplate's steps mutates rows in place (running orders keep
+ * their frozen snapshot, correctly). This guards traceability: an in-use count
+ * is surfaced to warn the admin, and every step change is written to the
+ * immutable audit log so the previous shape is never silently lost.
+ */
+class ProcessTemplateEditGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private ProductType $productType;
+
+    private ProcessTemplate $template;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach (['Admin', 'Supervisor', 'Operator'] as $r) {
+            Role::findOrCreate($r, 'web');
+        }
+        $this->admin = tap(User::factory()->create(), fn ($u) => $u->assignRole('Admin'));
+        $this->productType = ProductType::factory()->create();
+        $this->template = ProcessTemplate::factory()->create(['product_type_id' => $this->productType->id]);
+    }
+
+    private function step(int $number = 1, string $name = 'Assemble'): TemplateStep
+    {
+        return TemplateStep::factory()->create([
+            'process_template_id' => $this->template->id,
+            'step_number' => $number,
+            'name' => $name,
+        ]);
+    }
+
+    private function base(): string
+    {
+        return "/admin/product-types/{$this->productType->id}/process-templates/{$this->template->id}";
+    }
+
+    private function orderForTemplate(string $status): WorkOrder
+    {
+        return WorkOrder::factory()->create([
+            'process_snapshot' => ['template_id' => $this->template->id],
+            'status' => $status,
+        ]);
+    }
+
+    public function test_active_work_order_count_counts_non_terminal_orders_only(): void
+    {
+        $this->orderForTemplate(WorkOrder::STATUS_IN_PROGRESS);
+        $this->orderForTemplate(WorkOrder::STATUS_PENDING);
+        $this->orderForTemplate(WorkOrder::STATUS_DONE);       // terminal — ignored
+        $this->orderForTemplate(WorkOrder::STATUS_CANCELLED);  // terminal — ignored
+
+        $this->assertSame(2, $this->template->fresh()->activeWorkOrderCount());
+    }
+
+    public function test_show_exposes_the_active_work_order_count(): void
+    {
+        $this->step();
+        $this->orderForTemplate(WorkOrder::STATUS_IN_PROGRESS);
+
+        $this->actingAs($this->admin)
+            ->get("{$this->base()}")
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $p) => $p
+                ->component('admin/process-templates/Show')
+                ->where('processTemplate.active_work_order_count', 1));
+    }
+
+    public function test_adding_a_step_is_recorded_in_the_audit_log(): void
+    {
+        $this->actingAs($this->admin)->post("{$this->base()}/steps", ['name' => 'New step'])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity_type' => ProcessTemplate::class,
+            'entity_id' => $this->template->id,
+            'action' => 'template_step.added',
+        ]);
+    }
+
+    public function test_updating_a_step_records_before_and_after(): void
+    {
+        $step = $this->step(1, 'Original');
+
+        $this->actingAs($this->admin)->put("{$this->base()}/steps/{$step->id}", ['name' => 'Renamed'])
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'template_step.updated')->latest('id')->first();
+        $this->assertNotNull($log);
+        $this->assertSame('Original', $log->before_state['name']);
+        $this->assertSame('Renamed', $log->after_state['name']);
+    }
+
+    public function test_deleting_a_step_is_recorded_with_the_prior_shape(): void
+    {
+        $step = $this->step(1, 'Doomed');
+
+        $this->actingAs($this->admin)->delete("{$this->base()}/steps/{$step->id}")
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'template_step.deleted')->latest('id')->first();
+        $this->assertNotNull($log);
+        $this->assertSame('Doomed', $log->before_state['name']);
+        $this->assertNull($log->after_state);
+    }
+
+    public function test_reordering_steps_is_recorded(): void
+    {
+        $a = $this->step(1, 'A');
+        $b = $this->step(2, 'B');
+
+        $this->actingAs($this->admin)->post("{$this->base()}/steps/reorder", ['order' => [$b->id, $a->id]])
+            ->assertOk();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity_type' => ProcessTemplate::class,
+            'entity_id' => $this->template->id,
+            'action' => 'template_steps.reordered',
+        ]);
+    }
+}


### PR DESCRIPTION
Closes a traceability gap: editing a `ProcessTemplate`'s steps (add / rename / delete / reorder) mutates the rows **in place**, with no version bump, no history and no warning — while work orders referencing it keep running against a now-undocumented old shape.

The frozen-snapshot behaviour is **correct and unchanged** (already-created batches keep their original steps). This PR only adds the missing *steering and trace*.

## What it does (Option A — warn + confirm + audit)
- **`ProcessTemplate::activeWorkOrderCount()`** — counts non-terminal work orders that reference the template, via `process_snapshot.template_id` **or** a selected BOM (`work_order_boms`).
- **Warning banner** on the template page when it backs active work orders: explains that running orders keep their frozen snapshot, the change isn't versioned, and the previous shape lives only in the audit log (points to per-order change requests for controlled changes).
- **Confirmation** before destructive step edits (delete / move up/down) while the template is in use.
- **Immutable audit trail** — every step change (`add / update / delete / reorder / move`) is written to the existing `AuditLog` with `before_state` / `after_state`, so the prior shape is never silently lost. No new table.

## Why not version-bump / change-request flow (for now)
Those are the heavier directions (B/C) and were explicitly deferred — the existing `ChangeRequestService` is **work-order-scoped**, not template-scoped, so it doesn't map onto template editing without new machinery. This PR is the low-risk, high-value first step.

## Tests
6 new (`ProcessTemplateEditGuardTest`): active-count excludes terminal orders, show exposes the count, and add/update/delete/reorder each write the expected audit entry (before/after). Full suite **2512 passed** · Pint clean · frontend build OK · en/pl parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when editing process templates used by active work orders.
  * Added confirmation prompts for deleting or reordering steps in in-use templates.
  * Running work orders retain their original process snapshots.
  * Added immutable audit records for template-step additions, updates, deletions, and reordering.

* **Bug Fixes**
  * Terminal work orders are excluded from active-template usage counts.

* **Documentation**
  * Added English and Polish translations and changelog coverage for the new safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #266