### PR TITLE
docs(cla): governing-law note (Polish law) in the CLA header

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -2,6 +2,16 @@
 
 **Version 1.0**
 
+> **Governing law / Prawo właściwe.** This Agreement is prepared for, and governed by, **the law of the
+> Republic of Poland** — in particular the Act of 4 February 1994 on Copyright and Related Rights
+> (consolidated text: Dz.U. 2025 poz. 24). Its construction reflects that law (a non-exclusive licence
+> rather than a transfer of rights, and expressly enumerated fields of exploitation) so that it is valid
+> and effective under it. The **English text is binding**; Polish law and the courts having jurisdiction
+> over the Project Owner's seat apply. See Sections 4 and 13.
+>
+> *(PL) Niniejsza Umowa jest sporządzona pod prawo polskie i mu podlega (ustawa z 4 lutego 1994 r.
+> o prawie autorskim i prawach pokrewnych). Wersja angielska jest wiążąca.*
+
 ---
 
 ## Plain-language summary (non-binding)


### PR DESCRIPTION
Adds a prominent **Governing law / Prawo właściwe** note at the top of `CLA.md`: the Agreement is drafted for and governed by the law of the Republic of Poland (Act of 4 Feb 1994 on Copyright and Related Rights; consolidated text Dz.U. 2025 poz. 24), which is why it uses a non-exclusive licence (not an assignment) with expressly enumerated fields of exploitation. English text remains binding. Reinforces the existing §4 (Fields of Exploitation) and §13 (Governing Law). Docs-only.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)