### PR TITLE
feat(planner): place defined maintenance as distinct yellow tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Add maintenance to the planner** *(admin)* — a new **+ Maintenance** button on the schedule planner opens a modal to place a **defined maintenance** (a maintenance schedule, which pre-fills its title / type / line) or an ad-hoc one onto a line at a chosen date, time and duration. It lands as a **distinct yellow tile** in the line's maintenance strip (maintenance tiles are now yellow instead of purple, so they stand out from work orders). Backed by `POST /admin/schedule/maintenance`.
+
+### Added
 - **Plant timezone is changeable after installation** *(admin)* — Settings → System → General now carries a timezone picker (region + zone), writing the same `system_settings` row the installer's step does; the wizard already promised this was possible. The chosen zone is re-applied per request and before each queued job, so on Octane a change reaches every worker immediately instead of waiting for a container restart. Saving reloads the page so every displayed time switches over at once.
 - **Product types as Bill-of-Materials components** *(admin)* — a BOM line can now be a manufactured **product type** (a sub-assembly), not only a material. In the BOM editor a Material / Product type switch picks the component kind; product-type lines carry the same quantity-per-unit, step, scrap %, consumption timing and notes as materials. A product type can't be a component of itself, and each appears once per template. Lines are captured in the work-order snapshot as sub-assembly references; they're a simple component reference (they don't explode into their own BOM) and are skipped by the material stock/consumption engine. Additive — existing material BOMs are unaffected.
 

--- a/backend/app/Http/Controllers/Web/Admin/SchedulePlannerController.php
+++ b/backend/app/Http/Controllers/Web/Admin/SchedulePlannerController.php
@@ -158,6 +158,28 @@ class SchedulePlannerController extends Controller
         ]);
     }
 
+    /**
+     * Place a maintenance event on the planner (the "Add maintenance" modal). A
+     * defined maintenance schedule can pre-fill it, or an ad-hoc title/type.
+     */
+    public function storeMaintenance(Request $request)
+    {
+        $validated = $request->validate([
+            'schedule_id' => ['nullable', 'integer', 'exists:maintenance_schedules,id'],
+            'title' => ['required_without:schedule_id', 'nullable', 'string', 'max:255'],
+            'event_type' => ['nullable', 'in:planned,corrective,inspection'],
+            'line_id' => ['required', 'integer', 'exists:lines,id'],
+            'workstation_id' => ['nullable', 'integer', 'exists:workstations,id'],
+            'scheduled_at' => ['required', 'date'],
+            'duration_minutes' => ['nullable', 'integer', 'min:1', 'max:10080'],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $this->planner->createMaintenanceEvent($validated);
+
+        return back()->with('success', __('Maintenance added to the planner.'));
+    }
+
     public function checkUpdates(Request $request)
     {
         $lastUpdated = WorkOrder::max('updated_at');

--- a/backend/app/Http/Controllers/Web/Admin/SchedulePlannerController.php
+++ b/backend/app/Http/Controllers/Web/Admin/SchedulePlannerController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Web\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Web\Admin\StoreMaintenanceEventRequest;
 use App\Models\ScheduleChangeLog;
 use App\Models\WorkOrder;
 use App\Services\Schedule\SchedulePlannerService;
@@ -162,20 +163,9 @@ class SchedulePlannerController extends Controller
      * Place a maintenance event on the planner (the "Add maintenance" modal). A
      * defined maintenance schedule can pre-fill it, or an ad-hoc title/type.
      */
-    public function storeMaintenance(Request $request)
+    public function storeMaintenance(StoreMaintenanceEventRequest $request)
     {
-        $validated = $request->validate([
-            'schedule_id' => ['nullable', 'integer', 'exists:maintenance_schedules,id'],
-            'title' => ['required_without:schedule_id', 'nullable', 'string', 'max:255'],
-            'event_type' => ['nullable', 'in:planned,corrective,inspection'],
-            'line_id' => ['required', 'integer', 'exists:lines,id'],
-            'workstation_id' => ['nullable', 'integer', 'exists:workstations,id'],
-            'scheduled_at' => ['required', 'date'],
-            'duration_minutes' => ['nullable', 'integer', 'min:1', 'max:10080'],
-            'description' => ['nullable', 'string'],
-        ]);
-
-        $this->planner->createMaintenanceEvent($validated);
+        $this->planner->createMaintenanceEvent($request->validated());
 
         return back()->with('success', __('Maintenance added to the planner.'));
     }

--- a/backend/app/Http/Requests/Web/Admin/StoreMaintenanceEventRequest.php
+++ b/backend/app/Http/Requests/Web/Admin/StoreMaintenanceEventRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Web\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate an "Add maintenance" placement on the planner. A defined maintenance
+ * schedule can pre-fill it (must be active — the planner only offers active
+ * schedules, so a direct POST cannot smuggle in an inactive one), or an ad-hoc
+ * title/type is supplied instead. Admin access is gated by the route middleware.
+ */
+class StoreMaintenanceEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'schedule_id' => [
+                'nullable', 'integer',
+                Rule::exists('maintenance_schedules', 'id')->where('is_active', true),
+            ],
+            'title' => ['required_without:schedule_id', 'nullable', 'string', 'max:255'],
+            'event_type' => ['nullable', 'in:planned,corrective,inspection'],
+            'line_id' => ['required', 'integer', 'exists:lines,id'],
+            'workstation_id' => ['nullable', 'integer', 'exists:workstations,id'],
+            'scheduled_at' => ['required', 'date'],
+            'duration_minutes' => ['nullable', 'integer', 'min:1', 'max:10080'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/app/Services/Schedule/SchedulePlannerService.php
+++ b/backend/app/Services/Schedule/SchedulePlannerService.php
@@ -236,6 +236,19 @@ class SchedulePlannerService
                     : 60,
                 'description' => $m->description,
             ])->values()->all(),
+            // Defined maintenance (schedules) offered in the planner's "Add
+            // maintenance" modal — drop one onto a line/day as a yellow tile.
+            'maintenanceSchedules' => MaintenanceSchedule::where('is_active', true)
+                ->orderBy('name')
+                ->get(['id', 'name', 'event_type', 'line_id', 'workstation_id', 'description'])
+                ->map(fn ($s) => [
+                    'id' => $s->id,
+                    'name' => $s->name,
+                    'event_type' => $s->event_type,
+                    'line_id' => $s->line_id,
+                    'workstation_id' => $s->workstation_id,
+                    'description' => $s->description,
+                ])->values()->all(),
             'realtimeMode' => $realtimeMode,
             'overdueImportant' => [
                 'count' => $importantOverdueCount,
@@ -251,6 +264,35 @@ class SchedulePlannerService
      *
      * @return array{conflict:bool, message?:string, warnings?:array<string>}
      */
+    /**
+     * Place a maintenance event on the planner (the "Add maintenance" modal). A
+     * defined schedule (schedule_id) pre-fills the title / type / line; a bare
+     * title + event_type works too. Lands as a pending tile at the chosen slot.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function createMaintenanceEvent(array $input): MaintenanceEvent
+    {
+        $schedule = ! empty($input['schedule_id'])
+            ? MaintenanceSchedule::find($input['schedule_id'])
+            : null;
+
+        $scheduledAt = Carbon::parse($input['scheduled_at']);
+        $duration = (int) ($input['duration_minutes'] ?? 60);
+
+        return MaintenanceEvent::create([
+            'title' => $input['title'] ?? $schedule?->name ?? 'Maintenance',
+            'event_type' => $input['event_type'] ?? $schedule?->event_type ?? MaintenanceEvent::TYPE_PLANNED,
+            'status' => MaintenanceEvent::STATUS_PENDING,
+            'line_id' => $input['line_id'] ?? $schedule?->line_id,
+            'workstation_id' => $input['workstation_id'] ?? $schedule?->workstation_id,
+            'schedule_id' => $schedule?->id,
+            'scheduled_at' => $scheduledAt,
+            'scheduled_end_at' => $scheduledAt->copy()->addMinutes(max(1, $duration)),
+            'description' => $input['description'] ?? $schedule?->description,
+        ]);
+    }
+
     public function updateOrder(WorkOrder $workOrder, array $input, bool $force = false): array
     {
         $data = [];

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5669,5 +5669,14 @@
     "Region": "Region",
     "Select timezone": "Select timezone",
     "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.",
-    "Changing the timezone reloads the page so every displayed time switches over at once.": "Changing the timezone reloads the page so every displayed time switches over at once."
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Changing the timezone reloads the page so every displayed time switches over at once.",
+    "Add maintenance": "Add maintenance",
+    "Defined maintenance": "Defined maintenance",
+    "— None (custom) —": "— None (custom) —",
+    "e.g. Lubrication": "e.g. Lubrication",
+    "Minutes": "Minutes",
+    "Add to planner": "Add to planner",
+    "Pick a line, a date and a maintenance (defined or a title).": "Pick a line, a date and a maintenance (defined or a title).",
+    "Maintenance added to the planner.": "Maintenance added to the planner.",
+    "Could not add maintenance.": "Could not add maintenance."
 }

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5692,5 +5692,8 @@
     "Edit a template that is in use?": "Edit a template that is in use?",
     "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.",
     "Action parameters must be a JSON object.": "Action parameters must be a JSON object.",
-    "Could not add the maintenance.": "Could not add the maintenance."
+    "Could not add the maintenance.": "Could not add the maintenance.",
+    "Pick a maintenance for this slot": "Pick a maintenance for this slot",
+    "Search maintenance": "Search maintenance",
+    "No maintenance schedules.": "No maintenance schedules."
 }

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5691,5 +5691,6 @@
     "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.": "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.",
     "Edit a template that is in use?": "Edit a template that is in use?",
     "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.",
-    "Action parameters must be a JSON object.": "Action parameters must be a JSON object."
+    "Action parameters must be a JSON object.": "Action parameters must be a JSON object.",
+    "Could not add the maintenance.": "Could not add the maintenance."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5691,5 +5691,6 @@
     "Editing steps here does not affect those running orders — they keep the frozen snapshot taken when they were created. Changes are not versioned; the previous shape is kept only in the audit log. For a controlled change to a specific order, use its change request instead.": "Edycja kroków tutaj nie wpływa na trwające zlecenia — zachowują one zamrożony snapshot z chwili utworzenia. Zmiany nie są wersjonowane; poprzedni kształt pozostaje wyłącznie w dzienniku audytu. Dla kontrolowanej zmiany konkretnego zlecenia użyj jego wniosku o zmianę.",
     "Edit a template that is in use?": "Edytować szablon będący w użyciu?",
     "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "Ten szablon obsługuje :count aktywnych zleceń. Zachowują one zamrożony snapshot i pozostają nienaruszone, ale ta zmiana nie jest wersjonowana — poprzedni kształt zachowuje tylko dziennik audytu.",
-    "Action parameters must be a JSON object.": "Parametry akcji muszą być obiektem JSON."
+    "Action parameters must be a JSON object.": "Parametry akcji muszą być obiektem JSON.",
+    "Could not add the maintenance.": "Nie udało się dodać przeglądu."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5669,5 +5669,14 @@
     "Region": "Region",
     "Select timezone": "Wybierz strefę czasową",
     "Plant timezone. Every timestamp, report boundary and shift edge in the app is expressed in it.": "Strefa czasowa zakładu. Wszystkie znaczniki czasu, granice raportów i zmian w aplikacji są w niej wyrażone.",
-    "Changing the timezone reloads the page so every displayed time switches over at once.": "Zmiana strefy czasowej przeładowuje stronę, aby wszystkie wyświetlane godziny zmieniły się naraz."
+    "Changing the timezone reloads the page so every displayed time switches over at once.": "Zmiana strefy czasowej przeładowuje stronę, aby wszystkie wyświetlane godziny zmieniły się naraz.",
+    "Add maintenance": "Dodaj utrzymanie",
+    "Defined maintenance": "Zdefiniowane utrzymanie",
+    "— None (custom) —": "— Brak (własne) —",
+    "e.g. Lubrication": "np. Smarowanie",
+    "Minutes": "Minuty",
+    "Add to planner": "Dodaj do planera",
+    "Pick a line, a date and a maintenance (defined or a title).": "Wybierz linię, datę i utrzymanie (zdefiniowane lub tytuł).",
+    "Maintenance added to the planner.": "Utrzymanie dodane do planera.",
+    "Could not add maintenance.": "Nie udało się dodać utrzymania."
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5692,5 +5692,8 @@
     "Edit a template that is in use?": "Edytować szablon będący w użyciu?",
     "This template backs :count active work order(s). They keep their frozen snapshot and are unaffected, but this change is not versioned — only the audit log keeps the previous shape.": "Ten szablon obsługuje :count aktywnych zleceń. Zachowują one zamrożony snapshot i pozostają nienaruszone, ale ta zmiana nie jest wersjonowana — poprzedni kształt zachowuje tylko dziennik audytu.",
     "Action parameters must be a JSON object.": "Parametry akcji muszą być obiektem JSON.",
-    "Could not add the maintenance.": "Nie udało się dodać przeglądu."
+    "Could not add the maintenance.": "Nie udało się dodać przeglądu.",
+    "Pick a maintenance for this slot": "Wybierz przegląd dla tego slotu",
+    "Search maintenance": "Szukaj przeglądu",
+    "No maintenance schedules.": "Brak harmonogramów przeglądów."
 }

--- a/backend/resources/js/Pages/admin/schedule/Planner.jsx
+++ b/backend/resources/js/Pages/admin/schedule/Planner.jsx
@@ -13,6 +13,7 @@ import { HourlyView, MonthlyView } from './planner/views2';
 import { Toolbar, BacklogRail } from './planner/panels';
 import {
     OrderEditSheet, AssignPopup, ConflictDialog, LiveTrackingBar, Toasts, SavingOverlay,
+    AddMaintenanceModal,
 } from './planner/modals';
 
 // Hover affordances for the design's work-order blocks (brightness + reveal ✕).
@@ -40,7 +41,7 @@ export default function Planner() {
         workOrders = [], lines = [], allLines = [], shifts = [],
         viewMode = 'weekly', shiftsPerDay = 1, slotMinutes = 15, showWeekends = true,
         startDate, rangeStart, rangeEnd, navPrev, navNext,
-        backlogOrders = [], maintenanceEvents = [], realtimeMode = 'polling',
+        backlogOrders = [], maintenanceEvents = [], maintenanceSchedules = [], realtimeMode = 'polling',
         overdueImportant = { count: 0, orders: [] },
     } = usePage().props;
 
@@ -65,6 +66,7 @@ export default function Planner() {
     const [conflict, setConflict] = useState(null);     // { apply }
     const [confirmBox, setConfirmBox] = useState(null); // { title, body, confirmLabel, apply }
     const [trackingData, setTrackingData] = useState(null);
+    const [maintOpen, setMaintOpen] = useState(false);
     const draggingRef = useRef(false);
 
     const toast = useCallback((msg, kind = 'success') => {
@@ -362,6 +364,13 @@ export default function Planner() {
             <Toolbar ctx={ctx} view={viewMode} setView={setView} lineFilter={lineId} setLineFilter={setLineFilter}
                 live={live} onPrev={() => goTo(navPrev)} onNext={() => goTo(navNext)} onToday={() => nav({ view_mode: viewMode, line_id: lineId })} rangeLabel={rangeLabel} />
 
+            <div className="flex justify-end mb-2">
+                <button type="button" onClick={() => setMaintOpen(true)}
+                    style={{ fontSize: 12.5, fontWeight: 600, color: '#78350f', background: '#fde68a', border: '1px solid #d97706', borderRadius: 8, padding: '7px 12px' }}>
+                    + {__('Maintenance')}
+                </button>
+            </div>
+
             <div className="flex items-start" style={{ border: '1px solid var(--om-line)', borderRadius: 12, overflow: 'hidden', background: 'var(--om-bg)' }}>
                 <div className="om-main flex-1 min-w-0" style={{ padding: '18px 20px', overflow: 'auto' }}>
                     {viewMode === 'weekly' && <WeeklyView ctx={ctx} />}
@@ -382,6 +391,16 @@ export default function Planner() {
                     title={confirmBox.title} confirmLabel={confirmBox.confirmLabel} cancelLabel={__('Cancel')}>
                     {confirmBox.body}
                 </ConfirmDialog>
+            )}
+            {maintOpen && (
+                <AddMaintenanceModal
+                    lines={allLines}
+                    schedules={maintenanceSchedules}
+                    startDate={startDate}
+                    onClose={() => setMaintOpen(false)}
+                    onCreated={() => { setMaintOpen(false); toast(__('Maintenance added to the planner.')); }}
+                    onError={(msg) => toast(msg || __('Could not add maintenance.'), 'error')}
+                />
             )}
             {saving && <SavingOverlay />}
             <Toasts toasts={toasts} />

--- a/backend/resources/js/Pages/admin/schedule/Planner.jsx
+++ b/backend/resources/js/Pages/admin/schedule/Planner.jsx
@@ -383,7 +383,30 @@ export default function Planner() {
             </DndProvider>
 
             {selected && <OrderEditSheet wo={selected} ctx={ctx} onClose={() => setSelected(null)} onSave={saveEdit} onUnassign={unassign} />}
-            {assignTarget && <AssignPopup target={assignTarget} ctx={ctx} onClose={() => setAssignTarget(null)} onPick={(wo, target) => { setAssignTarget(null); dropToCell(wo, target); }} />}
+            {assignTarget && (
+                <AssignPopup
+                    target={assignTarget}
+                    ctx={ctx}
+                    schedules={maintenanceSchedules}
+                    onClose={() => setAssignTarget(null)}
+                    onPick={(wo, target) => { setAssignTarget(null); dropToCell(wo, target); }}
+                    onPickMaintenance={(s, target) => {
+                        setAssignTarget(null);
+                        router.post('/admin/schedule/maintenance', {
+                            schedule_id: s.id,
+                            title: s.name || null,
+                            event_type: s.event_type || 'planned',
+                            line_id: target.lineId,
+                            scheduled_at: `${target.date} 08:00`,
+                            duration_minutes: s.duration_minutes || 60,
+                        }, {
+                            preserveScroll: true,
+                            onSuccess: () => toast(__('Maintenance added to the planner.')),
+                            onError: (errors) => toast(Object.values(errors || {})[0] || __('Could not add maintenance.'), 'error'),
+                        });
+                    }}
+                />
+            )}
             {conflict && <ConflictDialog onCancel={() => setConflict(null)} onConfirm={() => { conflict.apply(); setConflict(null); }} />}
             {confirmBox && (
                 <ConfirmDialog open onClose={() => setConfirmBox(null)}

--- a/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
@@ -245,28 +245,48 @@ export function OrderEditSheet({ wo, ctx, onClose, onSave, onUnassign }) {
     );
 }
 
-// Assign popup — pick a backlog order for an empty cell.
-export function AssignPopup({ target, ctx, onClose, onPick }) {
+// Assign popup — pick a backlog order OR a defined maintenance for an empty cell.
+export function AssignPopup({ target, ctx, schedules = [], onClose, onPick, onPickMaintenance }) {
     const { data } = ctx;
     const [q, setQ] = useState('');
+    const [tab, setTab] = useState('orders');
     const line = data.allLines.find((l) => l.id === target.lineId);
-    const items = data.backlog.filter((o) => q === '' || o.order_no.toLowerCase().includes(q.toLowerCase()) || (o.product_name || '').toLowerCase().includes(q.toLowerCase()));
+    const orders = data.backlog.filter((o) => q === '' || o.order_no.toLowerCase().includes(q.toLowerCase()) || (o.product_name || '').toLowerCase().includes(q.toLowerCase()));
+    const maints = schedules.filter((s) => q === '' || (s.name || '').toLowerCase().includes(q.toLowerCase()));
+
+    const tabBtn = (key, label) => (
+        <button onClick={() => setTab(key)} style={{
+            flex: 1, fontSize: 12, fontWeight: 600, padding: '7px 0', borderRadius: 8, cursor: 'pointer',
+            color: tab === key ? 'var(--om-ink)' : 'var(--om-muted)',
+            background: tab === key ? 'var(--om-card)' : 'transparent',
+            border: tab === key ? '1px solid var(--om-line)' : '1px solid transparent',
+        }}>{label}</button>
+    );
+
     return (
         <Backdrop onClose={onClose}>
             <div style={{ width: 440, maxWidth: '92vw', maxHeight: 560, display: 'flex', flexDirection: 'column', background: 'var(--om-card)', border: '1px solid var(--om-line)', borderRadius: 14, boxShadow: '0 34px 80px -22px rgba(0,0,0,.5)', overflow: 'hidden' }}>
                 <div style={{ padding: '18px 20px', borderBottom: '1px solid var(--om-line2)' }}>
                     <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--om-ink)' }}>{__('Assign to')} {line?.code} · {target.date}</div>
-                    <div style={{ fontFamily: MONO, fontSize: 10.5, color: 'var(--om-faint)', marginTop: 3 }}>{__('Pick a backlog order for this slot')}</div>
+                    <div style={{ fontFamily: MONO, fontSize: 10.5, color: 'var(--om-faint)', marginTop: 3 }}>
+                        {tab === 'orders' ? __('Pick a backlog order for this slot') : __('Pick a maintenance for this slot')}
+                    </div>
                 </div>
-                <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--om-line2)' }}>
-                    <div className="flex items-center gap-2" style={{ background: 'var(--om-bg)', border: '1px solid var(--om-line)', borderRadius: 8, padding: '8px 11px' }}>
+                {onPickMaintenance && (
+                    <div className="flex gap-1.5" style={{ padding: '10px 20px 0', background: 'var(--om-bg)' }}>
+                        {tabBtn('orders', __('Orders'))}
+                        {tabBtn('maintenance', __('Maintenance'))}
+                    </div>
+                )}
+                <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--om-line2)', background: 'var(--om-bg)' }}>
+                    <div className="flex items-center gap-2" style={{ background: 'var(--om-card)', border: '1px solid var(--om-line)', borderRadius: 8, padding: '8px 11px' }}>
                         <span style={{ width: 12, height: 12, borderRadius: 999, border: '2px solid var(--om-faint)' }} />
-                        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={__('Search order or product')} autoFocus
+                        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={tab === 'orders' ? __('Search order or product') : __('Search maintenance')} autoFocus
                             className="flex-1 min-w-0 outline-none" style={{ border: 'none', background: 'transparent', fontSize: 12.5, color: 'var(--om-ink)' }} />
                     </div>
                 </div>
                 <div className="om-bl flex-1 overflow-y-auto" style={{ padding: '12px 20px' }}>
-                    {items.map((wo) => (
+                    {tab === 'orders' && orders.map((wo) => (
                         <div key={wo.id} onClick={() => onPick(wo, target)} className="flex items-center gap-3"
                             style={{ padding: '11px 12px', border: '1px solid var(--om-line)', borderRadius: 9, marginBottom: 8, cursor: 'pointer' }}>
                             <div className="flex-1 min-w-0">
@@ -276,7 +296,22 @@ export function AssignPopup({ target, ctx, onClose, onPick }) {
                             <StatusPill status={wo.status} />
                         </div>
                     ))}
-                    {items.length === 0 && <div className="text-center" style={{ padding: 30, color: 'var(--om-faint)', fontSize: 12.5 }}>{__('No matching orders.')}</div>}
+                    {tab === 'orders' && orders.length === 0 && <div className="text-center" style={{ padding: 30, color: 'var(--om-faint)', fontSize: 12.5 }}>{__('No matching orders.')}</div>}
+
+                    {tab === 'maintenance' && maints.map((s) => (
+                        <div key={s.id} onClick={() => onPickMaintenance(s, target)} className="flex items-center gap-3"
+                            style={{ padding: '11px 12px', border: '1px solid var(--om-line)', borderRadius: 9, marginBottom: 8, cursor: 'pointer' }}>
+                            <span style={{ width: 10, height: 10, borderRadius: 3, background: '#fde68a', border: '1px solid #d97706', flexShrink: 0 }} />
+                            <div className="flex-1 min-w-0">
+                                <div style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--om-ink)', marginBottom: 3 }}>{s.name}</div>
+                                <div style={{ fontFamily: MONO, fontSize: 9.5, color: 'var(--om-faint)' }}>
+                                    {__(s.event_type === 'corrective' ? 'Corrective' : s.event_type === 'inspection' ? 'Inspection' : 'Planned')}
+                                    {s.line_id ? ' · ' + (data.allLines.find((l) => l.id === s.line_id)?.code ?? '') : ''}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                    {tab === 'maintenance' && maints.length === 0 && <div className="text-center" style={{ padding: 30, color: 'var(--om-faint)', fontSize: 12.5 }}>{__('No maintenance schedules.')}</div>}
                 </div>
             </div>
         </Backdrop>

--- a/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
@@ -1,7 +1,7 @@
 // Edit panel, assign popup, new-order modal, conflict dialog, live tracking,
 // toast — styled to the OpenMES Schedule design.
 import { useState } from 'react';
-import { usePage } from '@inertiajs/react';
+import { usePage, router } from '@inertiajs/react';
 import { Dropdown, DatePicker } from '@openmes/ui';
 import { __ } from '../../../../lib/i18n';
 import DueCountdown from '../../../../components/DueCountdown';
@@ -10,6 +10,117 @@ import { statusOf, statusLabel, priorityMeta, fmtQty, MONO } from './helpers';
 import { StatusPill } from './OrderCard';
 
 const lblStyle = { fontFamily: MONO, fontSize: 8.5, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--om-faint)', marginBottom: 5 };
+
+const inputStyle = { width: '100%', fontSize: 13, padding: '8px 10px', border: '1px solid var(--om-line)', borderRadius: 8, background: 'var(--om-card)', color: 'var(--om-ink)' };
+
+/**
+ * "Add maintenance" — place a defined maintenance (a MaintenanceSchedule) or an
+ * ad-hoc one onto a line/day as a yellow tile. Posts to the planner; the board
+ * reloads with the new tile.
+ */
+export function AddMaintenanceModal({ lines = [], schedules = [], startDate, onClose, onCreated, onError }) {
+    const [scheduleId, setScheduleId] = useState('');
+    const [title, setTitle] = useState('');
+    const [eventType, setEventType] = useState('planned');
+    const [lineId, setLineId] = useState(lines[0] ? String(lines[0].id) : '');
+    const [date, setDate] = useState(startDate || '');
+    const [time, setTime] = useState('08:00');
+    const [duration, setDuration] = useState('60');
+    const [busy, setBusy] = useState(false);
+
+    const pickSchedule = (v) => {
+        setScheduleId(v);
+        const s = schedules.find((x) => String(x.id) === String(v));
+        if (s) {
+            setTitle(s.name || '');
+            if (s.event_type) setEventType(s.event_type);
+            if (s.line_id) setLineId(String(s.line_id));
+        }
+    };
+
+    const submit = () => {
+        if (!lineId || !date || (!scheduleId && !title.trim())) {
+            onError(__('Pick a line, a date and a maintenance (defined or a title).'));
+            return;
+        }
+        setBusy(true);
+        router.post('/admin/schedule/maintenance', {
+            schedule_id: scheduleId || null,
+            title: title || null,
+            event_type: eventType,
+            line_id: Number(lineId),
+            scheduled_at: `${date} ${time || '00:00'}`,
+            duration_minutes: Number(duration) || 60,
+        }, {
+            preserveScroll: true,
+            onSuccess: () => onCreated(),
+            onError: () => onError(),
+            onFinish: () => setBusy(false),
+        });
+    };
+
+    return (
+        <Backdrop onClose={onClose}>
+            <div style={{ width: 460, maxWidth: '92vw', background: 'var(--om-card)', border: '1px solid var(--om-line)', borderRadius: 14, overflow: 'hidden' }}>
+                <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--om-line2)', display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ width: 10, height: 10, borderRadius: 3, background: '#fde68a', border: '1px solid #d97706' }} />
+                    <h3 style={{ fontSize: 15, fontWeight: 700, color: 'var(--om-ink)' }}>{__('Add maintenance')}</h3>
+                </div>
+                <div style={{ padding: '16px 20px', display: 'grid', gap: 12 }}>
+                    <div>
+                        <div style={lblStyle}>{__('Defined maintenance')}</div>
+                        <Dropdown value={scheduleId} onChange={pickSchedule}
+                            placeholder={__('— None (custom) —')}
+                            options={[{ value: '', label: __('— None (custom) —') }, ...schedules.map((s) => ({ value: String(s.id), label: s.name }))]}
+                            className="w-full" />
+                    </div>
+                    <div>
+                        <div style={lblStyle}>{__('Title')}</div>
+                        <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder={__('e.g. Lubrication')} style={inputStyle} />
+                    </div>
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                        <div>
+                            <div style={lblStyle}>{__('Type')}</div>
+                            <Dropdown value={eventType} onChange={setEventType}
+                                options={[
+                                    { value: 'planned', label: __('Planned') },
+                                    { value: 'corrective', label: __('Corrective') },
+                                    { value: 'inspection', label: __('Inspection') },
+                                ]} className="w-full" />
+                        </div>
+                        <div>
+                            <div style={lblStyle}>{__('Line')}</div>
+                            <Dropdown value={lineId} onChange={setLineId}
+                                options={lines.map((l) => ({ value: String(l.id), label: l.code ? `${l.code} · ${l.name}` : l.name }))}
+                                className="w-full" />
+                        </div>
+                    </div>
+                    <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr 1fr', gap: 12 }}>
+                        <div>
+                            <div style={lblStyle}>{__('Date')}</div>
+                            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} style={inputStyle} />
+                        </div>
+                        <div>
+                            <div style={lblStyle}>{__('Time')}</div>
+                            <input type="time" value={time} onChange={(e) => setTime(e.target.value)} style={inputStyle} />
+                        </div>
+                        <div>
+                            <div style={lblStyle}>{__('Minutes')}</div>
+                            <input type="number" min="1" value={duration} onChange={(e) => setDuration(e.target.value)} style={inputStyle} />
+                        </div>
+                    </div>
+                </div>
+                <div style={{ padding: '14px 20px', borderTop: '1px solid var(--om-line2)', display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+                    <button type="button" onClick={onClose} style={{ fontSize: 13, fontWeight: 600, color: 'var(--om-muted)', background: 'var(--om-chip)', borderRadius: 9, padding: '9px 16px' }}>{__('Cancel')}</button>
+                    <button type="button" onClick={submit} disabled={busy}
+                        style={{ fontSize: 13, fontWeight: 700, color: '#78350f', background: '#fde68a', border: '1px solid #d97706', borderRadius: 9, padding: '9px 18px', opacity: busy ? 0.6 : 1 }}>
+                        {busy ? __('Adding…') : __('Add to planner')}
+                    </button>
+                </div>
+            </div>
+        </Backdrop>
+    );
+}
 
 function Backdrop({ children, onClose }) {
     return (

--- a/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/modals.jsx
@@ -54,7 +54,7 @@ export function AddMaintenanceModal({ lines = [], schedules = [], startDate, onC
         }, {
             preserveScroll: true,
             onSuccess: () => onCreated(),
-            onError: () => onError(),
+            onError: (errors) => onError(Object.values(errors || {})[0] || __('Could not add the maintenance.')),
             onFinish: () => setBusy(false),
         });
     };

--- a/backend/resources/js/Pages/admin/schedule/planner/views.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/views.jsx
@@ -25,12 +25,13 @@ const MAINT_H = 17;
 const fmtDow = (d) => formatDate(parseDate(d), { weekday: 'short' });
 const fmtDayMon = (d) => formatDate(parseDate(d), { day: '2-digit', month: 'short' });
 
+// Maintenance tiles are a distinct yellow so they stand out from work orders.
 function MaintPill({ m }) {
     return (
-        <div className="truncate" style={{ border: '1px dashed var(--om-maint)', background: 'var(--om-maint-bg)', borderRadius: 6, padding: '3px 7px', display: 'flex', alignItems: 'center', gap: 5 }}
+        <div className="truncate" style={{ border: '1px solid #d97706', background: '#fde68a', borderRadius: 6, padding: '3px 7px', display: 'flex', alignItems: 'center', gap: 5 }}
             title={m.title + (m.scheduled_at_time ? ' · ' + m.scheduled_at_time : '')}>
-            <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--om-maint)', flexShrink: 0 }} />
-            <span className="truncate" style={{ fontFamily: MONO, fontSize: 9, color: 'var(--om-maint)' }}>{m.title}</span>
+            <span style={{ width: 5, height: 5, borderRadius: 999, background: '#d97706', flexShrink: 0 }} />
+            <span className="truncate" style={{ fontFamily: MONO, fontSize: 9, color: '#78350f' }}>{m.title}</span>
         </div>
     );
 }

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -472,6 +472,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/schedule/changes/{change}/undo', [SchedulePlannerController::class, 'undoChange'])->name('schedule.changes.undo');
         Route::put('/schedule/{workOrder}', [SchedulePlannerController::class, 'updateOrder'])->name('schedule.update');
         Route::put('/schedule/{workOrder}/resize', [SchedulePlannerController::class, 'resizeOrder'])->name('schedule.resize');
+        Route::post('/schedule/maintenance', [SchedulePlannerController::class, 'storeMaintenance'])->name('schedule.maintenance.store');
 
         // Schedule · Employees (tachograph-style day/team/month planner)
         Route::get('/schedule/employees', [\App\Http\Controllers\Web\Admin\EmployeeScheduleController::class, 'index'])->name('schedule.employees');

--- a/backend/tests/Feature/Schedule/PlannerMaintenanceTest.php
+++ b/backend/tests/Feature/Schedule/PlannerMaintenanceTest.php
@@ -93,4 +93,29 @@ class PlannerMaintenanceTest extends TestCase
 
         $this->assertDatabaseCount('maintenance_events', 0);
     }
+
+    public function test_guest_cannot_place_maintenance(): void
+    {
+        $line = Line::factory()->create();
+
+        $this->post(route('admin.schedule.maintenance.store'), [
+            'title' => 'X', 'event_type' => 'planned', 'line_id' => $line->id,
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+        ])->assertRedirect(route('login'));
+
+        $this->assertDatabaseCount('maintenance_events', 0);
+    }
+
+    public function test_an_inactive_schedule_is_rejected(): void
+    {
+        $line = Line::factory()->create();
+        $schedule = MaintenanceSchedule::factory()->create(['is_active' => false]);
+
+        $this->actingAs($this->admin)->post(route('admin.schedule.maintenance.store'), [
+            'schedule_id' => $schedule->id, 'line_id' => $line->id,
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+        ])->assertSessionHasErrors('schedule_id');
+
+        $this->assertDatabaseCount('maintenance_events', 0);
+    }
 }

--- a/backend/tests/Feature/Schedule/PlannerMaintenanceTest.php
+++ b/backend/tests/Feature/Schedule/PlannerMaintenanceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Schedule;
+
+use App\Models\Line;
+use App\Models\MaintenanceEvent;
+use App\Models\MaintenanceSchedule;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Placing maintenance onto the planner: a defined schedule pre-fills it, or an
+ * ad-hoc title works. The event lands as a pending maintenance tile.
+ */
+class PlannerMaintenanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $operator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach (['Admin', 'Supervisor', 'Operator'] as $r) {
+            Role::findOrCreate($r, 'web');
+        }
+        $this->admin = tap(User::factory()->create(), fn ($u) => $u->assignRole('Admin'));
+        $this->operator = tap(User::factory()->create(), fn ($u) => $u->assignRole('Operator'));
+    }
+
+    public function test_admin_can_place_a_defined_maintenance_from_the_planner(): void
+    {
+        $line = Line::factory()->create();
+        $schedule = MaintenanceSchedule::factory()->create([
+            'name' => 'Weekly lube',
+            'event_type' => 'planned',
+            'line_id' => $line->id,
+        ]);
+
+        $this->actingAs($this->admin)->post(route('admin.schedule.maintenance.store'), [
+            'schedule_id' => $schedule->id,
+            'line_id' => $line->id,
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+            'duration_minutes' => 90,
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('maintenance_events', [
+            'title' => 'Weekly lube',
+            'event_type' => 'planned',
+            'line_id' => $line->id,
+            'schedule_id' => $schedule->id,
+            'status' => MaintenanceEvent::STATUS_PENDING,
+        ]);
+    }
+
+    public function test_admin_can_place_an_adhoc_maintenance(): void
+    {
+        $line = Line::factory()->create();
+
+        $this->actingAs($this->admin)->post(route('admin.schedule.maintenance.store'), [
+            'title' => 'Belt swap',
+            'event_type' => 'corrective',
+            'line_id' => $line->id,
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+            'duration_minutes' => 30,
+        ])->assertRedirect();
+
+        $event = MaintenanceEvent::firstWhere('title', 'Belt swap');
+        $this->assertNotNull($event);
+        $this->assertSame($line->id, $event->line_id);
+        $this->assertSame(30, (int) $event->scheduled_at->diffInMinutes($event->scheduled_end_at));
+    }
+
+    public function test_line_and_a_maintenance_are_required(): void
+    {
+        $this->actingAs($this->admin)->post(route('admin.schedule.maintenance.store'), [
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+        ])->assertSessionHasErrors(['line_id', 'title']);
+    }
+
+    public function test_operator_cannot_place_maintenance(): void
+    {
+        $line = Line::factory()->create();
+
+        $this->actingAs($this->operator)->post(route('admin.schedule.maintenance.store'), [
+            'title' => 'X', 'event_type' => 'planned', 'line_id' => $line->id,
+            'scheduled_at' => now()->addDay()->format('Y-m-d H:i'),
+        ])->assertForbidden();
+
+        $this->assertDatabaseCount('maintenance_events', 0);
+    }
+}


### PR DESCRIPTION
Adds the ability to put maintenance on the schedule planner, and makes maintenance tiles a **distinct yellow** so they stand out from work orders.

## What it does
- **+ Maintenance** button on the planner opens an **Add maintenance** modal:
  - pick a **defined maintenance** (a `MaintenanceSchedule` — pre-fills title / type / line), or type an ad-hoc title,
  - choose **line, date, time, duration**,
  - it's placed as a pending **`MaintenanceEvent`** and shows as a **yellow tile** in that line's maintenance strip.
- Maintenance tiles recoloured from purple → **yellow** (`MaintPill`), scoped to the planner.

## Backend
- `SchedulePlannerService::board()` now ships a `maintenanceSchedules` palette (active defined schedules).
- `SchedulePlannerService::createMaintenanceEvent()` + `POST /admin/schedule/maintenance` (`SchedulePlannerController::storeMaintenance`) — a defined schedule pre-fills, ad-hoc works too; lands as a pending tile; the board reloads with it.

## Tests
`PlannerMaintenanceTest`: defined-schedule placement (pre-fill), ad-hoc placement (duration honoured), line + maintenance required, operator forbidden. Full suite **2510 passed** · Pint clean · frontend build OK · en/pl parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin planners can add scheduled or ad-hoc maintenance directly to a line and date.
  * Set maintenance title, type, start time, and duration; maintenance is displayed as a distinct yellow tile.
  * Added validation, success confirmations, and error feedback for maintenance scheduling.
* **Localization**
  * Added English and Polish translations for maintenance scheduling and timezone-related messages.
* **Tests**
  * Added coverage for scheduled and ad-hoc maintenance, required fields, and access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->