### PR TITLE
chore(cla): Contributor License Agreement, CLA gate, and layered licensing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,9 +17,17 @@ reviews:
   poem: false
   review_status: true
   auto_review:
-    enabled: true
+    # Gated on the CLA: auto-review is OFF by default, and a positive label match
+    # turns it on. The CLA workflow (.github/workflows/cla.yml) adds the
+    # `cla-signed` label once every commit author has signed the CLA (and removes
+    # it if an unsigned commit is pushed), so CodeRabbit only reviews after the
+    # CLA is satisfied — first sign, then review. (Per CodeRabbit: when `enabled`
+    # is false, a positive label match still triggers a review.)
+    enabled: false
     drafts: false
-    # The base branches CodeRabbit auto-reviews (regex). This is the key setting.
+    labels:
+      - cla-signed
+    # The base branches CodeRabbit auto-reviews (regex).
     base_branches:
       - develop
       - main

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Closes #
 - [ ] Tested as Operator / Supervisor / Admin role (if UI change)
 
 ## Checklist
+- [ ] I have signed the CLA (or this change is trivial: ≤20 lines, no new logic) — see [CLA.md](../CLA.md)
 - [ ] No `.env` secrets committed
 - [ ] Migration added if schema changed
 - [ ] `$fillable` updated if new model columns added

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,96 @@
+name: CLA Assistant
+
+# Gates every pull request on the Contributor License Agreement (CLA.md).
+# A contributor who has not signed is asked to comment the sign phrase once;
+# their signature is recorded in the private Mes-Open/cla-signatures repo and the
+# check turns green. The owner's accounts, org members and bots are allow-listed
+# and never asked. See docs/cla/SETUP.md for the one-time setup (PAT + repo).
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        id: cla
+        # continue-on-error so the label steps below can run even when the CLA is
+        # not yet satisfied; the final step re-fails the job to keep the required
+        # "CLA Assistant" check red until everyone has signed.
+        continue-on-error: true
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Pinned to the exact commit of v2.6.1 (the action's repo is archived;
+        # pinning to a SHA removes the moving-tag supply-chain risk).
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained PAT with contents:write on Mes-Open/cla-signatures.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_PAT }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/Mes-Open/OpenMes/blob/main/CLA.md'
+          branch: 'main'
+          remote-organization-name: 'Mes-Open'
+          remote-repository-name: 'cla-signatures'
+          # Only the owner's own accounts and bots are exempt. Org members
+          # (Svannte / Mateusz Łuczyński, JanKolo04 / Jan Kołodziej, ElNinio978)
+          # are intentionally NOT allow-listed — they sign via the bot too; their
+          # ICLA then operates on behalf of and with the company's consent (CLA §C4).
+          allowlist: 'jakub-przepiora,jakubprzepiora-cyber,dependabot[bot],github-actions[bot],renovate[bot]'
+          create-file-commit-message: 'chore: create CLA signatures file'
+          signed-commit-message: 'chore: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          custom-notsigned-prcomment: |
+            Thank you for your pull request to OpenMES! / Dziękujemy za pull request do OpenMES!
+
+            Before we can merge it, please sign our Contributor License Agreement — read it in
+            [CLA.md](https://github.com/Mes-Open/OpenMes/blob/main/CLA.md). You keep the copyright to your
+            work; the CLA only grants the project the rights needed to keep OpenMES open source **and** offer
+            it under additional (commercial) licenses.
+
+            Zanim scalimy PR, prosimy o podpisanie CLA (treść w [CLA.md](https://github.com/Mes-Open/OpenMes/blob/main/CLA.md)).
+            Zachowujesz prawa autorskie do swojego kodu.
+
+            To sign, post a comment with exactly the following text / Aby podpisać, wklej komentarz o treści:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you! / Wszyscy autorzy podpisali CLA. Dziękujemy!'
+          lock-pullrequest-aftermerge: false
+
+      # Gate CodeRabbit on the CLA: add the `cla-signed` label once the CLA step
+      # passed (all authors signed / allow-listed), remove it otherwise. CodeRabbit
+      # (.coderabbit.yaml) only auto-reviews PRs carrying this label — so review
+      # happens only after signing. This is a convenience gate; the hard merge
+      # block is the required "CLA Assistant" status check below.
+      - name: Sync cla-signed label
+        if: always() && (steps.cla.outcome == 'success' || steps.cla.outcome == 'failure')
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const pr = context.payload.pull_request ?? context.payload.issue;
+            // Only act on PRs (an issue_comment on a plain issue has no pull_request).
+            if (!pr || (context.payload.issue && !context.payload.issue.pull_request)) return;
+            const label = 'cla-signed';
+            const params = { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number };
+            if ('${{ steps.cla.outcome }}' === 'success') {
+              await github.rest.issues.addLabels({ ...params, labels: [label] });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ ...params, name: label });
+              } catch (e) {
+                if (e.status !== 404) throw e; // label wasn't set — fine
+              }
+            }
+
+      # Preserve the red required check when the CLA is not yet satisfied.
+      - name: Propagate CLA status
+        if: always() && steps.cla.outcome == 'failure'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,10 @@ magika/
 
 # E2E local specs (not upstream)
 tests/e2e/car-production-buildout.spec.ts
+
+# CLA working files — contain contributor emails (PII), keep out of the repo.
+# Ignore the specific working docs only (NOT the whole docs/cla/ dir, so the
+# tracked CLA docs — CCLA-template.md, SETUP.md — stay versioned).
+docs/cla/contributors-audit.md
+docs/cla/ai-commits.md
+docs/cla/license-scan.md

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,308 @@
+# OpenMES Contributor License Agreement
+
+**Version 1.0**
+
+---
+
+## Plain-language summary (non-binding)
+
+OpenMES is open-source software (the core is licensed under **AGPL-3.0**; the modules in the `modules/`
+directory under **AFL-3.0**). This Agreement (the **CLA**) sets out which rights you grant in your
+Contribution.
+
+- **You keep the copyright in your code.** The CLA does **not** transfer ownership to us — you only grant
+  us a broad, irrevocable license.
+- That license lets OpenMES stay open source while also allowing the Project Owner to offer OpenMES under
+  **additional licenses, including commercial ones**, and as a **hosted service (SaaS)**. This funds the
+  project's continued development.
+- You remain free to use and license your own Contribution elsewhere.
+
+This summary is informational only; the numbered Agreement below is the operative text.
+
+---
+
+# OpenMES Individual Contributor License Agreement
+
+**Version 1.0**
+
+Thank you for your interest in contributing to OpenMES.
+
+OpenMES is developed as an open-source project. This Contributor License Agreement ("Agreement") defines
+the rights that you grant in Contributions submitted to the OpenMES project.
+
+The purpose of this Agreement is to ensure that OpenMES can remain available as open-source software while
+also allowing the Project Owner to offer OpenMES under additional licensing models, including commercial
+licenses.
+
+**You retain ownership of the copyright in your Contributions.**
+
+## 1. Definitions
+
+"**Project Owner**" means Jakub Przepióra, currently maintaining the OpenMES project, and any permitted
+successor or assignee to whom the rights under this Agreement are transferred in accordance with Section 9.
+
+"**OpenMES**" or "**Project**" means the OpenMES software project and its associated source code,
+documentation, specifications, tests, build files, configuration, user interfaces and other materials
+maintained by the Project Owner.
+
+"**You**" or "**Contributor**" means the individual accepting this Agreement.
+
+"**Contribution**" means any original work of authorship intentionally submitted by You for inclusion in
+OpenMES, including source code, object code, patches, modifications, documentation, tests, specifications,
+configuration files, database definitions, graphics and other materials.
+
+A Contribution does not include material that You clearly identify in writing as not being submitted as a
+Contribution.
+
+"**Submit**" means any intentional communication to the Project Owner or an OpenMES repository for the
+purpose of discussing or improving OpenMES, including pull requests, commits, patches or other electronic
+submissions.
+
+## 2. Ownership
+
+You retain all right, title and interest in and to Your Contributions, except for the rights expressly
+granted under this Agreement.
+
+Nothing in this Agreement prevents You from using, modifying, distributing or licensing Your own
+Contributions to other persons or projects.
+
+## 3. Copyright License
+
+To the maximum extent permitted by applicable law, You grant the Project Owner a perpetual, worldwide,
+non-exclusive, irrevocable, royalty-free and transferable license, with the right to grant sublicenses
+through one or more tiers of sublicensees, to use Your Contributions.
+
+This license includes, without limitation, the right to:
+
+a. reproduce and use the Contribution;
+b. modify, adapt, translate, arrange and otherwise alter the Contribution;
+c. create and use derivative works based upon the Contribution;
+d. combine the Contribution with OpenMES and with other software or materials;
+e. publicly display, perform, communicate and make the Contribution available;
+f. distribute and otherwise make available the Contribution, in source-code or object-code form;
+g. use the Contribution for commercial and non-commercial purposes;
+h. sublicense the Contribution;
+i. include the Contribution in products, services, hosted services, SaaS offerings and other commercial or
+   non-commercial offerings; and
+j. exercise the foregoing rights under one or more open-source, source-available, commercial or proprietary
+   licensing models.
+
+For avoidance of doubt, the Project Owner may license OpenMES, including Your Contribution as incorporated
+into OpenMES, under the GNU Affero General Public License version 3 ("AGPL-3.0"), the Academic Free License
+version 3.0 ("AFL-3.0") for the module layer, a later compatible licensing arrangement where legally
+permitted, and/or one or more separate commercial or proprietary licenses.
+
+The rights granted under this Section are independent of the license under which a particular public
+version of OpenMES is distributed.
+
+## 4. Fields of Exploitation
+
+To the extent required by applicable copyright law, including Polish copyright law, the license granted
+under this Agreement covers all fields of exploitation known at the time this Agreement is concluded that
+are relevant to computer software and the Contribution, including in particular:
+
+a. permanent or temporary reproduction of the Contribution, in whole or in part, by any means and in any
+   form, including digital reproduction and reproduction in computer memory, servers, cloud infrastructure,
+   virtual machines, containers, storage media and telecommunications systems;
+b. loading, displaying, running, transmitting, storing and otherwise using the Contribution;
+c. translation, adaptation, arrangement, modification and any other alteration of the Contribution;
+d. reproduction of the results of the acts referred to above;
+e. distribution, lending, rental, sale and other forms of making copies of the Contribution or software
+   incorporating it available;
+f. distribution and making available through computer networks, including the Internet, private networks,
+   repositories, package registries, application stores, cloud services and SaaS services;
+g. making the Contribution available to the public in such a manner that members of the public may access
+   it from a place and at a time individually chosen by them;
+h. incorporation of the Contribution into OpenMES or other software and combining it with other works,
+   software, databases or materials;
+i. development, distribution and commercial exploitation of modified versions and derivative works
+   incorporating the Contribution; and
+j. sublicensing the foregoing rights under open-source, source-available, commercial or proprietary
+   licenses.
+
+## 5. Derivative Works and Modifications
+
+You authorize the Project Owner and its sublicensees to modify Your Contribution and to exercise rights in
+adaptations, modifications and derivative works created from Your Contribution to the maximum extent
+permitted by applicable law.
+
+To the extent permitted by applicable law, You agree not to exercise Your moral rights in a manner that
+would prevent or materially restrict the Project Owner or its sublicensees from exercising the rights
+granted under this Agreement.
+
+Nothing in this Agreement transfers authorship of Your Contribution or permits another person to falsely
+claim authorship of Your original work.
+
+## 6. Patent License
+
+To the extent You own or control patent claims that would necessarily be infringed by Your Contribution
+alone or by its combination with OpenMES as submitted by You, You grant the Project Owner a perpetual,
+worldwide, non-exclusive, irrevocable, royalty-free and transferable patent license, with the right to
+sublicense, to make, have made, use, offer for sale, sell, import and otherwise exploit the Contribution
+and OpenMES incorporating the Contribution.
+
+This Section does not grant rights to patent claims that would be infringed only because of modifications
+or combinations that were not part of, or reasonably contemplated by, Your Contribution.
+
+## 7. Contributor Representations
+
+You represent that:
+
+a. You are legally entitled to grant the rights described in this Agreement;
+b. to the best of Your knowledge, Your Contribution is Your original work or You have sufficient rights to
+   submit it under this Agreement;
+c. Your Contribution does not knowingly include third-party material in a manner inconsistent with the
+   rights granted under this Agreement;
+d. if Your employer or another person or organization may own rights in Your Contribution, You have
+   obtained all permissions necessary to make the Contribution and grant the rights described in this
+   Agreement;
+e. You will identify any third-party material included in Your Contribution and provide information about
+   its applicable license where reasonably necessary;
+f. You will not knowingly submit confidential information or trade secrets belonging to another person
+   without authorization; and
+g. where AI-based tools were materially used to produce Your Contribution, You ran those tools yourself and
+   are responsible for the resulting output as if it were Your own; to the best of Your knowledge the
+   output does not incorporate third-party code under a license incompatible with this Agreement; and any
+   commit produced with such tools is authored by a human, with the tool credited at most as a
+   `Co-authored-by` trailer.
+
+You are not required to provide any warranty regarding the technical quality or fitness of Your
+Contribution.
+
+## 8. No Obligation to Use Contributions
+
+The Project Owner is not required to accept, merge, distribute or otherwise use any Contribution.
+
+Submitting a Contribution does not create an employment, partnership, agency or joint-venture relationship
+between You and the Project Owner.
+
+## 9. Transfer to a Successor
+
+The Project Owner may transfer or assign the rights and licenses received under this Agreement to a legal
+entity or successor that acquires, owns, operates or continues development of the OpenMES project or
+substantially all intellectual-property rights relating to OpenMES.
+
+This includes a company established by the current Project Owner for the purpose of owning, developing,
+maintaining or commercially licensing OpenMES.
+
+Any such successor shall receive the rights necessary to continue exercising the licenses granted under
+this Agreement.
+
+The Contributor's ownership of the Contributor's original Contribution is not affected by such transfer.
+
+## 10. Open-Source Availability
+
+The existence of commercial or proprietary licensing of OpenMES does not revoke the license applicable to
+copies of OpenMES that have already been distributed under AGPL-3.0.
+
+Nothing in this Agreement requires the Contributor to purchase a commercial license to use the
+Contributor's own Contribution.
+
+## 11. Contributions Made on Behalf of Organizations
+
+This Individual Contributor License Agreement applies only to Contributions for which You personally have
+authority to grant the rights described above.
+
+If rights in a Contribution belong to Your employer, company or another organization, the Project Owner
+may require an appropriate Corporate Contributor License Agreement or other written authorization before
+accepting the Contribution.
+
+## 12. Disclaimer
+
+Except for the representations expressly made in Section 7, Contributions are provided on an "AS IS" basis,
+without warranties or conditions of any kind to the maximum extent permitted by applicable law.
+
+## 13. Governing Law
+
+This Agreement shall be governed by the laws of the Republic of Poland, without prejudice to mandatory
+provisions of law that may otherwise apply.
+
+Any disputes arising from this Agreement shall be subject to the jurisdiction determined in accordance with
+applicable law.
+
+## 14. Entire Agreement and Severability
+
+This Agreement constitutes the agreement between You and the Project Owner regarding the rights granted in
+Your Contributions.
+
+If any provision is held invalid or unenforceable, it shall be interpreted or limited to the minimum extent
+necessary to make it enforceable where legally possible, and the remaining provisions shall continue in
+effect.
+
+## 15. Acceptance
+
+You agree that Contributions may be accepted only after You have accepted this Agreement through a method
+designated by the OpenMES project.
+
+The Project Owner should maintain a record identifying the Contributor, the version of this Agreement
+accepted, the date of acceptance and the account or identity used to submit Contributions.
+
+```
+Contributor: __________________________
+GitHub username: ______________________
+Email: _______________________________
+CLA version: 1.0
+Date: ________________________________
+Signature / approved electronic acceptance: __________________________
+```
+
+---
+
+## Personal Data (GDPR)
+
+When You accept this Agreement, the Project Owner records: Your GitHub username, the date of acceptance, the
+version (and content hash) of this document, and — where provided — Your name and e-mail. This data is
+processed to establish and document the licensing rights necessary to maintain and distribute OpenMES
+(legal basis: the performance of, and the legitimate interest in evidencing, this Agreement). It is stored
+in the project's signatures record for as long as OpenMES is maintained and the rights granted here are
+relied upon. You may contact the Project Owner regarding Your data.
+
+---
+
+# OpenMES Corporate Contributor License Agreement
+
+**Version 1.0**
+
+This Corporate Contributor License Agreement ("Corporate Agreement") is entered into between the Project
+Owner (as defined above) and the organization identified below ("**Company**"). It covers Contributions
+submitted to OpenMES by employees or other individuals designated by the Company.
+
+## C1. Grant
+
+The Company grants the Project Owner, for all Contributions submitted by its Designated Employees, the same
+copyright license, fields-of-exploitation coverage, patent license and successor-transfer rights set out in
+Sections 3, 4, 6 and 9 of the Individual Contributor License Agreement above, on the same terms.
+
+## C2. Ownership and Authority
+
+The Company represents that it owns or otherwise controls the intellectual-property rights in the
+Contributions of its Designated Employees and is authorized to grant the rights under this Corporate
+Agreement, and that the person accepting it is duly authorized to represent the Company.
+
+## C3. Designated Employees (Schedule A)
+
+The Company lists in **Schedule A** the individuals (and their GitHub accounts) whose Contributions this
+Corporate Agreement covers, and undertakes to keep that list current. Adding or removing a person takes
+effect when the Company notifies the Project Owner in writing (including by an updated Schedule A).
+
+## C4. Relationship to the Individual CLA
+
+This Corporate Agreement does not remove the requirement for each Designated Employee to sign the Individual
+CLA through the project's automated signing process (the bot records the account's signature). Where a
+Designated Employee has signed, their Individual CLA operates **on behalf of and with the consent of the
+Company** for Contributions within the scope of their work.
+
+## C5. Signing
+
+This Corporate Agreement is concluded in **written form or by qualified electronic signature** — it is
+**not** signed through the CLA bot. See `docs/cla/CCLA-template.md` for the form to complete and sign.
+
+## C6. Governing Law
+
+Sections 13 and 14 of the Individual Contributor License Agreement apply to this Corporate Agreement.
+
+---
+
+*OpenMES · CLA v1.0. The core is licensed under AGPL-3.0; the `modules/` layer under AFL-3.0. This
+Agreement does not change those licenses — it grants the Project Owner the rights described above in
+addition to them.*

--- a/LICENSE-AFL-3.0.txt
+++ b/LICENSE-AFL-3.0.txt
@@ -1,0 +1,166 @@
+Academic Free License ("AFL") v. 3.0
+
+SPDX short identifier: AFL-3.0
+
+This Academic Free License (the "License") applies to any original work of
+authorship (the "Original Work") whose owner (the "Licensor") has placed the
+following licensing notice adjacent to the copyright notice for the Original
+Work:
+
+Licensed under the Academic Free License version 3.0
+
+1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, for the duration of the copyright, to do
+the following:
+
+  a) to reproduce the Original Work in copies, either alone or as part of a
+     collective work;
+
+  b) to translate, adapt, alter, transform, modify, or arrange the Original
+     Work, thereby creating derivative works ("Derivative Works") based upon the
+     Original Work;
+
+  c) to distribute or communicate copies of the Original Work and Derivative
+     Works to the public, under any license of your choice that does not
+     contradict the terms and conditions, including Licensor's reserved rights
+     and remedies, in this Academic Free License;
+
+  d) to perform the Original Work publicly; and
+
+  e) to display the Original Work publicly.
+
+2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, under patent claims owned or controlled by
+the Licensor that are embodied in the Original Work as furnished by the Licensor,
+for the duration of the patents, to make, use, sell, offer for sale, have made,
+and import the Original Work and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the preferred form
+of the Original Work for making modifications to it and all available
+documentation describing how to modify the Original Work. Licensor agrees to
+provide a machine-readable copy of the Source Code of the Original Work along
+with each copy of the Original Work that Licensor distributes. Licensor reserves
+the right to satisfy this obligation by placing a machine-readable copy of the
+Source Code in an information repository reasonably calculated to permit
+inexpensive and convenient access by You for as long as Licensor continues to
+distribute the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names of
+any contributors to the Original Work, nor any of their trademarks or service
+marks, may be used to endorse or promote products derived from this Original Work
+without express prior permission of the Licensor. Except as expressly stated
+herein, nothing in this License grants any license to Licensor's trademarks,
+copyrights, patents, trade secrets or any other intellectual property. No patent
+license is granted to make, use, sell, offer for sale, have made, or import
+embodiments of any patent claims other than the licensed claims defined in
+Section 2. No license is granted to the trademarks of Licensor even if such marks
+are included in the Original Work. Nothing in this License shall be interpreted to
+prohibit Licensor from licensing under terms different from this License any
+Original Work that Licensor otherwise would have a right to license.
+
+5) External Deployment. The term "External Deployment" means the use,
+distribution, or communication of the Original Work or Derivative Works in any way
+such that the Original Work or Derivative Works may be used by anyone other than
+You, whether those works are distributed or communicated to those persons or made
+available as an application intended for use over a network. As an express
+condition for the grants of license hereunder, You must treat any External
+Deployment by You of the Original Work or a Derivative Work as a distribution
+under section 1(c).
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative Works
+that You create, all copyright, patent, or trademark notices from the Source Code
+of the Original Work, as well as any notices of licensing and any descriptive text
+identified therein as an "Attribution Notice." You must cause the Source Code for
+any Derivative Works that You create to carry a prominent Attribution Notice
+reasonably calculated to inform recipients that You have modified the Original
+Work.
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the
+copyright in and to the Original Work and the patent rights granted herein by
+Licensor are owned by the Licensor or are sublicensed to You under the terms of
+this License with the permission of the contributor(s) of those copyrights and
+patent rights. Except as expressly stated in the immediately preceding sentence,
+the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT
+WARRANTY, either express or implied, including, without limitation, the warranties
+of non-infringement, merchantability or fitness for a particular purpose. THE
+ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This DISCLAIMER OF
+WARRANTY constitutes an essential part of this License. No license to the Original
+Work is granted by this License except under this disclaimer.
+
+8) Limitation of Liability. Under no circumstances and under no legal theory,
+whether in tort (including negligence), contract, or otherwise, shall the Licensor
+be liable to anyone for any indirect, special, incidental, or consequential
+damages of any character arising as a result of this License or the use of the
+Original Work including, without limitation, damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial damages
+or losses. This limitation of liability shall not apply to the extent applicable
+law prohibits such limitation.
+
+9) Acceptance and Termination. If, at any time, You expressly assented to this
+License, that assent indicates your clear and irrevocable acceptance of this
+License and all of its terms and conditions. If You distribute or communicate
+copies of the Original Work or a Derivative Work, You must make a reasonable effort
+under the circumstances to obtain the express assent of recipients to the terms of
+this License. This License conditions your rights to undertake the activities
+listed in Section 1, including your right to create Derivative Works based upon the
+Original Work, and doing so without honoring these terms and conditions is
+prohibited by copyright law and international treaty. Nothing in this License is
+intended to affect copyright exceptions and limitations (including "fair use" or
+"fair dealing"). This License shall terminate immediately and You may no longer
+exercise any of the rights granted to You by this License upon your failure to
+honor the conditions in Section 1(c).
+
+10) Termination for Patent Action. This License shall terminate automatically and
+You may no longer exercise any of the rights granted to You by this License as of
+the date You commence an action, including a cross-claim or counterclaim, against
+Licensor or any licensee alleging that the Original Work infringes a patent. This
+termination provision shall not apply for an action alleging patent infringement
+by combinations of the Original Work with other software or hardware.
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this
+License may be brought only in the courts of a jurisdiction wherein the Licensor
+resides or in which Licensor conducts its primary business, and under the laws of
+that jurisdiction excluding its conflict-of-law provisions. The application of the
+United Nations Convention on Contracts for the International Sale of Goods is
+expressly excluded. Any use of the Original Work outside the scope of this License
+or after its termination shall be subject to the requirements and penalties of
+copyright or patent law in the appropriate jurisdiction. This section shall survive
+the termination of this License.
+
+12) Attorneys' Fees. In any action to enforce the terms of this License or seeking
+damages relating thereto, the prevailing party shall be entitled to recover its
+costs and expenses, including, without limitation, reasonable attorneys' fees and
+costs incurred in connection with such action, including any appeal of such action.
+This section shall survive the termination of this License.
+
+13) Miscellaneous. If any provision of this License is held to be unenforceable,
+such provision shall be reformed only to the extent necessary to make it
+enforceable.
+
+14) Definition of "You" in This License. "You" throughout this License, whether in
+upper or lower case, means an individual or a legal entity exercising rights under,
+and complying with all of the terms of, this License. For legal entities, "You"
+includes any entity that controls, is controlled by, or is under common control
+with you. For purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by contract
+or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding
+shares, or (iii) beneficial ownership of such entity.
+
+15) Right to Use. You may use the Original Work in all ways not otherwise
+restricted or conditioned by this License or by law, and Licensor promises not to
+interfere with or be responsible for such uses by You.
+
+16) Modification of This License. This License is Copyright (C) 2005 Lawrence
+Rosen. Permission is granted to copy, distribute, or communicate this License
+without modification. Nothing in this License permits You to modify this License as
+applied to the Original Work or to Derivative Works. However, You may modify the
+text of this License and copy, distribute or communicate your modified version (the
+"Modified License") and apply it to other original works of authorship subject to
+the following conditions: (i) You may not indicate in any way that your Modified
+License is the "Academic Free License" or "AFL" and you may not use those names in
+the name of your Modified License; (ii) You must replace the notice specified in
+the first paragraph above with the notice "Licensed under <insert your license name
+here>" or with a notice of your own that is not confusingly similar to the notice
+in this License; and (iii) You may not claim that your original works are open
+source software unless your Modified License has been approved by Open Source
+Initiative (OSI) and You comply with its license review and certification process.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,60 @@
+# OpenMES Licensing
+
+OpenMES uses a **layered / dual-licensing** model. This file explains which
+license applies to what. It is a summary; the license texts themselves govern.
+
+## 1. Core — AGPL-3.0
+
+The OpenMES **core** (everything except the `modules/` layer) is licensed under
+the **GNU Affero General Public License v3.0 (AGPL-3.0)**. See [`LICENSE`](LICENSE).
+
+Running a modified version over a network requires making the corresponding
+source available under the same license (AGPL §13).
+
+## 2. Modules — AFL-3.0
+
+Code under **`modules/`** is licensed under the **Academic Free License 3.0
+(AFL-3.0)** — a permissive license — so a module may be distributed under
+terms of the author's choosing, including **closed / proprietary**. See
+[`LICENSE-AFL-3.0.txt`](LICENSE-AFL-3.0.txt).
+
+A file is under AFL-3.0 only if it lives in `modules/` **and** carries, adjacent
+to its copyright notice, the notice:
+
+```
+Licensed under the Academic Free License version 3.0
+```
+
+Everything else in the repository is AGPL-3.0.
+
+> Note: `modules/` is currently deprecated in favor of core (see `.gitignore`);
+> most module code ships from separate repositories. This layer's AFL-3.0 terms
+> apply to such module code wherever it is distributed as an OpenMES module.
+
+## 3. Commercial licensing
+
+OpenMES is **also** available under separate **commercial licenses** (for
+partners who cannot accept AGPL obligations, OEM/white-label, and hosted/SaaS
+offerings). The Project Owner can offer these because contributors grant the
+necessary rights through the Contributor License Agreement (see below). Contact
+the Project Owner for commercial terms.
+
+## 4. Contributor License Agreement
+
+Contributions are accepted under the **OpenMES CLA** ([`CLA.md`](CLA.md)): you keep
+your copyright and grant the Project Owner a broad, irrevocable, sublicensable
+license that makes the dual-licensing above possible. See
+[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
+
+## 5. Module / core boundary
+
+AFL-3.0 is not GPL-compatible (per the FSF). For the module layer to be
+distributable under AFL/proprietary terms, a module must be a **separate work**,
+not a derivative of the AGPL core — i.e. the core/module boundary must be a
+genuine arm's-length interface, not tight linking that would make the module a
+derivative of AGPL code.
+
+---
+
+*Summary: **core = AGPL-3.0**, **`modules/` = AFL-3.0**, **commercial licenses available**,
+**contributions under the CLA**. The `LICENSE` and `LICENSE-AFL-3.0.txt` texts are authoritative.*

--- a/README.md
+++ b/README.md
@@ -554,20 +554,17 @@ subscribe to them again per page.
 
 ## 📄 License
 
-OpenMES is open-source software licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**.
+OpenMES uses a **layered / dual-licensing** model:
 
-This means you can:
-- ✅ Use it commercially
-- ✅ Modify it
-- ✅ Distribute it
-- ✅ Use it privately
+- **Core** — **GNU Affero General Public License v3.0 (AGPL-3.0)** — see [LICENSE](LICENSE).
+- **Modules** (`modules/`) — **Academic Free License 3.0 (AFL-3.0)** (permissive; modules may be closed/proprietary) — see [LICENSE-AFL-3.0.txt](LICENSE-AFL-3.0.txt).
+- **Commercial licenses** are also available for partners who cannot accept AGPL obligations, OEM/white-label, and hosted/SaaS offerings.
 
-Under the following conditions:
-- 📋 Disclose source — distributing or running a modified version over a network requires making the corresponding source available under the same license
-- 📋 Same license — derivative works must also be licensed under AGPL-3.0
-- 📋 State changes — document significant modifications
+Under AGPL-3.0 you can use, modify, distribute and use OpenMES privately, provided you disclose source for network/distributed modified versions, keep derivative works under AGPL-3.0, and state your changes.
 
-See [LICENSE](LICENSE) for full details.
+Contributions are accepted under the **Contributor License Agreement** ([CLA.md](CLA.md)) — you keep your copyright and grant the rights that make the dual-licensing model possible.
+
+See [LICENSING.md](LICENSING.md) for the full model and [CONTRIBUTING](docs/CONTRIBUTING.md) for how to contribute.
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Thank you for your interest in contributing to OpenMES! This document outlines h
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Licensing](#licensing)
+- [Contributor License Agreement](#contributor-license-agreement)
 - [Ways to Contribute](#ways-to-contribute)
 - [Development Setup](#development-setup)
 - [Submitting Changes](#submitting-changes)
@@ -19,6 +21,51 @@ Thank you for your interest in contributing to OpenMES! This document outlines h
 ## Code of Conduct
 
 We expect contributors to be respectful and constructive. We do not tolerate harassment or discrimination of any kind.
+
+---
+
+## Licensing
+
+OpenMES is open-source software:
+
+- the **core** is distributed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**;
+- the **module layer** (`modules/`) is distributed under the **Academic Free License 3.0 (AFL-3.0)**, so modules may be closed/proprietary.
+
+OpenMES may **also** be offered under separate **commercial** licensing terms. This dual-licensing model helps fund continued development while keeping an AGPL-licensed version available to the open-source community.
+
+---
+
+## Contributor License Agreement
+
+> **You keep your copyright. OpenMES stays open source. The CLA allows us to offer OpenMES under additional licenses, including commercial licenses.**
+
+Before we can merge your **first** contribution, please sign the OpenMES Contributor License Agreement ([CLA.md](../CLA.md)).
+
+**What the CLA means**
+- You **keep the copyright** to your work — the CLA does **not** transfer ownership of your contribution.
+- You grant the Project Owner the rights needed to use your contribution in OpenMES and to license OpenMES under both open-source and commercial models.
+- You remain free to use and license your own contribution elsewhere.
+- You confirm you have the right to contribute the code you submit.
+
+**Why we require it** — without a contributor agreement each contributor would hold copyright in their own contributions, which makes a consistent dual-licensing model impossible as the project grows. The CLA lets OpenMES keep shipping as open source, offer commercial/SaaS options that fund development, and transfer stewardship to a future company without asking everyone to re-sign.
+
+**How to sign** — open your pull request; a bot will comment if a signature is needed. Reply with the exact phrase it asks for:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature covers all your past and future contributions. It is recorded once; later PRs won't ask again (until the CLA version changes).
+
+**Contributions made for an employer** — if your employer or another organization owns the copyright in your work, do **not** accept the Individual CLA on its behalf unless you are authorized to. Contact the maintainers first — a Corporate CLA ([`docs/cla/CCLA-template.md`](cla/CCLA-template.md)) or other authorization may be required, and the PR won't be merged until it is in place.
+
+**Third-party code** — do not submit code copied from another project unless its license is compatible with OpenMES; identify its source and license in your PR.
+
+**AI-generated code** — if AI tools were materially used, disclose it in the PR where appropriate. You ran the tool and remain responsible for the result; to the best of your knowledge it must not incorporate third-party code under an incompatible license. Commits carry a **human author** (the AI credited at most as `Co-authored-by`).
+
+**Trivial changes** — a change of **≤ 20 lines with no new logic** (typo, formatting, an obvious fix) does not require a CLA; a maintainer may label the PR `cla: trivial` and merge it.
+
+Accepting the CLA records your GitHub username, the date, and the document version. See the privacy note in [CLA.md](../CLA.md#personal-data-gdpr).
 
 ---
 

--- a/docs/cla/CCLA-template.md
+++ b/docs/cla/CCLA-template.md
@@ -1,0 +1,82 @@
+# OpenMES — Corporate Contributor License Agreement (CCLA)
+
+**Version 1.0**
+
+This form is completed and signed by a company whose employees or contractors contribute to OpenMES. It is
+signed **in written form or by qualified electronic signature** and sent to the Project Owner — it is
+**not** signed through the CLA bot. The full terms are in [`CLA.md`](../../CLA.md) ("OpenMES Corporate
+Contributor License Agreement"); this template only collects the required particulars and signature.
+
+> The English text of `CLA.md` is binding. By signing below the Company accepts the Corporate Contributor
+> License Agreement in `CLA.md` for the Designated Employees listed in Schedule A.
+
+---
+
+## 1. Company
+
+| Field | Value |
+|-------|-------|
+| Legal name | ____________________________________________ |
+| Legal form (e.g. sp. z o.o., S.A., Ltd.) | ____________________________ |
+| Registered address | ____________________________________________ |
+| Registration number (KRS / NIP / equivalent) | ______________________ |
+| Country | ____________________________________________ |
+
+## 2. Authorized representative (signatory)
+
+The person signing must be authorized to represent the Company (e.g. management board member, prokurent,
+or attorney-in-fact with a power of attorney).
+
+| Field | Value |
+|-------|-------|
+| Full name | ____________________________________________ |
+| Position / basis of authority | ______________________________ |
+| E-mail | ____________________________________________ |
+
+## 3. Contact for CLA matters
+
+| Field | Value |
+|-------|-------|
+| Name | ____________________________________________ |
+| E-mail | ____________________________________________ |
+
+## 4. Schedule A — Designated Employees
+
+The Contributions of the following individuals are covered by this Corporate Agreement. The Company
+undertakes to keep this list current and to notify the Project Owner (including by an updated Schedule A)
+when a person is added or removed.
+
+| # | Full name | GitHub username | E-mail |
+|---|-----------|-----------------|--------|
+| 1 | ______________________ | ______________________ | ______________________ |
+| 2 | ______________________ | ______________________ | ______________________ |
+| 3 | ______________________ | ______________________ | ______________________ |
+| 4 | ______________________ | ______________________ | ______________________ |
+
+*(add rows as needed)*
+
+## 5. Declarations
+
+By signing, the Company confirms that:
+
+- it owns or otherwise controls the intellectual-property rights in the Contributions of the Designated
+  Employees and is authorized to grant the rights set out in the Corporate Contributor License Agreement in
+  `CLA.md`;
+- the signatory is duly authorized to represent the Company; and
+- it has read and accepts the terms of the Corporate Contributor License Agreement in `CLA.md` (Version 1.0).
+
+## 6. Signature
+
+| Field | Value |
+|-------|-------|
+| CLA version | 1.0 |
+| Place | ____________________________________________ |
+| Date | ____________________________________________ |
+| Signature (representative) | ____________________________ |
+| Company stamp (if used) | ____________________________ |
+
+---
+
+*Return the completed and signed form to the Project Owner at the address indicated in the project's
+`docs/cla/SETUP.md` / CONTRIBUTING. The core of OpenMES is licensed under AGPL-3.0; the `modules/` layer
+under AFL-3.0. This Agreement does not change those licenses.*

--- a/docs/cla/SETUP.md
+++ b/docs/cla/SETUP.md
@@ -1,0 +1,77 @@
+# CLA — one-time setup (maintainer)
+
+The CLA gate is a GitHub Action (`.github/workflows/cla.yml`, "CLA Assistant"). It runs on every pull
+request, asks unsigned contributors to sign by commenting, records signatures in a **private** repo, and
+blocks merge until all commit authors have signed. Owner accounts, org members and bots are allow-listed.
+
+Do these steps once (GitHub web UI + a token). Order matters.
+
+## 1. Create the signatures repo
+
+Create a **private** repo **`Mes-Open/cla-signatures`** with an empty `README.md`. Signatures are stored
+here as `signatures/version1/cla.json` (created automatically on the first signature).
+
+## 2. Create a token and add it as a secret
+
+- Create a **fine-grained personal access token** scoped to **only** `Mes-Open/cla-signatures`, with
+  **Repository permissions → Contents: Read and write**.
+- In **`Mes-Open/OpenMes` → Settings → Secrets and variables → Actions**, add a secret named
+  **`CLA_SIGNATURES_PAT`** with that token.
+
+## 3. Allow the workflow to write
+
+**`Mes-Open/OpenMes` → Settings → Actions → General → Workflow permissions →** enable
+**"Read and write permissions"** (the action posts PR comments and updates the commit status).
+
+## 4. Require the check on the protected branch
+
+In branch protection for **`main`** (and, if PRs land there, **`develop`**), require the status check
+**`CLA Assistant`** to pass before merging.
+
+## 5. Publish CLA.md where the link points
+
+`cla.yml` points contributors to `https://github.com/Mes-Open/OpenMes/blob/main/CLA.md`. Make sure `CLA.md`
+is present on `main` (it ships to `main` at the next release). Until then, either merge `CLA.md` to `main`
+first or temporarily point `path-to-document` at the `develop` blob.
+
+## 6. Test it
+
+Open a test PR from an account **not** on the allowlist. Confirm: the bot comments asking for a signature →
+comment the sign phrase → the check turns green → a row appears in `Mes-Open/cla-signatures`
+(`signatures/version1/cla.json`).
+
+Also confirm the **CodeRabbit gate**: before signing, the PR has **no `cla-signed` label** and CodeRabbit
+does **not** auto-review; after signing, the workflow adds `cla-signed` and CodeRabbit reviews. (The label
+is created automatically the first time it is applied; you may pre-create a `cla-signed` label with a
+distinctive colour if you like.)
+
+## CodeRabbit ordering (sign first, then review)
+
+`.coderabbit.yaml` sets `reviews.auto_review.enabled: false` with `labels: [cla-signed]`, so CodeRabbit
+only auto-reviews PRs that carry the **`cla-signed`** label. `cla.yml` adds that label once the CLA step
+passes (all commit authors signed or allow-listed) and removes it if a later unsigned commit is pushed.
+Net effect: **contributors sign first, then CodeRabbit reviews** — no review budget spent on unsigned PRs.
+The hard merge block remains the required **`CLA Assistant`** status check (step 4); the label is only a
+review-timing convenience.
+
+---
+
+## Tool note (accepted risk + alternative)
+
+`cla.yml` uses **`contributor-assistant/github-action`** (CLA Assistant Lite), **pinned to the exact commit
+of `v2.6.1`** (`ca4a40a…`). That repo was **archived in March 2026** — it is frozen, not broken; pinning to
+a SHA removes the moving-tag supply-chain risk, it runs only in CI, and it never ships in the product. Its
+advantage is that the **signature ledger stays inside `Mes-Open`** (your own private repo).
+
+If you prefer an actively-maintained tool, the alternative is the hosted **[cla-assistant.io](https://cla-assistant.io)**
+(SAP): a GitHub App, no workflow file or PAT to manage — but the signature data then lives on SAP's servers,
+not in your organization. Choose based on whether keeping the ledger in `Mes-Open` is a hard requirement.
+
+## Allowlist maintenance
+
+The allowlist in `cla.yml` covers only the owner's own accounts and bots:
+`jakub-przepiora`, `jakubprzepiora-cyber`, `dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`.
+
+Org members (`Svannte` / Mateusz Łuczyński, `JanKolo04` / Jan Kołodziej, `ElNinio978`) are **intentionally
+not allow-listed** — they sign via the bot as well; their ICLA then operates on behalf of and with the
+company's consent (CLA §C4). Add or remove logins here as the team changes.


### PR DESCRIPTION
## Contributor License Agreement + layered licensing

Introduces a CLA so contributions can be **dual-licensed** (AGPL core + commercial / SaaS) while the public repo stays open source. Contributors **keep their copyright** and grant a broad, irrevocable, sublicensable license (Canonical/Qt style — not an assignment). Project Owner = Jakub Przepióra, transferable to a future company (CLA §9).

### The gate (contribute → grant rights)
Every PR runs **CLA Assistant** (`.github/workflows/cla.yml`, pinned to the `v2.6.1` commit SHA). An unsigned author is asked to comment the sign phrase once; the signature is stored in the private `Mes-Open/cla-signatures`; merge is blocked until all commit authors have signed. Owner accounts + bots are allowlisted.

**CodeRabbit is gated on the CLA:** `.coderabbit.yaml` only auto-reviews PRs labeled `cla-signed`, which the workflow adds once everyone has signed — sign first, then review.

### Docs
- `CLA.md` — Individual + Corporate CLA (Polish-law aware: fields of exploitation, art. 41(3)/53/74(3), moral rights), plain-language summary, GDPR note, AI clause (§7g).
- `docs/cla/CCLA-template.md` — corporate sign-off form (Schedule A).
- `docs/CONTRIBUTING.md` + PR template — friendly CLA section + checkbox.
- `docs/cla/SETUP.md` — one-time maintainer setup (private repo, PAT, branch protection, test).

### Layered licensing
- Core = **AGPL-3.0** (`LICENSE`), modules (`modules/`) = **AFL-3.0** (`LICENSE-AFL-3.0.txt`), commercial available — described in `LICENSING.md` + README.

### Notes
- Contributor audit / AI-commit / license-scan working files are kept local (gitignored — they contain emails).
- Enabling enforcement on `main` is a one-time branch-protection step (see `SETUP.md`), independent of this merge.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive licensing guidance covering AGPL-3.0 core software, AFL-3.0 modules, and available commercial licensing.
  - Added an OpenMES Contributor License Agreement, including individual and corporate contribution terms.
  - Updated contribution guidance with CLA, copyright, third-party code, and AI-assisted development requirements.
  - Added the AFL-3.0 license text and a corporate CLA template.

- **Workflow Improvements**
  - Pull requests now include CLA confirmation requirements and automated CLA verification.
  - Automated reviews can be triggered after CLA approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->