### PR TITLE
feat: complete the demo dataset + report subassembly shortages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   own routing (slim assembly, pre-filter and carbon production, HVAC cassette), and the
   seeder snapshots it onto the work order with `toSnapshot()` instead of a hand-rolled
   header — so the snapshot carries the steps and the BOM the way the application writes it.
+- **Demo data now spans a fortnight either side of the day it is seeded** — it used to be a
+  single-day snapshot, so the planner emptied out after tomorrow and the shift monitor had
+  only the shift in progress. The planner now gets two weeks of scheduled orders and
+  maintenance ahead of today, and `ShiftMonitorDemoSeeder` lays down two weeks of finished
+  shifts behind the live one, so paging back through the monitor keeps finding real shifts.
+  History only goes backwards on purpose: the monitor draws what machines actually did, and
+  a shift that has not run yet has no counters to show.
 - **Demo data now includes shifts, maintenance and a live shift monitor** — the demo had no
   shifts at all, so the planner and the shift monitor both fell back to a synthetic window;
   it now seeds round-the-clock morning/afternoon/night cover. The planner board gains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   own routing (slim assembly, pre-filter and carbon production, HVAC cassette), and the
   seeder snapshots it onto the work order with `toSnapshot()` instead of a hand-rolled
   header — so the snapshot carries the steps and the BOM the way the application writes it.
+- **Demo data now includes received material lots** — `AirFilterDemoSeeder` seeds fifteen
+  lots across the demo materials, covering every lot status: stock on hand, a delivery still
+  in quarantine awaiting inbound QC, one rejected by it, one consumed down to zero, and a
+  time-expired adhesive beside its live replacement. Chemicals carry manufacturing and expiry
+  dates, and every lot carries a supplier lot reference, so the Material Lots list, the lot
+  pickers and traceability search have real data instead of an empty state.
 - **Demo data now includes a bill of materials for every product** — `AirFilterDemoSeeder`
   seeds the purchased parts (media grades, frame profiles, resin, carbon, seals, cartons)
   and a BOM for each routing: HEPA-13 Standard and Slim, pre-filter, carbon and the HVAC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
     which only offers what you may still pick.
 
 ### Fixed
+- **New stock document → "Create Draft" did nothing** *(Admin → Stock Documents)* — the
+  form chained `form.transform(...).post(...)`, but Inertia v3's `transform()` returns void,
+  so `.post` was read off `undefined` and the submit threw before any request
+  (`can't access property "post", u.transform(...) is undefined`, #282). Set the transform
+  and post in separate statements, matching every other form in the app.
 - **Doubled plus on three "new" buttons** *(Admin → Warehouses, Stock Documents, Inspection
   Plans)* — `ResourceTable` already draws a plus icon in the create button, and these three
   labels carried a literal `+ ` of their own, so they rendered as "+ + New Warehouse". The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   own routing (slim assembly, pre-filter and carbon production, HVAC cassette), and the
   seeder snapshots it onto the work order with `toSnapshot()` instead of a hand-rolled
   header — so the snapshot carries the steps and the BOM the way the application writes it.
-- **Demo data now includes a two-level bill of materials** — `AirFilterDemoSeeder` seeds the
-  purchased parts (media, frame profile, gasket, adhesives, carton) and one manufactured
-  sub-assembly, the HEPA-13 pleat pack, which has its own routing and BOM. The assembly BOM
-  therefore explodes through the pleat pack down to raw media, with scrap cascading between
-  levels, so the BOM screens, the net-requirements report and `BomExplosionService` all have
-  a realistic multi-level structure to work on instead of an empty one.
+- **Demo data now includes a bill of materials for every product** — `AirFilterDemoSeeder`
+  seeds the purchased parts (media grades, frame profiles, resin, carbon, seals, cartons)
+  and a BOM for each routing: HEPA-13 Standard and Slim, pre-filter, carbon and the HVAC
+  cassette. The HEPA-13 Standard BOM is two-level — it consumes a manufactured sub-assembly,
+  the pleat pack, which has its own routing and BOM — so exploding it reaches raw media with
+  scrap cascading between levels. The BOM screens, the net-requirements report and
+  `BomExplosionService` all have a realistic structure to work on instead of an empty one.
+
+### Fixed
+- **Demo seeder could resurrect deleted process-template steps** — it wrote steps with a
+  query-builder `updateOrInsert()` keyed on template + step number, which runs without the
+  model's soft-delete scope. On a database where a step had been deleted the match hit the
+  deleted row, so a re-run updated that instead of inserting a live one, leaving the template
+  short a step. The match now requires `deleted_at IS NULL`.
 - **Demo data now includes operator-reported issues** — `AirFilterDemoSeeder` seeds five
   issues against the demo work orders, one per lifecycle state (open, acknowledged,
   resolved, closed), reported by the demo operators and assigned to the demo supervisor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Demo data now includes operator-reported issues** — `AirFilterDemoSeeder` seeds five
+  issues against the demo work orders, one per lifecycle state (open, acknowledged,
+  resolved, closed), reported by the demo operators and assigned to the demo supervisor.
+  The operator's work-order view, the admin Issues list and the history screens all have
+  something to show instead of an empty state. Upsert-safe like the rest of the seeder.
+
 ### Changed
 - **The two old importers redirect into the unified importer** — Orders → CSV Import
   (`/admin/csv-import`, `/supervisor/csv-import`) and Materials → Import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   own routing (slim assembly, pre-filter and carbon production, HVAC cassette), and the
   seeder snapshots it onto the work order with `toSnapshot()` instead of a hand-rolled
   header — so the snapshot carries the steps and the BOM the way the application writes it.
+- **Demo data now includes shifts, maintenance and a live shift monitor** — the demo had no
+  shifts at all, so the planner and the shift monitor both fell back to a synthetic window;
+  it now seeds round-the-clock morning/afternoon/night cover. The planner board gains
+  maintenance to show: tools, three recurring schedules for its "Add maintenance" modal, and
+  five events across the current week — a completed job, one in progress (the maintenance
+  side of the seeded carbon-press issue) and three upcoming. `ShiftMonitorDemoSeeder` now
+  also knows the air-filter stations, and `DemoDataSeeder` runs it last, so the monitor opens
+  on a shift in progress with a state timeline, a per-minute counter feed and a couple of
+  stops left unclassified for the "needs a cause" flow.
 - **Demo data now includes received material lots** — `AirFilterDemoSeeder` seeds fifteen
   lots across the demo materials, covering every lot status: stock on hand, a delivery still
   in quarantine awaiting inbound QC, one rejected by it, one consumed down to zero, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Demo data now includes a two-level bill of materials** — `AirFilterDemoSeeder` seeds the
+  purchased parts (media, frame profile, gasket, adhesives, carton) and one manufactured
+  sub-assembly, the HEPA-13 pleat pack, which has its own routing and BOM. The assembly BOM
+  therefore explodes through the pleat pack down to raw media, with scrap cascading between
+  levels, so the BOM screens, the net-requirements report and `BomExplosionService` all have
+  a realistic multi-level structure to work on instead of an empty one.
 - **Demo data now includes operator-reported issues** — `AirFilterDemoSeeder` seeds five
   issues against the demo work orders, one per lifecycle state (open, acknowledged,
   resolved, closed), reported by the demo operators and assigned to the demo supervisor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **A shortage of a manufactured subassembly is now reported as such** — previously nothing
+  said "not enough pleat packs to build this order". The net-requirements report exploded
+  straight through a subassembly to the raw materials it is made from, so the subassembly
+  never appeared and the stock of it already on the shelf was ignored; the per-order check
+  that did cover it was an API endpoint no screen called.
+  - MRP now nets level by level: a subassembly's gross demand is met from its own stock
+    first and only the shortfall explodes downwards, so packs on the shelf pull no media and
+    a subassembly that runs out is listed by name.
+  - The planner marks any order stock cannot cover, naming the missing components on hover,
+    so it is visible while scheduling rather than when an operator tries to start.
+  - The operator's work-order screen leads with the same warning, listing what is needed,
+    what is free and what is missing.
 - **Every demo product now has a process template, and work orders carry it** — only the
   HEPA-13 Standard had a routing, so the other four products showed "0 templates" and their
   work orders had no steps for an operator to work through. Each product type now gets its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Every demo product now has a process template, and work orders carry it** — only the
+  HEPA-13 Standard had a routing, so the other four products showed "0 templates" and their
+  work orders had no steps for an operator to work through. Each product type now gets its
+  own routing (slim assembly, pre-filter and carbon production, HVAC cassette), and the
+  seeder snapshots it onto the work order with `toSnapshot()` instead of a hand-rolled
+  header — so the snapshot carries the steps and the BOM the way the application writes it.
 - **Demo data now includes a two-level bill of materials** — `AirFilterDemoSeeder` seeds the
   purchased parts (media, frame profile, gasket, adhesives, carton) and one manufactured
   sub-assembly, the HEPA-13 pleat pack, which has its own routing and BOM. The assembly BOM

--- a/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
+++ b/backend/app/Http/Controllers/Web/Operator/WorkOrderController.php
@@ -369,6 +369,12 @@ class WorkOrderController extends Controller
         // documents` on the client (Operator has it; see the seeder).
         $engineeringDocuments = $workOrder->frozenEngineeringDocuments();
 
-        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'scrapReasons', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates', 'processPhotos', 'stepPhotos', 'stepMedia', 'stepChecklists', 'stepOutputs', 'issueCustomFields', 'engineeringDocuments'));
+        // What this order cannot be built from, if anything. Shown before the
+        // operator starts rather than surfacing as a failed allocation — and a
+        // subassembly is named as itself, not as the parts it is made from.
+        $materialShortages = app(\App\Services\Material\MaterialAllocationService::class)
+            ->shortagesForWorkOrders(collect([$workOrder]))[$workOrder->id] ?? [];
+
+        return Inertia::render('operator/WorkOrderDetail', compact('workOrder', 'issueTypes', 'scrapReasons', 'workstations', 'defaultWorkstationId', 'line', 'labelTemplates', 'processPhotos', 'stepPhotos', 'stepMedia', 'stepChecklists', 'stepOutputs', 'issueCustomFields', 'engineeringDocuments', 'materialShortages'));
     }
 }

--- a/backend/app/Services/Material/MaterialAllocationService.php
+++ b/backend/app/Services/Material/MaterialAllocationService.php
@@ -10,6 +10,7 @@ use App\Models\Material;
 use App\Models\MaterialAllocation;
 use App\Models\StockMovement;
 use App\Models\User;
+use App\Models\WorkOrder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -71,7 +72,129 @@ class MaterialAllocationService
 
     public function previewForBatch(Batch $batch): array
     {
-        $bom = $batch->workOrder->process_snapshot['bom'] ?? [];
+        return $this->previewBom(
+            $batch->workOrder->process_snapshot['bom'] ?? [],
+            (float) $batch->target_qty,
+        );
+    }
+
+    /**
+     * The same component check one level up: can this work order's planned
+     * quantity be covered at all?
+     *
+     * Asked while the order is still only scheduled — before any batch exists —
+     * so the planner and the order screen can flag a shortage rather than
+     * letting it surface when an operator tries to start.
+     *
+     * A subassembly is a BOM line like any other here: the snapshot is read as
+     * written, so "not enough pleat packs" is reported as such rather than
+     * being resolved into the media it would be made from.
+     */
+    public function previewForWorkOrder(WorkOrder $workOrder): array
+    {
+        return $this->previewBom(
+            $workOrder->process_snapshot['bom'] ?? [],
+            (float) $workOrder->planned_qty,
+        );
+    }
+
+    /**
+     * Which of these work orders current stock cannot cover, and by what.
+     *
+     * Every material across every snapshot is loaded in one pass, so a planner
+     * board can be flagged without a query per tile. Each order is measured on
+     * its own against on-hand — orders are not netted against each other, so
+     * this answers "could this one run today", not "can the whole week".
+     *
+     * @param  Collection<int, WorkOrder>  $workOrders
+     * @return array<int, list<array<string, mixed>>> short lines keyed by work
+     *                                                order id; covered orders are absent
+     */
+    public function shortagesForWorkOrders(Collection $workOrders): array
+    {
+        $boms = [];
+        $ids = [];
+        $codes = [];
+
+        foreach ($workOrders as $workOrder) {
+            $bom = $workOrder->process_snapshot['bom'] ?? [];
+            if (empty($bom)) {
+                continue;
+            }
+
+            $boms[$workOrder->id] = $bom;
+
+            foreach ($bom as $bomItem) {
+                if (! empty($bomItem['material_id'])) {
+                    $ids[] = $bomItem['material_id'];
+                } elseif (! empty($bomItem['material_code'])) {
+                    $codes[] = $bomItem['material_code'];
+                }
+            }
+        }
+
+        if ($boms === []) {
+            return [];
+        }
+
+        $byId = $ids !== []
+            ? Material::whereIn('id', array_unique($ids))->get()->keyBy('id')
+            : collect();
+        $byCode = $codes !== []
+            ? Material::whereIn('code', array_unique($codes))->get()->keyBy('code')
+            : collect();
+
+        $out = [];
+
+        foreach ($workOrders as $workOrder) {
+            $bom = $boms[$workOrder->id] ?? null;
+            if (! $bom) {
+                continue;
+            }
+
+            $short = [];
+
+            foreach ($bom as $bomItem) {
+                $material = ! empty($bomItem['material_id'])
+                    ? $byId->get($bomItem['material_id'])
+                    : null;
+                if (! $material && ! empty($bomItem['material_code'])) {
+                    $material = $byCode->get($bomItem['material_code']);
+                }
+
+                // A BOM line naming a material that no longer exists cannot be
+                // covered either — worth flagging rather than skipping.
+                $required = $this->calculateRequiredQty($bomItem, (float) $workOrder->planned_qty);
+                $available = (float) ($material?->available_quantity ?? 0);
+
+                if ($material && $available >= $required) {
+                    continue;
+                }
+
+                $short[] = [
+                    'material_code' => $bomItem['material_code'] ?? $material?->code,
+                    'material_name' => $bomItem['material_name'] ?? $material?->name,
+                    'unit_of_measure' => $bomItem['unit_of_measure'] ?? $material?->unit_of_measure,
+                    'required_qty' => round($required, 4),
+                    'available_qty' => round($available, 4),
+                    'missing_qty' => round(max(0, $required - $available), 4),
+                    'material_exists' => $material !== null,
+                ];
+            }
+
+            if ($short !== []) {
+                $out[$workOrder->id] = $short;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $bom
+     */
+    private function previewBom(array $bom, float $quantity): array
+    {
         $preview = [];
 
         // Bulk load materials referenced by the BOM to avoid N+1. The
@@ -103,7 +226,7 @@ class MaterialAllocationService
             if (! $material && ! empty($bomItem['material_code'])) {
                 $material = $materialsByCode->get($bomItem['material_code']);
             }
-            $requiredQty = $this->calculateRequiredQty($bomItem, (float) $batch->target_qty);
+            $requiredQty = $this->calculateRequiredQty($bomItem, $quantity);
             $available = $material?->available_quantity ?? 0;
 
             $preview[] = [

--- a/backend/app/Services/Material/NetRequirementsService.php
+++ b/backend/app/Services/Material/NetRequirementsService.php
@@ -13,6 +13,13 @@ use Illuminate\Support\Collection;
  * component requirements, net them against on-hand stock and produce a shortage
  * list.
  *
+ * Netting runs level by level, not against a flattened leaf explosion. A
+ * manufactured subassembly is demand in its own right: its gross requirement is
+ * netted against its own stock first, and only the shortfall explodes into the
+ * level below. So packs already on the shelf appear as covered demand and pull
+ * no media, and a subassembly that runs out is reported by name — a flat leaf
+ * explosion could do neither.
+ *
  * Demand scope: only PENDING / ACCEPTED work orders — these are planned but not
  * yet started, so no materials have been allocated for them. Started orders
  * (IN_PROGRESS/BLOCKED) have already pulled their materials out of
@@ -24,6 +31,9 @@ class NetRequirementsService
 {
     /** Statuses whose un-started demand MRP plans for. */
     public const DEMAND_STATUSES = [WorkOrder::STATUS_PENDING, WorkOrder::STATUS_ACCEPTED];
+
+    /** @var array<int, list<array{material_id: int, required_per_unit: float}>> */
+    private array $componentCache = [];
 
     public function __construct(private readonly BomExplosionService $explosion) {}
 
@@ -45,52 +55,103 @@ class NetRequirementsService
             ->when($lineId, fn ($q) => $q->where('line_id', $lineId))
             ->get(['id', 'order_no', 'product_type_id', 'planned_qty', 'line_id', 'due_date']);
 
-        // BOM per product type, exploded through every subassembly level to the
-        // materials that actually have to be bought or drawn from stock.
-        $bomByProductType = $this->bomByProductType($workOrders->pluck('product_type_id')->unique()->filter());
+        $templates = $this->activeTemplateByProductType($workOrders->pluck('product_type_id')->unique()->filter());
 
-        // Accumulate gross requirement + the driving work orders, per material.
-        $gross = [];          // material_id => qty
+        // Level 1 demand: the direct components of each order's product. Nothing
+        // is exploded yet — a subassembly is demand in its own right first.
+        $pending = [];        // material_id => qty needed at this level
         $relatedWos = [];     // material_id => [order_no => true]
+
         foreach ($workOrders as $wo) {
-            $lines = $bomByProductType->get($wo->product_type_id, collect());
-            foreach ($lines as $line) {
-                // required_per_unit already carries the scrap compounded through
-                // every level of the explosion, so it only needs scaling here.
-                $required = round((float) $line['required_per_unit'] * (float) $wo->planned_qty, 4);
+            $template = $templates->get($wo->product_type_id);
+            if (! $template) {
+                continue;
+            }
+
+            foreach ($this->directComponents($template) as $line) {
+                $required = round($line['required_per_unit'] * (float) $wo->planned_qty, 4);
                 if ($required <= 0) {
                     continue;
                 }
                 $mid = $line['material_id'];
-                $gross[$mid] = ($gross[$mid] ?? 0) + $required;
+                $pending[$mid] = ($pending[$mid] ?? 0) + $required;
                 $relatedWos[$mid][$wo->order_no] = true;
             }
         }
 
-        if (empty($gross)) {
+        if (empty($pending)) {
             return $this->emptyReport($from, $to, $lineId, $workOrders->count());
         }
 
-        $materials = Material::whereIn('id', array_keys($gross))->get()->keyBy('id');
+        $rows = [];        // material_id => requirement row
+        $stockLeft = [];   // material_id => on-hand not yet claimed by a higher level
+        $level = 0;
 
-        $requirements = [];
-        foreach ($gross as $materialId => $grossQty) {
-            $material = $materials->get($materialId);
-            $onHand = (float) ($material?->stock_quantity ?? 0);
-            $net = round(max(0, $grossQty - $onHand), 4);
+        while ($pending !== [] && $level < BomExplosionService::MAX_DEPTH) {
+            $materials = Material::with('producingTemplate')
+                ->whereIn('id', array_keys($pending))
+                ->get()
+                ->keyBy('id');
 
-            $requirements[] = [
-                'material_id' => $materialId,
-                'code' => $material?->code,
-                'name' => $material?->name ?? __('Unknown'),
-                'unit_of_measure' => $material?->unit_of_measure,
-                'required_qty' => round($grossQty, 4),
-                'available_qty' => round($onHand, 4),
-                'net_qty' => $net,
-                'is_short' => $net > 0,
-                'related_work_orders' => array_keys($relatedWos[$materialId] ?? []),
-            ];
+            $next = [];
+
+            foreach ($pending as $materialId => $grossQty) {
+                $material = $materials->get($materialId);
+                $onHand = (float) ($material?->stock_quantity ?? 0);
+
+                // Stock is claimed once, by whichever level asks first — a
+                // material used both directly and inside a subassembly must not
+                // spend the same units twice.
+                $stockLeft[$materialId] ??= $onHand;
+                $fromStock = min($grossQty, max(0.0, $stockLeft[$materialId]));
+                $stockLeft[$materialId] -= $fromStock;
+                $net = round($grossQty - $fromStock, 4);
+
+                $rows[$materialId] ??= [
+                    'material_id' => $materialId,
+                    'code' => $material?->code,
+                    'name' => $material?->name ?? __('Unknown'),
+                    'unit_of_measure' => $material?->unit_of_measure,
+                    'required_qty' => 0.0,
+                    'available_qty' => round($onHand, 4),
+                    'net_qty' => 0.0,
+                    'is_short' => false,
+                    'is_manufactured' => (bool) ($material?->is_manufactured),
+                    'level' => $level,
+                    'related_work_orders' => [],
+                ];
+
+                $rows[$materialId]['required_qty'] = round($rows[$materialId]['required_qty'] + $grossQty, 4);
+                $rows[$materialId]['net_qty'] = round($rows[$materialId]['net_qty'] + $net, 4);
+                $rows[$materialId]['is_short'] = $rows[$materialId]['net_qty'] > 0;
+
+                // Only the shortfall has to be made, so only the shortfall
+                // explodes. Packs already on the shelf pull no media.
+                if ($net > 0 && $material?->isExplodable()) {
+                    foreach ($this->directComponents($material->producingTemplate) as $child) {
+                        $qty = round($child['required_per_unit'] * $net, 4);
+                        if ($qty <= 0) {
+                            continue;
+                        }
+                        $next[$child['material_id']] = ($next[$child['material_id']] ?? 0) + $qty;
+
+                        // The child inherits whatever orders drive its parent.
+                        foreach (array_keys($relatedWos[$materialId] ?? []) as $orderNo) {
+                            $relatedWos[$child['material_id']][$orderNo] = true;
+                        }
+                    }
+                }
+            }
+
+            $pending = $next;
+            $level++;
         }
+
+        foreach ($rows as $materialId => $row) {
+            $rows[$materialId]['related_work_orders'] = array_keys($relatedWos[$materialId] ?? []);
+        }
+
+        $requirements = array_values($rows);
 
         // Stable, useful ordering: biggest shortfall first, then by name.
         usort($requirements, function ($a, $b) {
@@ -114,53 +175,55 @@ class NetRequirementsService
     }
 
     /**
-     * Build a map of product_type_id => collection of leaf requirement lines
-     * (material_id, required_per_unit) from each type's active template,
-     * exploded through every subassembly level.
+     * The active template (highest version) per product type.
      *
-     * @return Collection<int, Collection<int, array<string, mixed>>>
+     * @return Collection<int, ProcessTemplate>
      */
-    private function bomByProductType(Collection $productTypeIds): Collection
+    private function activeTemplateByProductType(Collection $productTypeIds): Collection
     {
         if ($productTypeIds->isEmpty()) {
             return collect();
         }
 
-        // Active template id per product type (highest version, active).
-        $templateIds = ProcessTemplate::whereIn('product_type_id', $productTypeIds)
+        return ProcessTemplate::whereIn('product_type_id', $productTypeIds)
             ->where('is_active', true)
             ->orderBy('version', 'desc')
-            ->get(['id', 'product_type_id'])
+            ->get()
             ->groupBy('product_type_id')
-            ->map(fn ($rows) => $rows->first()->id);
+            ->map(fn ($rows) => $rows->first());
+    }
 
-        if ($templateIds->isEmpty()) {
-            return collect();
+    /**
+     * One template's own BOM lines — one level, not exploded. Quantity carries
+     * that line's scrap; deeper scrap is applied by the level that adds it.
+     *
+     * Product-type lines are plain component references with no material behind
+     * them, so the material engine skips them, exactly as the explosion does.
+     *
+     * @return list<array{material_id: int, required_per_unit: float}>
+     */
+    private function directComponents(ProcessTemplate $template): array
+    {
+        $templateId = (int) $template->getKey();
+
+        if (isset($this->componentCache[$templateId])) {
+            return $this->componentCache[$templateId];
         }
 
-        // Explode each template for a single unit: leaf quantities come back
-        // with scrap already compounded through every level, so the caller only
-        // scales by planned_qty. Subassemblies are resolved into what they are
-        // made of rather than counted as demand themselves — netting a
-        // manufactured item against its own stock is a separate MRP concern.
-        $templates = ProcessTemplate::whereIn('id', $templateIds->values())->get()->keyBy('id');
-        $productTypeByTemplate = $templateIds->flip();
+        $lines = $template->bomItems()
+            ->whereNotNull('material_id')
+            ->orderBy('sort_order')
+            ->get(['material_id', 'quantity_per_unit', 'scrap_percentage'])
+            ->map(fn ($item) => [
+                'material_id' => (int) $item->material_id,
+                'required_per_unit' => round(
+                    (float) $item->quantity_per_unit * (1 + ((float) $item->scrap_percentage / 100)),
+                    6
+                ),
+            ])
+            ->all();
 
-        return $templateIds->values()
-            ->mapWithKeys(function (int $templateId) use ($templates, $productTypeByTemplate) {
-                $template = $templates->get($templateId);
-
-                $lines = $template
-                    ? collect($this->explosion->leafRequirements($template, 1.0))
-                        ->map(fn (array $leaf) => [
-                            'material_id' => $leaf['material_id'],
-                            'required_per_unit' => (float) $leaf['required_qty'],
-                        ])
-                    : collect();
-
-                return [$productTypeByTemplate->get($templateId) => $lines];
-            })
-            ->filter(fn ($lines) => $lines->isNotEmpty());
+        return $this->componentCache[$templateId] = $lines;
     }
 
     private function emptyReport(Carbon $from, Carbon $to, ?int $lineId, int $woCount): array

--- a/backend/app/Services/Schedule/SchedulePlannerService.php
+++ b/backend/app/Services/Schedule/SchedulePlannerService.php
@@ -26,6 +26,10 @@ class SchedulePlannerService
 {
     public const VIEW_MODES = ['weekly', 'daily', 'hourly', 'monthly'];
 
+    public function __construct(
+        private readonly \App\Services\Material\MaterialAllocationService $allocation,
+    ) {}
+
     /**
      * Everything the planner board renders for one view/range/line filter.
      *
@@ -185,7 +189,16 @@ class SchedulePlannerService
         $realtimeMode = trim($settings['realtime_mode'] ?? 'polling', '"\'');
 
         return [
-            'workOrders' => $workOrders->map(fn ($wo) => $this->flattenOrder($wo))->values()->all(),
+            // Component cover for everything on the board, in one pass, so a
+            // planner can see an order is unbuildable before scheduling around it.
+            'workOrders' => (function () use ($workOrders) {
+                $shortages = $this->allocation->shortagesForWorkOrders($workOrders);
+
+                return $workOrders
+                    ->map(fn ($wo) => $this->flattenOrder($wo, $shortages[$wo->id] ?? []))
+                    ->values()
+                    ->all();
+            })(),
             'lines' => $this->flattenLines($lines),
             'allLines' => $this->flattenLines($allLines),
             'shifts' => $shifts->map(fn ($s) => [
@@ -534,12 +547,20 @@ class SchedulePlannerService
             ->exists();
     }
 
-    public function flattenOrder(WorkOrder $wo): array
+    /**
+     * @param  list<array<string, mixed>>  $shortages  short component lines for this
+     *                                                 order, empty when stock covers it
+     */
+    public function flattenOrder(WorkOrder $wo, array $shortages = []): array
     {
         $planned = (float) $wo->planned_qty;
         $produced = (float) $wo->produced_qty;
 
         return [
+            // Cannot be built from stock as it stands. Carries the offending
+            // lines so the tile can say what is missing without another call.
+            'has_material_shortage' => $shortages !== [],
+            'material_shortages' => $shortages,
             'id' => $wo->id,
             'order_no' => $wo->order_no,
             'customer_name' => $wo->customer?->name,

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -49,7 +49,7 @@ class AirFilterDemoSeeder extends Seeder
         $templates = $this->seedProcessTemplates($productTypes, $workstations);
         $users = $this->seedUsers($lines);
         $materials = $this->seedMaterials($templates['PLEATPACK13']);
-        $this->seedBom($templates['HEPA13_STD'], $templates['PLEATPACK13'], $materials);
+        $this->seedBom($templates, $materials);
         $workOrders = $this->seedWorkOrders($lines, $productTypes, $templates);
         $this->seedActiveBatch($workOrders['WO-186-001'], $templates['HEPA13_STD'], $users['operator-mk']);
         $this->seedIssues($workOrders, $users);
@@ -70,13 +70,28 @@ class AirFilterDemoSeeder extends Seeder
         $typeIds = MaterialType::pluck('id', 'code');
 
         $defs = [
-            // Purchased.
+            // Purchased — HEPA-13 line.
             ['code' => 'MEDIA-H13',   'name' => 'HEPA-13 filter media',      'type' => 'raw_material', 'unit_of_measure' => 'm2',  'stock_quantity' => 4200,  'unit_price' => 6.40,  'supplier_name' => 'Filtrair Media BV'],
             ['code' => 'FRAME-AL-13', 'name' => 'Aluminium frame profile',   'type' => 'raw_material', 'unit_of_measure' => 'pcs', 'stock_quantity' => 1800,  'unit_price' => 11.20, 'supplier_name' => 'AluFab Sp. z o.o.'],
+            ['code' => 'FRAME-SLIM',  'name' => 'Slim frame, pre-formed',    'type' => 'raw_material', 'unit_of_measure' => 'pcs', 'stock_quantity' => 900,   'unit_price' => 12.80, 'supplier_name' => 'AluFab Sp. z o.o.'],
             ['code' => 'GASKET-PU-13', 'name' => 'PU gasket seal',           'type' => 'raw_material', 'unit_of_measure' => 'm',   'stock_quantity' => 2600,  'unit_price' => 1.85,  'supplier_name' => 'SealTech GmbH'],
             ['code' => 'ADH-2K-A',    'name' => 'Two-part adhesive (A)',     'type' => 'auxiliary',    'unit_of_measure' => 'kg',  'stock_quantity' => 180,   'unit_price' => 24.50, 'supplier_name' => 'ChemBond'],
             ['code' => 'HOTMELT-01',  'name' => 'Hot-melt edge sealant',     'type' => 'auxiliary',    'unit_of_measure' => 'kg',  'stock_quantity' => 95,    'unit_price' => 18.90, 'supplier_name' => 'ChemBond'],
+
+            // Housing line — moulded products (pre-filter, carbon).
+            ['code' => 'RESIN-ABS',   'name' => 'ABS moulding granulate',    'type' => 'raw_material', 'unit_of_measure' => 'kg',  'stock_quantity' => 1450,  'unit_price' => 4.75,  'supplier_name' => 'PolyNord AB'],
+            ['code' => 'MEDIA-G4',    'name' => 'G4 coarse filter media',    'type' => 'raw_material', 'unit_of_measure' => 'm2',  'stock_quantity' => 3100,  'unit_price' => 2.30,  'supplier_name' => 'Filtrair Media BV'],
+            ['code' => 'CARBON-GRAN', 'name' => 'Activated carbon granulate', 'type' => 'raw_material', 'unit_of_measure' => 'kg', 'stock_quantity' => 860,   'unit_price' => 9.60,  'supplier_name' => 'CarbonWorks Ltd'],
+            ['code' => 'MESH-RET',    'name' => 'Retaining mesh disc',       'type' => 'raw_material', 'unit_of_measure' => 'pcs', 'stock_quantity' => 2400,  'unit_price' => 0.95,  'supplier_name' => 'MeshPro'],
+            ['code' => 'SEAL-EPDM',   'name' => 'EPDM seal strip',           'type' => 'raw_material', 'unit_of_measure' => 'm',   'stock_quantity' => 3400,  'unit_price' => 1.40,  'supplier_name' => 'SealTech GmbH'],
+
+            // HVAC cassette.
+            ['code' => 'FRAME-CASS',  'name' => 'HVAC cassette frame',       'type' => 'raw_material', 'unit_of_measure' => 'pcs', 'stock_quantity' => 420,   'unit_price' => 18.40, 'supplier_name' => 'AluFab Sp. z o.o.'],
+            ['code' => 'MEDIA-F7',    'name' => 'F7 fine filter media',      'type' => 'raw_material', 'unit_of_measure' => 'm2',  'stock_quantity' => 1900,  'unit_price' => 4.10,  'supplier_name' => 'Filtrair Media BV'],
+
+            // Packaging.
             ['code' => 'CARTON-10',   'name' => 'Carton, 10 filters',        'type' => 'packaging',    'unit_of_measure' => 'pcs', 'stock_quantity' => 640,   'unit_price' => 3.10,  'supplier_name' => 'PackLine'],
+            ['code' => 'CARTON-CASS', 'name' => 'Carton, 1 cassette',        'type' => 'packaging',    'unit_of_measure' => 'pcs', 'stock_quantity' => 380,   'unit_price' => 2.40,  'supplier_name' => 'PackLine'],
         ];
 
         $materials = [];
@@ -115,57 +130,97 @@ class AirFilterDemoSeeder extends Seeder
     }
 
     /**
-     * Two BOM levels: the HEPA-13 assembly consumes the pleat pack plus the
-     * purchased parts, and the pleat pack's own template consumes media and
-     * sealant. Exploding the top level therefore reaches the raw media.
+     * A bill of materials for every demo routing, not just the HEPA-13.
+     *
+     * The HEPA-13 assembly is the two-level one: it consumes the pleat pack,
+     * whose own template consumes media and sealant, so exploding the top level
+     * reaches the raw media. The rest are single level.
      *
      * Lines are pinned to the step that actually consumes them, so the operator's
      * kit list matches the routing.
      *
+     * @param  array<string, ProcessTemplate>  $templates  keyed by product code
      * @param  array<string, Material>  $materials
      */
-    private function seedBom(ProcessTemplate $assembly, ProcessTemplate $pleatPack, array $materials): void
+    private function seedBom(array $templates, array $materials): void
     {
+        // [product code => [[step number, material code, qty per unit, scrap %, consumed at], …]]
         $defs = [
-            // HEPA-13 assembly.
-            [$assembly, 2, 'FRAME-AL-13',  1,    0,   'start'],
-            [$assembly, 3, 'PLEATPACK13',  1,    2,   'start'],
-            [$assembly, 4, 'GASKET-PU-13', 1.6,  3,   'during'],
-            [$assembly, 4, 'ADH-2K-A',     0.08, 5,   'during'],
-            // 10 filters to a carton.
-            [$assembly, 6, 'CARTON-10',    0.1,  0,   'end'],
-
-            // Pleat pack — the level below.
-            [$pleatPack, 1, 'MEDIA-H13',   2.4,  5,   'start'],
-            [$pleatPack, 2, 'HOTMELT-01',  0.03, 2,   'during'],
+            'HEPA13_STD' => [
+                [2, 'FRAME-AL-13',  1,    0, 'start'],
+                // The sub-assembly line — this is what explodes a level down.
+                [3, 'PLEATPACK13',  1,    2, 'start'],
+                [4, 'GASKET-PU-13', 1.6,  3, 'during'],
+                [4, 'ADH-2K-A',     0.08, 5, 'during'],
+                // 10 filters to a carton.
+                [6, 'CARTON-10',    0.1,  0, 'end'],
+            ],
+            // Its routing pleats media directly rather than taking a finished
+            // pack, so the BOM names the media, not the sub-assembly.
+            'HEPA13_SLIM' => [
+                [1, 'FRAME-SLIM',   1,    0, 'start'],
+                [2, 'MEDIA-H13',    1.9,  5, 'start'],
+                [3, 'GASKET-PU-13', 1.4,  3, 'during'],
+                [3, 'ADH-2K-A',     0.07, 5, 'during'],
+                [5, 'CARTON-10',    0.1,  0, 'end'],
+            ],
+            'PREFILTER' => [
+                [1, 'RESIN-ABS',    0.42, 3, 'start'],
+                [2, 'MEDIA-G4',     0.8,  4, 'start'],
+                // Coarse filters ship 20 to a box.
+                [4, 'CARTON-10',    0.05, 0, 'end'],
+            ],
+            'CARBON' => [
+                [1, 'RESIN-ABS',    0.85, 3, 'start'],
+                [2, 'CARBON-GRAN',  1.2,  2, 'during'],
+                [3, 'MESH-RET',     1,    1, 'during'],
+                [3, 'SEAL-EPDM',    0.9,  2, 'during'],
+                [5, 'CARTON-10',    0.1,  0, 'end'],
+            ],
+            'HVAC' => [
+                [1, 'FRAME-CASS',   1,    0, 'start'],
+                [2, 'MEDIA-G4',     1.1,  4, 'start'],
+                [3, 'MEDIA-F7',     1.6,  5, 'during'],
+                [4, 'SEAL-EPDM',    2.2,  2, 'during'],
+                [6, 'CARTON-CASS',  1,    0, 'end'],
+            ],
+            // The level below the HEPA-13 assembly.
+            'PLEATPACK13' => [
+                [1, 'MEDIA-H13',    2.4,  5, 'start'],
+                [2, 'HOTMELT-01',   0.03, 2, 'during'],
+            ],
         ];
 
-        $sortOrder = [];
-
-        foreach ($defs as [$template, $stepNumber, $code, $qty, $scrap, $consumedAt]) {
-            $material = $materials[$code] ?? null;
-            if (! $material) {
+        foreach ($defs as $productCode => $lines) {
+            $template = $templates[$productCode] ?? null;
+            if (! $template) {
                 continue;
             }
 
-            $stepId = DB::table('template_steps')
-                ->where('process_template_id', $template->id)
-                ->where('step_number', $stepNumber)
-                ->value('id');
+            $sortOrder = 0;
 
-            $key = $template->id;
-            $sortOrder[$key] = ($sortOrder[$key] ?? 0) + 1;
+            foreach ($lines as [$stepNumber, $code, $qty, $scrap, $consumedAt]) {
+                $material = $materials[$code] ?? null;
+                if (! $material) {
+                    continue;
+                }
 
-            BomItem::updateOrCreate(
-                ['process_template_id' => $template->id, 'material_id' => $material->id],
-                [
-                    'template_step_id' => $stepId,
-                    'quantity_per_unit' => $qty,
-                    'scrap_percentage' => $scrap,
-                    'consumed_at' => $consumedAt,
-                    'sort_order' => $sortOrder[$key],
-                ]
-            );
+                $stepId = DB::table('template_steps')
+                    ->where('process_template_id', $template->id)
+                    ->where('step_number', $stepNumber)
+                    ->value('id');
+
+                BomItem::updateOrCreate(
+                    ['process_template_id' => $template->id, 'material_id' => $material->id],
+                    [
+                        'template_step_id' => $stepId,
+                        'quantity_per_unit' => $qty,
+                        'scrap_percentage' => $scrap,
+                        'consumed_at' => $consumedAt,
+                        'sort_order' => ++$sortOrder,
+                    ]
+                );
+            }
         }
     }
 
@@ -438,8 +493,16 @@ class AirFilterDemoSeeder extends Seeder
             );
 
             foreach ($steps as [$stepNo, $stepName, $instruction, $duration, $wsCode]) {
+                // Match live rows only. template_steps is soft-deletable and
+                // updateOrInsert() runs without the model's scope, so leaving
+                // deleted_at out would let a re-run resurrect (and overwrite) a
+                // step the user had deleted instead of inserting a fresh one.
                 DB::table('template_steps')->updateOrInsert(
-                    ['process_template_id' => $template->id, 'step_number' => $stepNo],
+                    [
+                        'process_template_id' => $template->id,
+                        'step_number' => $stepNo,
+                        'deleted_at' => null,
+                    ],
                     [
                         'name' => $stepName,
                         'instruction' => $instruction,

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -9,6 +9,7 @@ use App\Models\Issue;
 use App\Models\IssueType;
 use App\Models\Line;
 use App\Models\Material;
+use App\Models\MaterialLot;
 use App\Models\MaterialType;
 use App\Models\ProcessTemplate;
 use App\Models\ProductType;
@@ -33,6 +34,8 @@ use Spatie\Permission\Models\Role;
  *  - A two-level BOM: the HEPA-13 assembly consumes a manufactured pleat pack
  *    (sub-assembly) plus purchased parts; the pleat pack has its own routing
  *    and BOM, so exploding the top level reaches the raw media
+ *  - Received material lots, one per lot status (released, quarantine, rejected,
+ *    consumed, expired)
  *
  * Run with: `php artisan db:seed --class=AirFilterDemoSeeder`
  *
@@ -50,6 +53,7 @@ class AirFilterDemoSeeder extends Seeder
         $users = $this->seedUsers($lines);
         $materials = $this->seedMaterials($templates['PLEATPACK13']);
         $this->seedBom($templates, $materials);
+        $this->seedMaterialLots($materials);
         $workOrders = $this->seedWorkOrders($lines, $productTypes, $templates);
         $this->seedActiveBatch($workOrders['WO-186-001'], $templates['HEPA13_STD'], $users['operator-mk']);
         $this->seedIssues($workOrders, $users);
@@ -127,6 +131,68 @@ class AirFilterDemoSeeder extends Seeder
         );
 
         return $materials;
+    }
+
+    /**
+     * Received material lots — the incoming side of traceability.
+     *
+     * One per material that is worth tracing, covering every lot status the app
+     * knows: stock on hand (released), a delivery still waiting on inbound QC
+     * (quarantine), one that failed it (rejected), one used up (consumed) and a
+     * time-expired adhesive next to its live replacement (expired / released).
+     * Chemicals carry manufacturing and expiry dates; the rest do not.
+     *
+     * @param  array<string, Material>  $materials
+     */
+    private function seedMaterialLots(array $materials): void
+    {
+        // [lot number, material code, status, received, available, days ago, shelf life in days or null]
+        $defs = [
+            ['LOT-MED-26031', 'MEDIA-H13',   MaterialLot::STATUS_RELEASED,   1200, 845,  12, null],
+            // Landed this morning, inbound inspection not done yet.
+            ['LOT-MED-26034', 'MEDIA-H13',   MaterialLot::STATUS_QUARANTINE, 900,  900,  0,  null],
+            // Failed the inbound check — kept for the supplier claim.
+            ['LOT-MED-25488', 'MEDIA-H13',   MaterialLot::STATUS_REJECTED,   600,  0,    46, null],
+            ['LOT-FRM-26030', 'FRAME-AL-13', MaterialLot::STATUS_RELEASED,   900,  612,  15, null],
+            ['LOT-SLM-26031', 'FRAME-SLIM',  MaterialLot::STATUS_RELEASED,   400,  355,  11, null],
+            ['LOT-RES-26029', 'RESIN-ABS',   MaterialLot::STATUS_RELEASED,   750,  410,  18, null],
+            ['LOT-CRB-26030', 'CARBON-GRAN', MaterialLot::STATUS_RELEASED,   500,  268,  16, null],
+            ['LOT-G4-26028',  'MEDIA-G4',    MaterialLot::STATUS_RELEASED,   1400, 980,  21, null],
+            ['LOT-F7-26031',  'MEDIA-F7',    MaterialLot::STATUS_RELEASED,   800,  745,  10, null],
+            ['LOT-SEL-26027', 'SEAL-EPDM',   MaterialLot::STATUS_RELEASED,   1500, 1130, 24, null],
+            // Drawn down to nothing — what a closed-out lot looks like in tracing.
+            ['LOT-MSH-26025', 'MESH-RET',    MaterialLot::STATUS_CONSUMED,   1200, 0,    30, null],
+            // Past its shelf life; the replacement below is the live one.
+            ['LOT-ADH-25512', 'ADH-2K-A',    MaterialLot::STATUS_EXPIRED,    60,   18,   200, 180],
+            ['LOT-ADH-26032', 'ADH-2K-A',    MaterialLot::STATUS_RELEASED,   80,   62,   9,   180],
+            ['LOT-HM-26030',  'HOTMELT-01',  MaterialLot::STATUS_RELEASED,   45,   31,   14,  365],
+            ['LOT-CAS-26029', 'FRAME-CASS',  MaterialLot::STATUS_RELEASED,   220,  168,  19,  null],
+        ];
+
+        foreach ($defs as [$lotNumber, $code, $status, $received, $available, $daysAgo, $shelfLife]) {
+            $material = $materials[$code] ?? null;
+            if (! $material) {
+                continue;
+            }
+
+            $receivedAt = now()->subDays($daysAgo);
+
+            MaterialLot::updateOrCreate(
+                ['lot_number' => $lotNumber],
+                [
+                    'material_id' => $material->id,
+                    'quantity_received' => $received,
+                    'quantity_available' => $available,
+                    'unit_of_measure' => $material->unit_of_measure,
+                    'received_at' => $receivedAt,
+                    'manufacturing_date' => $shelfLife ? $receivedAt->copy()->subDays(14)->toDateString() : null,
+                    'expiry_date' => $shelfLife ? $receivedAt->copy()->addDays($shelfLife)->toDateString() : null,
+                    'status' => $status,
+                    'supplier_lot_no' => str_replace('LOT-', 'S/', $lotNumber),
+                    'supplier_reference' => $material->supplier_name,
+                ]
+            );
+        }
     }
 
     /**

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -46,50 +46,13 @@ class AirFilterDemoSeeder extends Seeder
         $lines = $this->seedLines();
         $workstations = $this->seedWorkstations($lines);
         $productTypes = $this->seedProductTypes();
-        $template = $this->seedHepaProcessTemplate($productTypes['HEPA13_STD'], $workstations);
+        $templates = $this->seedProcessTemplates($productTypes, $workstations);
         $users = $this->seedUsers($lines);
-        $pleatPackTemplate = $this->seedPleatPackTemplate($productTypes['PLEATPACK13'], $workstations);
-        $materials = $this->seedMaterials($pleatPackTemplate);
-        $this->seedBom($template, $pleatPackTemplate, $materials);
-        $workOrders = $this->seedWorkOrders($lines, $productTypes, $template);
-        $this->seedActiveBatch($workOrders['WO-186-001'], $template, $users['operator-mk']);
+        $materials = $this->seedMaterials($templates['PLEATPACK13']);
+        $this->seedBom($templates['HEPA13_STD'], $templates['PLEATPACK13'], $materials);
+        $workOrders = $this->seedWorkOrders($lines, $productTypes, $templates);
+        $this->seedActiveBatch($workOrders['WO-186-001'], $templates['HEPA13_STD'], $users['operator-mk']);
         $this->seedIssues($workOrders, $users);
-    }
-
-    /**
-     * The pleat pack's own routing. Its existence is what makes PLEATPACK13 a
-     * sub-assembly rather than a purchased part: a material flagged
-     * `is_manufactured` and pointed at a producing template is what
-     * BomExplosionService follows down a level.
-     *
-     * @param  array<string, Workstation>  $ws
-     */
-    private function seedPleatPackTemplate(ProductType $productType, array $ws): ProcessTemplate
-    {
-        $template = ProcessTemplate::updateOrCreate(
-            ['product_type_id' => $productType->id, 'version' => 1],
-            ['name' => 'Pleat pack HEPA-13 — production v1', 'is_active' => true]
-        );
-
-        $steps = [
-            [1, 'Media pleating', 'Feed the media roll and fold to the HEPA-13 pitch. Check pleat height on the first five packs.', 6, $ws['WS-PA-01'] ?? null],
-            [2, 'Edge sealing', 'Run a hot-melt bead down both open edges and press until set.', 4, $ws['WS-AB-01'] ?? null],
-        ];
-
-        foreach ($steps as [$stepNo, $name, $instruction, $duration, $workstation]) {
-            DB::table('template_steps')->updateOrInsert(
-                ['process_template_id' => $template->id, 'step_number' => $stepNo],
-                [
-                    'name' => $name,
-                    'instruction' => $instruction,
-                    'estimated_duration_minutes' => $duration,
-                    'workstation_id' => $workstation?->id,
-                    'created_at' => now(),
-                ]
-            );
-        }
-
-        return $template;
     }
 
     /**
@@ -402,37 +365,95 @@ class AirFilterDemoSeeder extends Seeder
         return $result;
     }
 
-    private function seedHepaProcessTemplate(ProductType $productType, array $ws): ProcessTemplate
+    /**
+     * A routing for every demo product, not just the HEPA-13. Without one a
+     * product type shows "0 templates", its work orders carry no steps for the
+     * operator to work through, and there is nowhere to hang a BOM.
+     *
+     * @param  array<string, ProductType>  $pt
+     * @param  array<string, Workstation>  $ws
+     * @return array<string, ProcessTemplate> keyed by product code
+     */
+    private function seedProcessTemplates(array $pt, array $ws): array
     {
-        $template = ProcessTemplate::updateOrCreate(
-            ['product_type_id' => $productType->id, 'version' => 1],
-            ['name' => 'HEPA-13 Standard — assembly v1', 'is_active' => true]
-        );
-
-        $steps = [
-            [1, 'Material kit pickup',     'Pull the BOM kit (pleat sheet, frame blank, adhesive, gasket) from staging.', 5,  $ws['WS-MK-01']],
-            [2, 'Frame stamping',          'Stamp the aluminium frame blank on the housing press; check perpendicularity.', 4, $ws['WS-FR-01']],
-            [3, 'Pleat assembly',          'Pleat the filter media and slot into frame. Maintain pitch ±0.5 mm.', 8, $ws['WS-PA-01']],
-            [4, 'Adhesive bonding',        'Apply two-part adhesive bead around perimeter; cure 6 min at 60 °C.', 10, $ws['WS-AB-01']],
-            [5, 'QC visual inspection',    'Inspect for pleat collapse, adhesive squeeze-out, gasket fit. Photograph defects.', 3, $ws['WS-QC-01']],
-            [6, 'Packaging (10/box)',      'Pack 10 filters per carton with desiccant; apply lot label.', 4, $ws['WS-PK-01']],
-            [7, 'Pallet handoff',          'Stack cartons on pallet, wrap, hand off to dispatch with batch sheet.', 3, $ws['WS-PH-01']],
+        $defs = [
+            'HEPA13_STD' => ['HEPA-13 Standard — assembly v1', [
+                [1, 'Material kit pickup',  'Pull the BOM kit (pleat sheet, frame blank, adhesive, gasket) from staging.', 5, 'WS-MK-01'],
+                [2, 'Frame stamping',       'Stamp the aluminium frame blank on the housing press; check perpendicularity.', 4, 'WS-FR-01'],
+                [3, 'Pleat assembly',       'Pleat the filter media and slot into frame. Maintain pitch ±0.5 mm.', 8, 'WS-PA-01'],
+                [4, 'Adhesive bonding',     'Apply two-part adhesive bead around perimeter; cure 6 min at 60 °C.', 10, 'WS-AB-01'],
+                [5, 'QC visual inspection', 'Inspect for pleat collapse, adhesive squeeze-out, gasket fit. Photograph defects.', 3, 'WS-QC-01'],
+                [6, 'Packaging (10/box)',   'Pack 10 filters per carton with desiccant; apply lot label.', 4, 'WS-PK-01'],
+                [7, 'Pallet handoff',       'Stack cartons on pallet, wrap, hand off to dispatch with batch sheet.', 3, 'WS-PH-01'],
+            ]],
+            // Shares the HEPA line but skips the separate stamping pass — the slim
+            // frame arrives pre-formed.
+            'HEPA13_SLIM' => ['HEPA-13 Slim — assembly v1', [
+                [1, 'Material kit pickup',  'Pull the slim-frame kit from staging; check the frame depth marking.', 5, 'WS-MK-01'],
+                [2, 'Pleat assembly',       'Pleat to the slim pitch and seat into the pre-formed frame.', 9, 'WS-PA-01'],
+                [3, 'Adhesive bonding',     'Bead the perimeter and cure. Slim frames need the lower 55 °C profile.', 10, 'WS-AB-01'],
+                [4, 'QC visual inspection', 'Check pleat pitch, seal continuity and that the depth is within tolerance.', 3, 'WS-QC-01'],
+                [5, 'Packaging (10/box)',   'Pack 10 per carton; slim cartons take the same lot label.', 4, 'WS-PK-01'],
+            ]],
+            // Coarse filter on the housing line — moulded, not pleated.
+            'PREFILTER' => ['Pre-filter G4 — production v1', [
+                [1, 'Housing mould',        'Mould the G4 housing frame; check for short shots before releasing.', 6, 'WS-HM-01'],
+                [2, 'Media insert',         'Cut the G4 media to size and press into the housing.', 5, 'WS-HM-01'],
+                [3, 'Housing QC',           'Verify the media sits flush and the frame has no flash.', 3, 'WS-HQC-01'],
+                [4, 'Pack & label',         'Bag, box and label for stock replenishment.', 4, 'WS-PK-04'],
+            ]],
+            'CARBON' => ['Carbon X2 — production v1', [
+                [1, 'Housing mould',        'Mould the Carbon X2 housing; verify the fill port is clear.', 6, 'WS-HM-01'],
+                [2, 'Carbon fill',          'Fill with activated carbon to the weight target, then settle on the vibrator.', 8, 'WS-HM-01'],
+                [3, 'Seal & press',         'Press the retaining mesh and seal the fill port.', 5, 'WS-HM-01'],
+                [4, 'Housing QC',           'Weigh-check the fill and confirm no carbon migration past the mesh.', 4, 'WS-HQC-01'],
+                [5, 'Pack & label',         'Box, label and stage for dispatch.', 4, 'WS-PK-04'],
+            ]],
+            'HVAC' => ['HVAC cassette — assembly v1', [
+                [1, 'Cassette frame prep',  'Square up the cassette frame and fit the corner brackets.', 6, 'WS-SA-01'],
+                [2, 'Stage 1 media',        'Load the coarse pre-filter stage into the first channel.', 5, 'WS-SA-01'],
+                [3, 'Stage 2 media',        'Load the fine media stage; check the gasket seats on both sides.', 6, 'WS-SA-02'],
+                [4, 'Cassette closing',     'Close the cassette and secure the retaining clips.', 4, 'WS-SA-02'],
+                [5, 'Leak check',           'Pressure-test the cassette seal; log the reading on the batch sheet.', 5, 'WS-SA-02'],
+                [6, 'Pack & label',         'Sleeve, box and label the cassette.', 4, 'WS-PK-04'],
+            ]],
+            // The sub-assembly's own routing — what makes PLEATPACK13 explodable.
+            'PLEATPACK13' => ['Pleat pack HEPA-13 — production v1', [
+                [1, 'Media pleating',       'Feed the media roll and fold to the HEPA-13 pitch. Check pleat height on the first five packs.', 6, 'WS-PA-01'],
+                [2, 'Edge sealing',         'Run a hot-melt bead down both open edges and press until set.', 4, 'WS-AB-01'],
+            ]],
         ];
 
-        foreach ($steps as [$stepNo, $name, $instruction, $duration, $workstation]) {
-            DB::table('template_steps')->updateOrInsert(
-                ['process_template_id' => $template->id, 'step_number' => $stepNo],
-                [
-                    'name' => $name,
-                    'instruction' => $instruction,
-                    'estimated_duration_minutes' => $duration,
-                    'workstation_id' => $workstation?->id,
-                    'created_at' => now(),
-                ]
+        $templates = [];
+
+        foreach ($defs as $productCode => [$name, $steps]) {
+            $productType = $pt[$productCode] ?? null;
+            if (! $productType) {
+                continue;
+            }
+
+            $template = ProcessTemplate::updateOrCreate(
+                ['product_type_id' => $productType->id, 'version' => 1],
+                ['name' => $name, 'is_active' => true]
             );
+
+            foreach ($steps as [$stepNo, $stepName, $instruction, $duration, $wsCode]) {
+                DB::table('template_steps')->updateOrInsert(
+                    ['process_template_id' => $template->id, 'step_number' => $stepNo],
+                    [
+                        'name' => $stepName,
+                        'instruction' => $instruction,
+                        'estimated_duration_minutes' => $duration,
+                        'workstation_id' => $ws[$wsCode]?->id,
+                        'created_at' => now(),
+                    ]
+                );
+            }
+
+            $templates[$productCode] = $template;
         }
 
-        return $template;
+        return $templates;
     }
 
     private function seedUsers(array $lines): array
@@ -493,7 +514,10 @@ class AirFilterDemoSeeder extends Seeder
         return $result;
     }
 
-    private function seedWorkOrders(array $lines, array $pt, ProcessTemplate $hepaTemplate): array
+    /**
+     * @param  array<string, ProcessTemplate>  $templates  keyed by product code
+     */
+    private function seedWorkOrders(array $lines, array $pt, array $templates): array
     {
         $today = now()->copy();
         // We pin due times so a screenshot taken at any clock-hour still sees
@@ -511,7 +535,6 @@ class AirFilterDemoSeeder extends Seeder
                 'priority' => 4,
                 'due_date' => $at(14, 30),
                 'description' => 'Standard HEPA-13, B2B order — Filtex distribution.',
-                'snapshot_template' => $hepaTemplate,
             ],
             [
                 'order_no' => 'WO-186-002',
@@ -586,14 +609,14 @@ class AirFilterDemoSeeder extends Seeder
             if (! empty($def['completed_at'])) {
                 $payload['completed_at'] = $def['completed_at'];
             }
-            if (! empty($def['snapshot_template'])) {
-                $template = $def['snapshot_template'];
-                $payload['process_snapshot'] = [
-                    'template_id' => $template->id,
-                    'template_name' => $template->name,
-                    'template_version' => $template->version,
-                    'snapshotted_at' => now()->toIso8601String(),
-                ];
+            // Snapshot the product's own routing the way the app does — a
+            // hand-rolled header carries no steps and no BOM, which leaves the
+            // operator with nothing to work through and no kit list.
+            $template = $templates[$def['product']] ?? null;
+            if ($template) {
+                $payload['process_snapshot'] = $template
+                    ->fresh(['steps.workstation', 'bomItems.material'])
+                    ->toSnapshot();
             }
 
             $wo = WorkOrder::updateOrCreate(['order_no' => $def['order_no']], $payload);

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use App\Models\Batch;
 use App\Models\BatchStep;
+use App\Models\Issue;
+use App\Models\IssueType;
 use App\Models\Line;
 use App\Models\ProcessTemplate;
 use App\Models\ProductType;
@@ -24,6 +26,7 @@ use Spatie\Permission\Models\Role;
  *  - 7-step HEPA-13 process template
  *  - 6 work orders (WO-186-001..005 due today/tomorrow + WO-185-088 done)
  *  - A running batch on WO-186-001 with steps 1-2 DONE, step 3 IN_PROGRESS
+ *  - Operator-reported issues, one per lifecycle state (open → closed)
  *
  * Run with: `php artisan db:seed --class=AirFilterDemoSeeder`
  *
@@ -41,6 +44,123 @@ class AirFilterDemoSeeder extends Seeder
         $users = $this->seedUsers($lines);
         $workOrders = $this->seedWorkOrders($lines, $productTypes, $template);
         $this->seedActiveBatch($workOrders['WO-186-001'], $template, $users['operator-mk']);
+        $this->seedIssues($workOrders, $users);
+    }
+
+    /**
+     * Issues as the shop floor actually files them: an operator picks a type on
+     * the work order and writes a line about what stopped them. One per status so
+     * the queue, the supervisor board and the history all have something to show.
+     *
+     * Keyed on (work order, title) so a re-run updates in place — the seeder is
+     * upsert-safe like the rest of this file.
+     *
+     * @param  array<string, WorkOrder>  $workOrders
+     * @param  array<string, User>  $users
+     */
+    private function seedIssues(array $workOrders, array $users): void
+    {
+        $types = IssueType::pluck('id', 'code');
+
+        // Without the issue-type reference data there is nothing to attach to;
+        // IssueTypesSeeder owns those rows.
+        if ($types->isEmpty()) {
+            return;
+        }
+
+        $supervisor = $users['supervisor'];
+        $mk = $users['operator-mk'];
+        $an = $users['operator-an'];
+
+        $defs = [
+            // Blocking, still waiting on someone — what the supervisor board is for.
+            [
+                'wo' => 'WO-186-001',
+                'type' => 'MATERIAL_DEFECT',
+                'title' => 'Pleat pack delaminating on infeed',
+                'description' => 'Every third pack from the current pallet separates at the glue line. Set the pallet aside and stopped feeding it.',
+                'status' => Issue::STATUS_OPEN,
+                'reported_by' => $mk,
+                'reported_ago' => 35,
+            ],
+            // Non-blocking question — production keeps running.
+            [
+                'wo' => 'WO-186-002',
+                'type' => 'OPERATOR_ASSISTANCE',
+                'title' => 'Need a second pair of hands for the frame change',
+                'description' => 'Slim frames need two people to load safely. Asking for support before starting the run.',
+                'status' => Issue::STATUS_OPEN,
+                'reported_by' => $an,
+                'reported_ago' => 20,
+            ],
+            // Picked up by the supervisor — this is why WO-186-004 sits paused.
+            [
+                'wo' => 'WO-186-004',
+                'type' => 'TOOL_FAILURE',
+                'title' => 'Carbon press holding pressure only to 4 bar',
+                'description' => 'Press will not reach the 6 bar set point. Line paused until maintenance looks at it.',
+                'status' => Issue::STATUS_ACKNOWLEDGED,
+                'reported_by' => $an,
+                'reported_ago' => 95,
+                'acknowledged_ago' => 70,
+                'assigned_to' => $supervisor,
+            ],
+            // Fixed, kept open one more shift for verification.
+            [
+                'wo' => 'WO-186-001',
+                'type' => 'MEASUREMENT_ERROR',
+                'title' => 'Depth gauge reading 0.4 mm high',
+                'description' => 'Gauge disagreed with the reference block on the first check of the shift.',
+                'status' => Issue::STATUS_RESOLVED,
+                'reported_by' => $mk,
+                'reported_ago' => 300,
+                'acknowledged_ago' => 280,
+                'resolved_ago' => 240,
+                'assigned_to' => $supervisor,
+                'resolution_notes' => 'Gauge re-zeroed against the reference block and re-checked on ten parts.',
+            ],
+            // Closed out on a finished order — the history view needs one.
+            [
+                'wo' => 'WO-185-088',
+                'type' => 'QUALITY_ISSUE',
+                'title' => 'Two filters with visible frame scratches',
+                'description' => 'Scratches on the short edge, most likely from the transport rack.',
+                'status' => Issue::STATUS_CLOSED,
+                'reported_by' => $mk,
+                'reported_ago' => 1_500,
+                'acknowledged_ago' => 1_480,
+                'resolved_ago' => 1_400,
+                'closed_ago' => 1_380,
+                'assigned_to' => $supervisor,
+                'resolution_notes' => 'Both units reworked and passed the visual check. Rack padding replaced.',
+            ],
+        ];
+
+        foreach ($defs as $def) {
+            $workOrder = $workOrders[$def['wo']] ?? null;
+            $typeId = $types[$def['type']] ?? null;
+
+            if (! $workOrder || ! $typeId) {
+                continue;
+            }
+
+            Issue::updateOrCreate(
+                ['work_order_id' => $workOrder->id, 'title' => $def['title']],
+                [
+                    'issue_type_id' => $typeId,
+                    'description' => $def['description'],
+                    'status' => $def['status'],
+                    'source' => Issue::SOURCE_IN_PROCESS,
+                    'reported_by_id' => $def['reported_by']->id,
+                    'assigned_to_id' => isset($def['assigned_to']) ? $def['assigned_to']->id : null,
+                    'reported_at' => now()->subMinutes($def['reported_ago']),
+                    'acknowledged_at' => isset($def['acknowledged_ago']) ? now()->subMinutes($def['acknowledged_ago']) : null,
+                    'resolved_at' => isset($def['resolved_ago']) ? now()->subMinutes($def['resolved_ago']) : null,
+                    'closed_at' => isset($def['closed_ago']) ? now()->subMinutes($def['closed_ago']) : null,
+                    'resolution_notes' => $def['resolution_notes'] ?? null,
+                ]
+            );
+        }
     }
 
     private function seedLines(): array
@@ -336,7 +456,7 @@ class AirFilterDemoSeeder extends Seeder
                 'produced_qty' => 108,
                 'status' => Batch::STATUS_IN_PROGRESS,
                 'started_at' => $startedAt,
-                'lot_number' => 'LOT-2026-' . str_pad((string) $wo->id, 4, '0', STR_PAD_LEFT),
+                'lot_number' => 'LOT-2026-'.str_pad((string) $wo->id, 4, '0', STR_PAD_LEFT),
                 // varchar(10): trigger code, not a timestamp. Values: on_start / on_release.
                 'lot_assigned_at' => 'on_start',
                 'scrap_qty' => 3,

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -4,9 +4,12 @@ namespace Database\Seeders;
 
 use App\Models\Batch;
 use App\Models\BatchStep;
+use App\Models\BomItem;
 use App\Models\Issue;
 use App\Models\IssueType;
 use App\Models\Line;
+use App\Models\Material;
+use App\Models\MaterialType;
 use App\Models\ProcessTemplate;
 use App\Models\ProductType;
 use App\Models\User;
@@ -27,6 +30,9 @@ use Spatie\Permission\Models\Role;
  *  - 6 work orders (WO-186-001..005 due today/tomorrow + WO-185-088 done)
  *  - A running batch on WO-186-001 with steps 1-2 DONE, step 3 IN_PROGRESS
  *  - Operator-reported issues, one per lifecycle state (open → closed)
+ *  - A two-level BOM: the HEPA-13 assembly consumes a manufactured pleat pack
+ *    (sub-assembly) plus purchased parts; the pleat pack has its own routing
+ *    and BOM, so exploding the top level reaches the raw media
  *
  * Run with: `php artisan db:seed --class=AirFilterDemoSeeder`
  *
@@ -42,9 +48,162 @@ class AirFilterDemoSeeder extends Seeder
         $productTypes = $this->seedProductTypes();
         $template = $this->seedHepaProcessTemplate($productTypes['HEPA13_STD'], $workstations);
         $users = $this->seedUsers($lines);
+        $pleatPackTemplate = $this->seedPleatPackTemplate($productTypes['PLEATPACK13'], $workstations);
+        $materials = $this->seedMaterials($pleatPackTemplate);
+        $this->seedBom($template, $pleatPackTemplate, $materials);
         $workOrders = $this->seedWorkOrders($lines, $productTypes, $template);
         $this->seedActiveBatch($workOrders['WO-186-001'], $template, $users['operator-mk']);
         $this->seedIssues($workOrders, $users);
+    }
+
+    /**
+     * The pleat pack's own routing. Its existence is what makes PLEATPACK13 a
+     * sub-assembly rather than a purchased part: a material flagged
+     * `is_manufactured` and pointed at a producing template is what
+     * BomExplosionService follows down a level.
+     *
+     * @param  array<string, Workstation>  $ws
+     */
+    private function seedPleatPackTemplate(ProductType $productType, array $ws): ProcessTemplate
+    {
+        $template = ProcessTemplate::updateOrCreate(
+            ['product_type_id' => $productType->id, 'version' => 1],
+            ['name' => 'Pleat pack HEPA-13 — production v1', 'is_active' => true]
+        );
+
+        $steps = [
+            [1, 'Media pleating', 'Feed the media roll and fold to the HEPA-13 pitch. Check pleat height on the first five packs.', 6, $ws['WS-PA-01'] ?? null],
+            [2, 'Edge sealing', 'Run a hot-melt bead down both open edges and press until set.', 4, $ws['WS-AB-01'] ?? null],
+        ];
+
+        foreach ($steps as [$stepNo, $name, $instruction, $duration, $workstation]) {
+            DB::table('template_steps')->updateOrInsert(
+                ['process_template_id' => $template->id, 'step_number' => $stepNo],
+                [
+                    'name' => $name,
+                    'instruction' => $instruction,
+                    'estimated_duration_minutes' => $duration,
+                    'workstation_id' => $workstation?->id,
+                    'created_at' => now(),
+                ]
+            );
+        }
+
+        return $template;
+    }
+
+    /**
+     * The items the two BOMs consume: purchased parts plus the one manufactured
+     * material (the pleat pack) that links the levels together.
+     *
+     * @return array<string, Material>
+     */
+    private function seedMaterials(ProcessTemplate $pleatPackTemplate): array
+    {
+        // raw_material / semi_finished / packaging / auxiliary. Idempotent, and
+        // the demo must not depend on that seeder having been run separately.
+        $this->call(MaterialTypesSeeder::class);
+
+        $typeIds = MaterialType::pluck('id', 'code');
+
+        $defs = [
+            // Purchased.
+            ['code' => 'MEDIA-H13',   'name' => 'HEPA-13 filter media',      'type' => 'raw_material', 'unit_of_measure' => 'm2',  'stock_quantity' => 4200,  'unit_price' => 6.40,  'supplier_name' => 'Filtrair Media BV'],
+            ['code' => 'FRAME-AL-13', 'name' => 'Aluminium frame profile',   'type' => 'raw_material', 'unit_of_measure' => 'pcs', 'stock_quantity' => 1800,  'unit_price' => 11.20, 'supplier_name' => 'AluFab Sp. z o.o.'],
+            ['code' => 'GASKET-PU-13', 'name' => 'PU gasket seal',           'type' => 'raw_material', 'unit_of_measure' => 'm',   'stock_quantity' => 2600,  'unit_price' => 1.85,  'supplier_name' => 'SealTech GmbH'],
+            ['code' => 'ADH-2K-A',    'name' => 'Two-part adhesive (A)',     'type' => 'auxiliary',    'unit_of_measure' => 'kg',  'stock_quantity' => 180,   'unit_price' => 24.50, 'supplier_name' => 'ChemBond'],
+            ['code' => 'HOTMELT-01',  'name' => 'Hot-melt edge sealant',     'type' => 'auxiliary',    'unit_of_measure' => 'kg',  'stock_quantity' => 95,    'unit_price' => 18.90, 'supplier_name' => 'ChemBond'],
+            ['code' => 'CARTON-10',   'name' => 'Carton, 10 filters',        'type' => 'packaging',    'unit_of_measure' => 'pcs', 'stock_quantity' => 640,   'unit_price' => 3.10,  'supplier_name' => 'PackLine'],
+        ];
+
+        $materials = [];
+        foreach ($defs as $def) {
+            $materials[$def['code']] = Material::updateOrCreate(
+                ['code' => $def['code']],
+                [
+                    'name' => $def['name'],
+                    'material_type_id' => $typeIds[$def['type']] ?? null,
+                    'unit_of_measure' => $def['unit_of_measure'],
+                    'tracking_type' => 'batch',
+                    'is_manufactured' => false,
+                    'stock_quantity' => $def['stock_quantity'],
+                    'unit_price' => $def['unit_price'],
+                    'supplier_name' => $def['supplier_name'],
+                ]
+            );
+        }
+
+        // The sub-assembly. `is_manufactured` + the producing template is what
+        // lets a BOM line for it be exploded into the level below.
+        $materials['PLEATPACK13'] = Material::updateOrCreate(
+            ['code' => 'PLEATPACK13'],
+            [
+                'name' => 'Pleat pack HEPA-13',
+                'material_type_id' => $typeIds['semi_finished'] ?? null,
+                'unit_of_measure' => 'pcs',
+                'tracking_type' => 'batch',
+                'is_manufactured' => true,
+                'producing_process_template_id' => $pleatPackTemplate->id,
+                'stock_quantity' => 260,
+            ]
+        );
+
+        return $materials;
+    }
+
+    /**
+     * Two BOM levels: the HEPA-13 assembly consumes the pleat pack plus the
+     * purchased parts, and the pleat pack's own template consumes media and
+     * sealant. Exploding the top level therefore reaches the raw media.
+     *
+     * Lines are pinned to the step that actually consumes them, so the operator's
+     * kit list matches the routing.
+     *
+     * @param  array<string, Material>  $materials
+     */
+    private function seedBom(ProcessTemplate $assembly, ProcessTemplate $pleatPack, array $materials): void
+    {
+        $defs = [
+            // HEPA-13 assembly.
+            [$assembly, 2, 'FRAME-AL-13',  1,    0,   'start'],
+            [$assembly, 3, 'PLEATPACK13',  1,    2,   'start'],
+            [$assembly, 4, 'GASKET-PU-13', 1.6,  3,   'during'],
+            [$assembly, 4, 'ADH-2K-A',     0.08, 5,   'during'],
+            // 10 filters to a carton.
+            [$assembly, 6, 'CARTON-10',    0.1,  0,   'end'],
+
+            // Pleat pack — the level below.
+            [$pleatPack, 1, 'MEDIA-H13',   2.4,  5,   'start'],
+            [$pleatPack, 2, 'HOTMELT-01',  0.03, 2,   'during'],
+        ];
+
+        $sortOrder = [];
+
+        foreach ($defs as [$template, $stepNumber, $code, $qty, $scrap, $consumedAt]) {
+            $material = $materials[$code] ?? null;
+            if (! $material) {
+                continue;
+            }
+
+            $stepId = DB::table('template_steps')
+                ->where('process_template_id', $template->id)
+                ->where('step_number', $stepNumber)
+                ->value('id');
+
+            $key = $template->id;
+            $sortOrder[$key] = ($sortOrder[$key] ?? 0) + 1;
+
+            BomItem::updateOrCreate(
+                ['process_template_id' => $template->id, 'material_id' => $material->id],
+                [
+                    'template_step_id' => $stepId,
+                    'quantity_per_unit' => $qty,
+                    'scrap_percentage' => $scrap,
+                    'consumed_at' => $consumedAt,
+                    'sort_order' => $sortOrder[$key],
+                ]
+            );
+        }
     }
 
     /**
@@ -228,6 +387,10 @@ class AirFilterDemoSeeder extends Seeder
             ['code' => 'PREFILTER',   'name' => 'Pre-filter G4',     'description' => 'Coarse pre-filter (G4 grade), upstream of HEPA',         'unit_of_measure' => 'pcs'],
             ['code' => 'CARBON',      'name' => 'Carbon X2',         'description' => 'Activated-carbon odour and VOC filter',                  'unit_of_measure' => 'pcs'],
             ['code' => 'HVAC',        'name' => 'HVAC cassette',     'description' => 'HVAC cassette filter, multi-stage media stack',          'unit_of_measure' => 'pcs'],
+            // Semi-finished: produced on its own template, then consumed by the
+            // HEPA-13 assembly. It needs a product type because that is what a
+            // process template is written against.
+            ['code' => 'PLEATPACK13', 'name' => 'Pleat pack HEPA-13', 'description' => 'Folded and edge-sealed HEPA-13 media pack, ready to frame', 'unit_of_measure' => 'pcs'],
         ];
 
         $result = [];

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -32,7 +32,8 @@ use Spatie\Permission\Models\Role;
  *  - Lines L-01 .. L-04
  *  - Product types HEPA-13 Std/Slim, Pre-filter G4, Carbon X2, HVAC cassette
  *  - 7-step HEPA-13 process template
- *  - 6 work orders (WO-186-001..005 due today/tomorrow + WO-185-088 done)
+ *  - 16 work orders: WO-186-001..005 due today, WO-185-088 done, and a
+ *    fortnight of scheduled work ahead so the planner's horizon is not empty
  *  - A running batch on WO-186-001 with steps 1-2 DONE, step 3 IN_PROGRESS
  *  - Operator-reported issues, one per lifecycle state (open → closed)
  *  - A two-level BOM: the HEPA-13 assembly consumes a manufactured pleat pack
@@ -173,6 +174,24 @@ class AirFilterDemoSeeder extends Seeder
                 'type' => MaintenanceEvent::TYPE_INSPECTION, 'status' => MaintenanceEvent::STATUS_PENDING,
                 'startsInHours' => 72, 'durationMinutes' => 120,
                 'description' => 'Torque and leak-test rig calibration on the cassette bench.'],
+            // The rest of the fortnight, so the planner's horizon keeps showing
+            // maintenance alongside the scheduled orders rather than only this week.
+            ['title' => 'Housing mould clean-down', 'line' => 'L-02', 'ws' => null, 'tool' => 'TL-MOULD-G4',
+                'type' => MaintenanceEvent::TYPE_PLANNED, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 24 * 5 + 6, 'durationMinutes' => 150,
+                'description' => 'Full clean-down and vent inspection on the G4 housing mould.'],
+            ['title' => 'Pleat table pitch calibration', 'line' => 'L-01', 'ws' => 'WS-PA-01', 'tool' => null,
+                'type' => MaintenanceEvent::TYPE_INSPECTION, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 24 * 8 + 6, 'durationMinutes' => 90,
+                'description' => 'Verify pleat pitch against the reference gauge after the media change.'],
+            ['title' => 'Adhesive nozzle replacement', 'line' => 'L-01', 'ws' => 'WS-AB-01', 'tool' => 'TL-NOZZLE-01',
+                'type' => MaintenanceEvent::TYPE_PLANNED, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 24 * 11 + 6, 'durationMinutes' => 120,
+                'description' => 'Scheduled nozzle set replacement in the bonding booth.'],
+            ['title' => 'Frame press die inspection', 'line' => 'L-01', 'ws' => 'WS-FR-01', 'tool' => 'TL-DIE-01',
+                'type' => MaintenanceEvent::TYPE_INSPECTION, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 24 * 13 + 6, 'durationMinutes' => 180,
+                'description' => 'Wear check on the progressive die; measure the first-off frame.'],
         ];
 
         foreach ($eventDefs as $def) {
@@ -862,6 +881,36 @@ class AirFilterDemoSeeder extends Seeder
                 'completed_at' => $today->copy()->subHours(20),
             ],
         ];
+
+        // A fortnight of scheduled work ahead of today. Without it the planner's
+        // horizon empties out after tomorrow and the board looks abandoned two
+        // days in — the orders above only cover today.
+        $horizon = [
+            [2,  'WO-186-006', 'L-01', 'HEPA13_STD',  200, 3, 'Filtex — stock replenishment.'],
+            [3,  'WO-186-007', 'L-02', 'CARBON',      150, 2, 'Carbon X2 for the Q4 stock build.'],
+            [4,  'WO-186-008', 'L-03', 'HVAC',        80,  4, 'HVAC cassettes — Nordwind contract.'],
+            [5,  'WO-186-009', 'L-01', 'HEPA13_SLIM', 140, 2, 'Slim retrofit, second batch.'],
+            [6,  'WO-186-010', 'L-02', 'PREFILTER',   500, 1, 'G4 pre-filters — bulk stock.'],
+            [8,  'WO-186-011', 'L-01', 'HEPA13_STD',  260, 4, 'Standard HEPA-13 — export pallet.'],
+            [9,  'WO-186-012', 'L-03', 'HVAC',        60,  3, 'HVAC cassette top-up.'],
+            [10, 'WO-186-013', 'L-02', 'CARBON',      180, 2, 'Carbon X2 — service parts.'],
+            [11, 'WO-186-014', 'L-01', 'HEPA13_SLIM', 110, 3, 'Slim filters, retrofit phase 2.'],
+            [13, 'WO-186-015', 'L-01', 'HEPA13_STD',  300, 5, 'Standard HEPA-13 — Filtex quarterly.'],
+        ];
+
+        foreach ($horizon as [$inDays, $orderNo, $line, $product, $qty, $priority, $description]) {
+            $defs[] = [
+                'order_no' => $orderNo,
+                'line' => $line,
+                'product' => $product,
+                'planned_qty' => $qty,
+                'produced_qty' => 0,
+                'status' => WorkOrder::STATUS_PENDING,
+                'priority' => $priority,
+                'due_date' => $today->copy()->addDays($inDays)->setTime(14, 0),
+                'description' => $description,
+            ];
+        }
 
         $result = [];
         foreach ($defs as $def) {

--- a/backend/database/seeders/AirFilterDemoSeeder.php
+++ b/backend/database/seeders/AirFilterDemoSeeder.php
@@ -8,11 +8,15 @@ use App\Models\BomItem;
 use App\Models\Issue;
 use App\Models\IssueType;
 use App\Models\Line;
+use App\Models\MaintenanceEvent;
+use App\Models\MaintenanceSchedule;
 use App\Models\Material;
 use App\Models\MaterialLot;
 use App\Models\MaterialType;
 use App\Models\ProcessTemplate;
 use App\Models\ProductType;
+use App\Models\Shift;
+use App\Models\Tool;
 use App\Models\User;
 use App\Models\WorkOrder;
 use App\Models\Workstation;
@@ -54,9 +58,145 @@ class AirFilterDemoSeeder extends Seeder
         $materials = $this->seedMaterials($templates['PLEATPACK13']);
         $this->seedBom($templates, $materials);
         $this->seedMaterialLots($materials);
+        $this->seedShifts();
         $workOrders = $this->seedWorkOrders($lines, $productTypes, $templates);
         $this->seedActiveBatch($workOrders['WO-186-001'], $templates['HEPA13_STD'], $users['operator-mk']);
         $this->seedIssues($workOrders, $users);
+        $this->seedMaintenance($lines, $workstations, $users);
+    }
+
+    /**
+     * Round-the-clock shift cover. The planner lays orders out against shifts and
+     * the shift monitor fills whichever one is running, so without these both
+     * fall back to a synthetic window — and the monitor looks dead outside it.
+     */
+    private function seedShifts(): void
+    {
+        $defs = [
+            ['code' => 'A', 'name' => 'Morning',   'start_time' => '06:00', 'end_time' => '14:00', 'sort_order' => 1],
+            ['code' => 'B', 'name' => 'Afternoon', 'start_time' => '14:00', 'end_time' => '22:00', 'sort_order' => 2],
+            ['code' => 'C', 'name' => 'Night',     'start_time' => '22:00', 'end_time' => '06:00', 'sort_order' => 3],
+        ];
+
+        foreach ($defs as $def) {
+            Shift::updateOrCreate(
+                ['code' => $def['code']],
+                array_merge($def, [
+                    // Every day, so a demo opened at the weekend still has a
+                    // shift in progress.
+                    'days_of_week' => [1, 2, 3, 4, 5, 6, 7],
+                    'line_id' => null,
+                    'is_active' => true,
+                ])
+            );
+        }
+    }
+
+    /**
+     * Maintenance the planner can show: tools, the recurring schedules its "Add
+     * maintenance" modal offers, and real events in the current week so the
+     * board has tiles on it rather than only orders.
+     *
+     * The corrective one is the counterpart to the acknowledged carbon-press
+     * issue — the same fault, seen from the maintenance side.
+     *
+     * @param  array<string, Line>  $lines
+     * @param  array<string, Workstation>  $ws
+     * @param  array<string, User>  $users
+     */
+    private function seedMaintenance(array $lines, array $ws, array $users): void
+    {
+        $tools = [];
+        $toolDefs = [
+            ['code' => 'TL-DIE-01',    'name' => 'Frame stamping die',   'description' => 'Progressive die for the HEPA-13 aluminium frame.'],
+            ['code' => 'TL-NOZZLE-01', 'name' => 'Adhesive nozzle set',  'description' => 'Two-part adhesive applicator nozzles, bonding booth.'],
+            ['code' => 'TL-MOULD-G4',  'name' => 'Housing mould G4',     'description' => 'Injection mould for the G4 pre-filter housing.'],
+        ];
+
+        foreach ($toolDefs as $def) {
+            $tools[$def['code']] = Tool::updateOrCreate(
+                ['code' => $def['code']],
+                array_merge($def, ['status' => 'available', 'next_service_at' => now()->addDays(21)->toDateString()])
+            );
+        }
+
+        $supervisor = $users['supervisor'];
+
+        $scheduleDefs = [
+            ['name' => 'Weekly press lubrication',   'line' => 'L-01', 'ws' => 'WS-FR-01', 'tool' => 'TL-DIE-01',    'type' => MaintenanceEvent::TYPE_PLANNED,    'frequency' => 'weekly',    'interval' => 1, 'dueInDays' => 3],
+            ['name' => 'Monthly extraction service', 'line' => 'L-01', 'ws' => 'WS-AB-01', 'tool' => 'TL-NOZZLE-01', 'type' => MaintenanceEvent::TYPE_INSPECTION, 'frequency' => 'monthly',   'interval' => 1, 'dueInDays' => 12],
+            ['name' => 'Quarterly mould service',    'line' => 'L-02', 'ws' => null,       'tool' => 'TL-MOULD-G4',  'type' => MaintenanceEvent::TYPE_PLANNED,    'frequency' => 'quarterly', 'interval' => 1, 'dueInDays' => 30],
+        ];
+
+        foreach ($scheduleDefs as $def) {
+            MaintenanceSchedule::updateOrCreate(
+                ['name' => $def['name']],
+                [
+                    'line_id' => $lines[$def['line']]->id,
+                    'workstation_id' => $def['ws'] ? $ws[$def['ws']]->id : null,
+                    'tool_id' => $tools[$def['tool']]->id,
+                    'event_type' => $def['type'],
+                    'assigned_to_id' => $supervisor->id,
+                    'frequency' => $def['frequency'],
+                    'interval_value' => $def['interval'],
+                    'preferred_time' => '06:00',
+                    'lead_time_days' => 2,
+                    'next_due_at' => now()->addDays($def['dueInDays'])->setTime(6, 0),
+                    'is_active' => true,
+                ]
+            );
+        }
+
+        $eventDefs = [
+            // Already done — yesterday's planned job, so the board shows history.
+            ['title' => 'Pleat table belt change', 'line' => 'L-01', 'ws' => 'WS-PA-01', 'tool' => null,
+                'type' => MaintenanceEvent::TYPE_PLANNED, 'status' => MaintenanceEvent::STATUS_COMPLETED,
+                'startsInHours' => -26, 'durationMinutes' => 90,
+                'description' => 'Drive belt replaced on the pleat table and re-tensioned.'],
+            // Running right now — the maintenance side of the carbon press issue.
+            ['title' => 'Carbon press pressure fault', 'line' => 'L-02', 'ws' => null, 'tool' => 'TL-MOULD-G4',
+                'type' => MaintenanceEvent::TYPE_CORRECTIVE, 'status' => MaintenanceEvent::STATUS_IN_PROGRESS,
+                'startsInHours' => -1, 'durationMinutes' => 180,
+                'description' => 'Press will not hold 6 bar. Stripping the regulator — line paused.'],
+            // Later today.
+            ['title' => 'Bonding booth extraction check', 'line' => 'L-01', 'ws' => 'WS-AB-01', 'tool' => 'TL-NOZZLE-01',
+                'type' => MaintenanceEvent::TYPE_INSPECTION, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 6, 'durationMinutes' => 60,
+                'description' => 'Airflow and filter check on the bonding booth extraction.'],
+            // Tomorrow morning.
+            ['title' => 'Frame press weekly lubrication', 'line' => 'L-01', 'ws' => 'WS-FR-01', 'tool' => 'TL-DIE-01',
+                'type' => MaintenanceEvent::TYPE_PLANNED, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 22, 'durationMinutes' => 90,
+                'description' => 'Weekly lubrication and die inspection on the frame press.'],
+            // Later in the week, on the sub-assembly line.
+            ['title' => 'Cassette bench calibration', 'line' => 'L-03', 'ws' => 'WS-SA-01', 'tool' => null,
+                'type' => MaintenanceEvent::TYPE_INSPECTION, 'status' => MaintenanceEvent::STATUS_PENDING,
+                'startsInHours' => 72, 'durationMinutes' => 120,
+                'description' => 'Torque and leak-test rig calibration on the cassette bench.'],
+        ];
+
+        foreach ($eventDefs as $def) {
+            $start = now()->addHours($def['startsInHours'])->setSecond(0);
+            $completed = $def['status'] === MaintenanceEvent::STATUS_COMPLETED;
+            $running = $def['status'] === MaintenanceEvent::STATUS_IN_PROGRESS;
+
+            MaintenanceEvent::updateOrCreate(
+                ['title' => $def['title']],
+                [
+                    'event_type' => $def['type'],
+                    'status' => $def['status'],
+                    'line_id' => $lines[$def['line']]->id,
+                    'workstation_id' => $def['ws'] ? $ws[$def['ws']]->id : null,
+                    'tool_id' => $def['tool'] ? $tools[$def['tool']]->id : null,
+                    'assigned_to_id' => $supervisor->id,
+                    'scheduled_at' => $start,
+                    'scheduled_end_at' => $start->copy()->addMinutes($def['durationMinutes']),
+                    'started_at' => ($completed || $running) ? $start : null,
+                    'completed_at' => $completed ? $start->copy()->addMinutes($def['durationMinutes']) : null,
+                    'description' => $def['description'],
+                ]
+            );
+        }
     }
 
     /**

--- a/backend/database/seeders/DemoDataSeeder.php
+++ b/backend/database/seeders/DemoDataSeeder.php
@@ -5,15 +5,19 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 
 /**
- * Umbrella seeder for the demo / screenshot dataset. Runs the three
- * focused seeders in dependency order so a single command populates
- * everything the mobile UI expects.
+ * Umbrella seeder for the demo / screenshot dataset. Runs the focused
+ * seeders in dependency order so a single command populates everything
+ * the mobile UI expects.
  *
  *   php artisan db:seed --class=DemoDataSeeder
  *
  * Idempotent — each child seeder upserts on stable keys, so re-running
  * is safe. NOT wired into the main DatabaseSeeder (production deploys
  * should never see this data); run it manually after install.
+ *
+ * The shift monitor runs last: it fills whichever shift is in progress
+ * right now, so it needs the lines, stations and shifts the others
+ * create. Re-run it alone whenever the demo needs a fresh live shift.
  */
 class DemoDataSeeder extends Seeder
 {
@@ -23,6 +27,7 @@ class DemoDataSeeder extends Seeder
             AirFilterDemoSeeder::class,
             HrDemoSeeder::class,
             OeeAndDowntimeDemoSeeder::class,
+            ShiftMonitorDemoSeeder::class,
         ]);
     }
 }

--- a/backend/database/seeders/ShiftMonitorDemoSeeder.php
+++ b/backend/database/seeders/ShiftMonitorDemoSeeder.php
@@ -30,6 +30,16 @@ class ShiftMonitorDemoSeeder extends Seeder
     private const BATCH_NUMBER_BASE = 9000;
 
     /**
+     * How much shift history to lay down behind the live one, so paging back
+     * through the monitor keeps finding shifts instead of empty days.
+     *
+     * Only backwards: the monitor draws what the machines actually did, and
+     * there are no actuals for a shift that has not run yet. The forward two
+     * weeks are the planner's job — orders and maintenance, not counters.
+     */
+    private const DAYS_BACK = 14;
+
+    /**
      * Stations to bring to life, with their nameplate rate in pcs/hour. Covers
      * both demo datasets — whichever one is installed; a station that does not
      * exist is skipped with a warning.
@@ -68,29 +78,92 @@ class ShiftMonitorDemoSeeder extends Seeder
 
     private function seedStation(Workstation $workstation, int $ratePerHour): void
     {
-        $window = $this->window($workstation);
+        // One station-wide reset before the loop: the per-window cleanup below
+        // cannot see batches, which are scoped by the seeder's number range.
+        Batch::where('workstation_id', $workstation->id)
+            ->where('batch_number', '>=', self::BATCH_NUMBER_BASE)
+            ->forceDelete();
+
+        $windows = $this->windows($workstation);
         $now = Carbon::now();
-        $elapsed = (int) min(
-            $window->durationMinutes(),
-            max(1, floor($window->start->diffInMinutes($now)))
-        );
+        $stops = 0;
+        $unclassified = 0;
 
-        $this->clear($workstation, $window);
+        // Oldest first when writing. clear() wipes everything at or after the
+        // window it is given, so working newest-first would have each older
+        // shift delete the history already laid down above it. array_reverse
+        // keeps the keys, so index 0 stays the live shift.
+        foreach (array_reverse($windows, true) as $index => $window) {
+            // A finished shift is filled end to end; the one in progress stops
+            // at the current minute so its last slice stays open.
+            $isLive = $window->contains($now);
+            $elapsed = (int) min(
+                $window->durationMinutes(),
+                max(1, floor($window->start->diffInMinutes($now)))
+            );
 
-        $plan = $this->plan($elapsed, $workstation->id);
+            $this->clear($workstation, $window);
 
-        $this->writeStates($workstation, $window, $plan, $elapsed);
-        $this->seedBatches($workstation, $window, $elapsed, $ratePerHour);
-        $this->writeCounters($workstation, $window, $plan, $elapsed, $ratePerHour);
+            // Vary the story per shift, or every day would be a carbon copy.
+            $plan = $this->plan($elapsed, $workstation->id + $index * 101);
+
+            $this->writeStates($workstation, $window, $plan, $elapsed, $isLive);
+            $this->seedBatches($workstation, $window, $elapsed, $ratePerHour, $index);
+            $this->writeCounters($workstation, $window, $plan, $elapsed, $ratePerHour);
+
+            $stops += count(array_filter($plan, fn ($s) => $s['kind'] === 'down'));
+            $unclassified += count(array_filter($plan, fn ($s) => ($s['unclassified'] ?? false)));
+        }
 
         $this->command?->info(sprintf(
-            '%s — %d min of shift %s seeded (%d stops, %d unclassified).',
+            '%s — %d shift(s) seeded back to %s (%d stops, %d unclassified).',
             $workstation->code,
-            $elapsed,
-            $window->shift?->code ?? '—',
-            count(array_filter($plan, fn ($s) => $s['kind'] === 'down')),
-            count(array_filter($plan, fn ($s) => ($s['unclassified'] ?? false))),
+            count($windows),
+            $windows ? end($windows)->start->format('D d.m') : '—',
+            $stops,
+            $unclassified,
         ));
+    }
+
+    /**
+     * The shifts to fill: the one running now, then backwards through
+     * DAYS_BACK. Newest first, so the live shift keeps index 0 and its
+     * generated story stays stable as history grows behind it.
+     *
+     * @return list<ShiftWindow>
+     */
+    private function windows(Workstation $workstation): array
+    {
+        $now = Carbon::now();
+        $shifts = Shift::where('is_active', true)->orderBy('start_time')->get();
+
+        // No shifts defined — fall back to the single synthetic window, which is
+        // what the monitor itself falls back to.
+        if ($shifts->isEmpty()) {
+            return [$this->window($workstation)];
+        }
+
+        $windows = [];
+
+        for ($day = 0; $day <= self::DAYS_BACK; $day++) {
+            $date = $now->copy()->subDays($day)->startOfDay();
+
+            foreach ($shifts as $shift) {
+                $window = ShiftWindow::startingOn($shift, $date);
+
+                // Not started yet — nothing to record.
+                if ($window->start > $now) {
+                    continue;
+                }
+
+                $windows[] = $window;
+            }
+        }
+
+        // Newest first.
+        usort($windows, fn ($a, $b) => $b->start <=> $a->start);
+
+        return $windows;
     }
 
     /** The shift occurrence to fill: whichever one the station's line is running. */
@@ -203,8 +276,13 @@ class ShiftMonitorDemoSeeder extends Seeder
     /**
      * @param  array<int, array<string, mixed>>  $plan
      */
-    private function writeStates(Workstation $workstation, ShiftWindow $window, array $plan, int $elapsed): void
-    {
+    private function writeStates(
+        Workstation $workstation,
+        ShiftWindow $window,
+        array $plan,
+        int $elapsed,
+        bool $isLive = true,
+    ): void {
         $reasons = DowntimeReason::pluck('id', 'code');
 
         foreach ($plan as $segment) {
@@ -216,7 +294,10 @@ class ShiftMonitorDemoSeeder extends Seeder
             };
 
             $from = $window->start->copy()->addMinutes($segment['from']);
-            $isOpen = $segment['to'] >= $elapsed;
+            // Only the shift actually in progress ends on an open slice. A
+            // finished shift left one open would read as a machine still in that
+            // state days later — and the next shift's cleanup would delete it.
+            $isOpen = $isLive && $segment['to'] >= $elapsed;
             $to = $isOpen ? null : $window->start->copy()->addMinutes($segment['to']);
 
             WorkstationState::create([
@@ -285,15 +366,13 @@ class ShiftMonitorDemoSeeder extends Seeder
      * behind it and one still running. Attached to real work orders on the
      * station's line so the panel links back to something that exists.
      */
-    private function seedBatches(Workstation $workstation, ShiftWindow $window, int $elapsed, int $ratePerHour): void
-    {
-        // Scoped by the seeder's own number range rather than by the window: a
-        // later run lands on a different shift, and window-scoped cleanup would
-        // leave the previous run's rows behind to collide on (order, number).
-        Batch::where('workstation_id', $workstation->id)
-            ->where('batch_number', '>=', self::BATCH_NUMBER_BASE)
-            ->forceDelete();
-
+    private function seedBatches(
+        Workstation $workstation,
+        ShiftWindow $window,
+        int $elapsed,
+        int $ratePerHour,
+        int $windowIndex = 0,
+    ): void {
         $workOrders = WorkOrder::where('line_id', $workstation->line_id)
             ->orderBy('id')
             ->limit(4)
@@ -303,11 +382,12 @@ class ShiftMonitorDemoSeeder extends Seeder
             return;
         }
 
-        mt_srand($workstation->id + 4231);
+        mt_srand($workstation->id + 4231 + $windowIndex * 101);
 
         // Split the elapsed shift into four stretches; the last one is open.
         $slice = max(30, intdiv($elapsed, 4));
         $lotDate = $window->start->format('y-md');
+        $shiftMark = $window->shift?->code ?? 'X';
 
         foreach ($workOrders->values() as $i => $workOrder) {
             $from = $window->start->copy()->addMinutes($i * $slice);
@@ -321,10 +401,11 @@ class ShiftMonitorDemoSeeder extends Seeder
             Batch::create([
                 'work_order_id' => $workOrder->id,
                 'workstation_id' => $workstation->id,
-                // Stations on the same line draw from the same work orders, so
-                // the number has to be unique per station, not just per index.
-                'batch_number' => self::BATCH_NUMBER_BASE + $workstation->id * 10 + $i,
-                'lot_number' => sprintf('LOT %s-%s%s', $lotDate, $workstation->id, chr(65 + $i)),
+                // Stations on the same line draw from the same work orders, and
+                // every shift in the history reuses them again, so the number
+                // has to be unique per station AND per shift — not just index.
+                'batch_number' => self::BATCH_NUMBER_BASE + $workstation->id * 1000 + $windowIndex * 10 + $i,
+                'lot_number' => sprintf('LOT %s-%s%s%s', $lotDate, $shiftMark, $workstation->id, chr(65 + $i)),
                 'target_qty' => $target,
                 'produced_qty' => $produced,
                 'scrap_qty' => (int) round($produced * mt_rand(1, 3) / 100),
@@ -354,7 +435,13 @@ class ShiftMonitorDemoSeeder extends Seeder
 
         $perMinute = $ratePerHour / 60;
         $rows = [];
-        $batchId = Batch::where('workstation_id', $workstation->id)->value('id');
+        // The batch this shift's pulses belong to. Scoped to the window: with
+        // history behind it the station has a batch per shift, and an unscoped
+        // lookup would pin every day's counters to the oldest one.
+        $batchId = Batch::where('workstation_id', $workstation->id)
+            ->where('started_at', '>=', $window->start)
+            ->orderBy('started_at')
+            ->value('id');
         $slowFor = 0;
 
         foreach ($plan as $segment) {

--- a/backend/database/seeders/ShiftMonitorDemoSeeder.php
+++ b/backend/database/seeders/ShiftMonitorDemoSeeder.php
@@ -29,12 +29,22 @@ class ShiftMonitorDemoSeeder extends Seeder
     /** Batch numbers at or above this belong to the seeder and are its to reset. */
     private const BATCH_NUMBER_BASE = 9000;
 
-    /** Stations to bring to life, with their nameplate rate in pcs/hour. */
+    /**
+     * Stations to bring to life, with their nameplate rate in pcs/hour. Covers
+     * both demo datasets — whichever one is installed; a station that does not
+     * exist is skipped with a warning.
+     */
     private const STATIONS = [
+        // Print shop (PrintShopDemoSeeder).
         'DTG-1' => 1200,
         'DTG-2' => 1200,
         'SITO-1' => 900,
         'HAFT-1' => 600,
+        // Air filter line (AirFilterDemoSeeder).
+        'WS-FR-01' => 120,
+        'WS-PA-01' => 80,
+        'WS-AB-01' => 75,
+        'WS-PK-01' => 200,
     ];
 
     public function run(): void

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -5966,5 +5966,12 @@
     "Rejected cells in the preview: :n. Hover a marked cell for the reason.": "Rejected cells in the preview: :n. Hover a marked cell for the reason.",
     "Rows": "Rows",
     ":shown of :total rows": ":shown of :total rows",
-    ":n columns": ":n columns"
+    ":n columns": ":n columns",
+    "Not enough material": "Not enough material",
+    "not in stock list": "not in stock list",
+    "MAT": "MAT",
+    "Not enough material to complete this order": "Not enough material to complete this order",
+    "need": "need",
+    "have": "have",
+    "missing": "missing"
 }

--- a/backend/lang/pl.json
+++ b/backend/lang/pl.json
@@ -5966,5 +5966,12 @@
     "Rejected cells in the preview: :n. Hover a marked cell for the reason.": "Odrzucone komórki w podglądzie: :n. Najedź na oznaczoną komórkę, aby poznać powód.",
     "Rows": "Wiersze",
     ":shown of :total rows": ":shown z :total wierszy",
-    ":n columns": ":n kolumn"
+    ":n columns": ":n kolumn",
+    "Not enough material": "Za mało materiału",
+    "not in stock list": "brak w kartotece materiałów",
+    "MAT": "MAT",
+    "Not enough material to complete this order": "Za mało materiału, aby wykonać to zlecenie",
+    "need": "potrzeba",
+    "have": "jest",
+    "missing": "brakuje"
 }

--- a/backend/resources/js/Pages/admin/schedule/planner/OrderCard.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/OrderCard.jsx
@@ -62,6 +62,42 @@ export function LoadBar({ pct, color, w = 90 }) {
     );
 }
 
+// The order cannot be built from stock as it stands. Scheduling around it is
+// the planner's decision, so this informs rather than blocks — but the missing
+// components are named, including subassemblies, which is the case that used to
+// be invisible until an operator tried to start.
+function shortageTitle(wo) {
+    const missing = wo.material_shortages || [];
+    if (!missing.length) return '';
+    const parts = missing.map((m) => {
+        const code = m.material_code || m.material_name || '?';
+        if (!m.material_exists) return `${code} — ${__('not in stock list')}`;
+        return `${code} −${fmtQty(m.missing_qty)} ${m.unit_of_measure || ''}`.trim();
+    });
+    return `${__('Not enough material')}: ${parts.join(', ')}`;
+}
+
+export function ShortageChip({ wo, compact = false }) {
+    if (!wo.has_material_shortage) return null;
+    const title = shortageTitle(wo);
+
+    if (compact) {
+        return (
+            <span title={title} aria-label={title}
+                style={{ fontFamily: MONO, fontSize: 8, color: '#fff', background: 'var(--om-warn, #b45309)', borderRadius: 3, padding: '0 3px' }}>
+                {__('MAT')}
+            </span>
+        );
+    }
+
+    return (
+        <div title={title} className="truncate mt-0.5"
+            style={{ fontFamily: MONO, fontSize: 9, color: 'var(--om-warn, #b45309)' }}>
+            ⚠ {__('Not enough material')}
+        </div>
+    );
+}
+
 // ── OrderCard ─────────────────────────────────────────────────────────────────
 // variant: 'cell' (weekly) | 'day' (daily) | 'backlog' | 'overlay'
 export function OrderCard({ wo, variant = 'cell', selected = false, conflict = false, twinMeta = null, onClick, onUnassign, unassignTitle, dragProps = {} }) {
@@ -102,6 +138,7 @@ export function OrderCard({ wo, variant = 'cell', selected = false, conflict = f
                         </>
                     )}
                 </div>
+                <ShortageChip wo={wo} />
             </div>
         );
     }
@@ -119,6 +156,7 @@ export function OrderCard({ wo, variant = 'cell', selected = false, conflict = f
                 </div>
                 <div className="truncate" style={{ fontSize: 11, color: 'var(--om-muted)' }}>{wo.product_name || '—'}</div>
                 <div className="mt-0.5" style={{ fontFamily: MONO, fontSize: 9, color: 'var(--om-faint)' }}>{fmtQty(wo.planned_qty)} {__('pcs')} · {statusLabel(wo.status)}</div>
+                <ShortageChip wo={wo} />
             </div>
         );
     }
@@ -130,7 +168,10 @@ export function OrderCard({ wo, variant = 'cell', selected = false, conflict = f
             {onUnassign && <UnassignX onUnassign={onUnassign} wo={wo} />}
             <div className="flex items-center gap-1.5">
                 <span className="whitespace-nowrap" style={{ fontFamily: MONO, fontSize: 10, fontWeight: 600, color: 'var(--om-ink)' }}>{wo.order_no}</span>
-                {overdue && <span className="ml-auto" style={{ fontFamily: MONO, fontSize: 8, color: '#fff', background: 'var(--om-blocked)', borderRadius: 3, padding: '0 3px' }}>!</span>}
+                <span className="ml-auto flex items-center gap-1">
+                    <ShortageChip wo={wo} compact />
+                    {overdue && <span style={{ fontFamily: MONO, fontSize: 8, color: '#fff', background: 'var(--om-blocked)', borderRadius: 3, padding: '0 3px' }}>!</span>}
+                </span>
             </div>
             <div className="truncate" style={{ fontSize: 10, color: 'var(--om-muted)', marginTop: 2 }}>{wo.product_name || '—'} · {fmtQty(wo.planned_qty)}</div>
         </div>

--- a/backend/resources/js/Pages/admin/schedule/planner/views.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/views.jsx
@@ -5,7 +5,7 @@
 import { useState, useRef, useEffect, memo } from 'react';
 import Tooltip from '../../../../components/Tooltip';
 import { __, formatDate } from '../../../../lib/i18n';
-import { OrderCard, TwinChip, TierDot } from './OrderCard';
+import { OrderCard, TwinChip, TierDot, ShortageChip } from './OrderCard';
 import { DraggableOrder, useOrderDrop } from './dnd';
 import {
     weeklySlot, weeklyPlacements, lineLoad, loadColor, shiftColor, statusOf, fmtQty, parseDate, dayList, onLine, chainChipMeta, segmentChain, placementsOf, projectSegment, MONO,
@@ -149,7 +149,10 @@ function WeekBlock({ item, ctx, N, laneH, setPreview }) {
                         <TierDot wo={wo} />
                         <span className="whitespace-nowrap" style={{ fontFamily: MONO, fontSize: 10, fontWeight: 600, color: 'var(--om-ink)' }}>{wo.order_no}</span>
                         {twinMeta && <TwinChip code={twinMeta.code} dir={twinMeta.dir} />}
-                        {wo.is_overdue && <span className="ml-auto" style={{ fontFamily: MONO, fontSize: 8, color: '#fff', background: 'var(--om-blocked)', borderRadius: 3, padding: '0 3px' }}>!</span>}
+                        <span className="ml-auto flex items-center gap-1">
+                            <ShortageChip wo={wo} compact />
+                            {wo.is_overdue && <span style={{ fontFamily: MONO, fontSize: 8, color: '#fff', background: 'var(--om-blocked)', borderRadius: 3, padding: '0 3px' }}>!</span>}
+                        </span>
                     </div>
                     <span className="truncate" style={{ fontSize: 10, color: 'var(--om-muted)' }}>{wo.product_name || '—'} · {fmtQty(wo.planned_qty)}</span>
                 </div>

--- a/backend/resources/js/Pages/admin/schedule/planner/views2.jsx
+++ b/backend/resources/js/Pages/admin/schedule/planner/views2.jsx
@@ -4,7 +4,7 @@
 import { useState, useRef } from 'react';
 import Tooltip from '../../../../components/Tooltip';
 import { __, formatDate, formatTime } from '../../../../lib/i18n';
-import { TwinChip } from './OrderCard';
+import { TwinChip, ShortageChip } from './OrderCard';
 import {
     hourlyLanes, onMonthlyDay, statusOf, parseDate, todayKey, loadColor, chainChipMeta, MONO,
 } from './helpers';
@@ -70,6 +70,7 @@ function HourlyBar({ item, ctx, slotMinutes, laneTop }) {
                         <span style={{ fontFamily: MONO, fontSize: 10, fontWeight: 600, color: 'var(--om-ink)', whiteSpace: 'nowrap' }}>{wo.order_no}</span>
                         {twinMeta && <TwinChip code={twinMeta.code} dir={twinMeta.dir} />}
                         {width > 16 && <span className="truncate" style={{ fontFamily: MONO, fontSize: 9, color: 'var(--om-muted)' }}>{wo.product_name}</span>}
+                        <span className="ml-auto"><ShortageChip wo={wo} compact /></span>
                     </div>
                     <span style={{ fontFamily: MONO, fontSize: 9, fontWeight: 500, color: 'var(--om-muted)', whiteSpace: 'nowrap' }}>{fmtMin(cur.start)}–{fmtMin(cur.end)} · {dur}</span>
                 </div>

--- a/backend/resources/js/Pages/admin/stock-documents/StockDocumentForm.jsx
+++ b/backend/resources/js/Pages/admin/stock-documents/StockDocumentForm.jsx
@@ -70,9 +70,11 @@ export default function StockDocumentForm({
                 notes: line.notes || null,
             }));
 
-        form
-            .transform(() => ({ ...data, lines: payload, ...(stay ? { stay: 1 } : {}) }))
-            .post('/admin/stock-documents', { preserveScroll: stay, onSuccess });
+        // transform() mutates and returns void in Inertia v3 — it can't be chained
+        // with .post() (that threw "transform(...) is undefined", #282). Set it,
+        // then post.
+        form.transform(() => ({ ...data, lines: payload, ...(stay ? { stay: 1 } : {}) }));
+        form.post('/admin/stock-documents', { preserveScroll: stay, onSuccess });
     };
 
     return (

--- a/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
+++ b/backend/resources/js/Pages/operator/WorkOrderDetail.jsx
@@ -1960,7 +1960,7 @@ function EngineeringDocsSection({ docs = [], onView }) {
 // ---------------------------------------------------------------------------
 
 export default function WorkOrderDetail() {
-    const { workOrder, issueTypes = [], scrapReasons = [], workstations = [], issueCustomFields = [], defaultWorkstationId, line, labelTemplates = [], processPhotos = [], stepPhotos = {}, stepMedia = {}, stepChecklists = {}, stepOutputs = {}, engineeringDocuments = [] } = usePage().props;
+    const { workOrder, issueTypes = [], scrapReasons = [], workstations = [], issueCustomFields = [], defaultWorkstationId, line, labelTemplates = [], processPhotos = [], stepPhotos = {}, stepMedia = {}, stepChecklists = {}, stepOutputs = {}, engineeringDocuments = [], materialShortages = [] } = usePage().props;
 
     const [engViewer, setEngViewer] = useState(null); // { url, title } for the sandboxed viewer
 
@@ -2031,6 +2031,28 @@ export default function WorkOrderDetail() {
                         </Link>
                     </div>
                 </div>
+
+                {/* Stock cannot cover this order. Said here, before the operator
+                    starts, rather than surfacing as a failed allocation mid-run.
+                    A subassembly is named as itself — "not enough pleat packs"
+                    is the useful sentence, not the media it is made from. */}
+                {materialShortages.length > 0 && (
+                    <div className="mb-6 rounded-om border border-om-blocked bg-om-blocked-bg px-4 py-3">
+                        <p className="font-medium text-om-blocked text-[13px]">
+                            {__('Not enough material to complete this order')}
+                        </p>
+                        <ul className="mt-2 space-y-1">
+                            {materialShortages.map((m, i) => (
+                                <li key={i} className="font-mono text-[12px] text-om-blocked">
+                                    {m.material_code || m.material_name}
+                                    {m.material_exists
+                                        ? ` · ${__('need')} ${fmtQty(m.required_qty)} · ${__('have')} ${fmtQty(m.available_qty)} · ${__('missing')} ${fmtQty(m.missing_qty)} ${m.unit_of_measure || ''}`
+                                        : ` · ${__('not in stock list')}`}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
 
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                     {/* Main content */}

--- a/backend/tests/Feature/Material/HierarchicalBomTest.php
+++ b/backend/tests/Feature/Material/HierarchicalBomTest.php
@@ -390,6 +390,45 @@ class HierarchicalBomTest extends TestCase
         $this->assertSame(300.0, $required['PART-1160']);
         $this->assertSame(80.0, $required['PART-1110']);
         $this->assertSame(60.0, $required['PART-1200']);
-        $this->assertFalse($required->has('SUBASSEMBLY-1100'));
+
+        // Netting runs level by level, so a subassembly is demand in its own
+        // right and is reported by name — with none in stock the leaves below it
+        // are unchanged.
+        $this->assertSame(20.0, $required['SUBASSEMBLY-1100']);
+        $this->assertSame(60.0, $required['SUBASSEMBLY-1150']);
+    }
+
+    public function test_mrp_nets_a_subassembly_against_its_own_stock_before_exploding(): void
+    {
+        $parent = $this->threeLevelStructure();
+
+        // Twelve of the twenty needed are already on the shelf.
+        Material::where('code', 'SUBASSEMBLY-1100')->update(['stock_quantity' => 12]);
+
+        WorkOrder::factory()->create([
+            'product_type_id' => $parent->product_type_id,
+            'planned_qty' => 10,
+            'status' => WorkOrder::STATUS_PENDING,
+            'due_date' => now()->addDays(3),
+        ]);
+
+        $rows = collect(app(NetRequirementsService::class)
+            ->report(now()->subDay(), now()->addDays(30))['requirements'])
+            ->keyBy('code');
+
+        // Still 20 gross, but only the 8 not covered by stock have to be made.
+        $this->assertSame(20.0, (float) $rows['SUBASSEMBLY-1100']['required_qty']);
+        $this->assertSame(12.0, (float) $rows['SUBASSEMBLY-1100']['available_qty']);
+        $this->assertSame(8.0, (float) $rows['SUBASSEMBLY-1100']['net_qty']);
+        $this->assertTrue($rows['SUBASSEMBLY-1100']['is_short']);
+
+        // Only that shortfall explodes: 8 × 3 = 24 of the next level down, and
+        // 24 × 5 = 120 of its leaf — not the 60 / 300 an ungated explosion gives.
+        $this->assertSame(24.0, (float) $rows['SUBASSEMBLY-1150']['required_qty']);
+        $this->assertSame(120.0, (float) $rows['PART-1160']['required_qty']);
+        $this->assertSame(32.0, (float) $rows['PART-1110']['required_qty']);
+
+        // Components of the parent itself are untouched by the subassembly stock.
+        $this->assertSame(60.0, (float) $rows['PART-1200']['required_qty']);
     }
 }

--- a/backend/tests/Feature/Material/WorkOrderMaterialShortageTest.php
+++ b/backend/tests/Feature/Material/WorkOrderMaterialShortageTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature\Material;
+
+use App\Models\Material;
+use App\Models\MaterialType;
+use App\Models\WorkOrder;
+use App\Services\Material\MaterialAllocationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * "This order cannot be built from stock" — the check behind the planner tile,
+ * the operator's banner and the batch preview.
+ *
+ * It reads the order's own snapshot BOM, so a manufactured subassembly is
+ * reported as itself rather than resolved into the parts it would be made from.
+ * That case used to be invisible until an operator tried to start.
+ */
+class WorkOrderMaterialShortageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private MaterialAllocationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(MaterialAllocationService::class);
+    }
+
+    private function material(string $code, float $stock, bool $manufactured = false): Material
+    {
+        return Material::factory()->create([
+            'code' => $code,
+            'material_type_id' => MaterialType::factory()->create()->id,
+            'unit_of_measure' => 'pcs',
+            'is_manufactured' => $manufactured,
+            'stock_quantity' => $stock,
+            'reserved_quantity' => 0,
+        ]);
+    }
+
+    /** A work order whose snapshot names the given components. */
+    private function order(array $bom, float $plannedQty = 100): WorkOrder
+    {
+        return WorkOrder::factory()->create([
+            'planned_qty' => $plannedQty,
+            'status' => WorkOrder::STATUS_PENDING,
+            'process_snapshot' => ['bom' => $bom],
+        ]);
+    }
+
+    private function line(Material $material, float $perUnit, float $scrap = 0): array
+    {
+        return [
+            'material_id' => $material->id,
+            'material_code' => $material->code,
+            'material_name' => $material->name,
+            'unit_of_measure' => $material->unit_of_measure,
+            'quantity_per_unit' => $perUnit,
+            'scrap_percentage' => $scrap,
+            'consumed_at' => 'start',
+        ];
+    }
+
+    public function test_an_order_covered_by_stock_reports_no_shortage(): void
+    {
+        $part = $this->material('PART', 500);
+        $order = $this->order([$this->line($part, 2)]);
+
+        $this->assertSame([], $this->service->shortagesForWorkOrders(collect([$order])));
+    }
+
+    public function test_a_subassembly_that_runs_out_is_reported_by_name(): void
+    {
+        // 100 units × 1 pack, 2% scrap = 102 needed, 40 on the shelf.
+        $pack = $this->material('PLEATPACK', 40, manufactured: true);
+        $order = $this->order([$this->line($pack, 1, 2)]);
+
+        $short = $this->service->shortagesForWorkOrders(collect([$order]))[$order->id] ?? null;
+
+        $this->assertNotNull($short, 'The order should be flagged.');
+        $this->assertCount(1, $short);
+        $this->assertSame('PLEATPACK', $short[0]['material_code']);
+        $this->assertSame(102.0, $short[0]['required_qty']);
+        $this->assertSame(40.0, $short[0]['available_qty']);
+        $this->assertSame(62.0, $short[0]['missing_qty']);
+    }
+
+    public function test_reserved_stock_does_not_count_as_available(): void
+    {
+        $part = $this->material('PART', 150);
+        $part->update(['reserved_quantity' => 100]);
+
+        $order = $this->order([$this->line($part, 1)]);
+
+        $short = $this->service->shortagesForWorkOrders(collect([$order]))[$order->id] ?? null;
+
+        // 150 on hand, 100 already spoken for → only 50 free against 100 needed.
+        $this->assertNotNull($short);
+        $this->assertSame(50.0, $short[0]['available_qty']);
+        $this->assertSame(50.0, $short[0]['missing_qty']);
+    }
+
+    public function test_a_bom_line_whose_material_is_gone_is_flagged_not_skipped(): void
+    {
+        $order = $this->order([[
+            'material_code' => 'DELETED-PART',
+            'material_name' => 'Deleted part',
+            'quantity_per_unit' => 1,
+            'scrap_percentage' => 0,
+            'consumed_at' => 'start',
+        ]]);
+
+        $short = $this->service->shortagesForWorkOrders(collect([$order]))[$order->id] ?? null;
+
+        $this->assertNotNull($short);
+        $this->assertFalse($short[0]['material_exists']);
+    }
+
+    public function test_orders_are_measured_independently_not_netted_against_each_other(): void
+    {
+        // Enough for either order alone, not for both — each is still "can run".
+        $part = $this->material('PART', 100);
+        $a = $this->order([$this->line($part, 1)], 100);
+        $b = $this->order([$this->line($part, 1)], 100);
+
+        $this->assertSame([], $this->service->shortagesForWorkOrders(collect([$a, $b])));
+    }
+
+    public function test_an_order_without_a_snapshot_bom_is_not_flagged(): void
+    {
+        $order = WorkOrder::factory()->create([
+            'planned_qty' => 10,
+            'status' => WorkOrder::STATUS_PENDING,
+            'process_snapshot' => ['steps' => []],
+        ]);
+
+        $this->assertSame([], $this->service->shortagesForWorkOrders(collect([$order])));
+    }
+}


### PR DESCRIPTION
Dwa powiązane wątki: uzupełnienie zestawu demo do stanu, w którym każdy ekran ma co pokazać, oraz — co z tego wynikło — domknięcie realnej luki w MRP.

> **Stos PR-ów:** zawiera commit z #285 (fix #282), bo gałąź wyrasta z punktu, w którym był już zmergowany lokalnie. Po zmergowaniu #285 ten diff sam się skurczy. Kolejność: **#285 → ten**.

---

## 1. Braki półproduktów były niewidoczne

Nic nie mówiło „nie starczy pakietów plisowanych na to zlecenie".

- **Raport Net Requirements** rozwijał BOM *przez* półprodukt aż do surowców — półprodukt nigdy się nie pojawiał, a jego stan magazynowy był ignorowany. Kod sam to dokumentował: *„netting a manufactured item against its own stock is a separate MRP concern"*.
- **Sprawdzenie per zlecenie**, które poprawnie obejmowało półprodukt, istniało wyłącznie jako endpoint API — żaden ekran go nie wołał (`grep` po `resources/js` = zero trafień).

### Co się zmieniło

**MRP netuje poziom po poziomie.** Zapotrzebowanie na półprodukt jest najpierw zaspokajane z jego własnego stanu, a w dół rozwija się tylko niedobór:

```
[SUB] PLEATPACK13   req=775,2   avail=260   net=515,2   SHORT
      MEDIA-H13     req=2036,5  (było 2691,65)
```

Media spadły dokładnie o `260 × 2,52 = 655,2` — o tyle, ile nie trzeba kupować, bo pakiety leżą na półce.

**Planer** oznacza zlecenia nie do wykonania chipem `MAT` z tooltipem nazywającym brakujące komponenty (widok tygodniowy, dzienny, godzinowy, backlog).

**Ekran operatora** prowadzi banerem: *„Za mało materiału, aby wykonać to zlecenie — PLEATPACK13 · potrzeba 255 · jest 100 · brakuje 155 pcs"* — przed startem, zamiast jako nieudana alokacja w trakcie.

Wspólny prymityw `shortagesForWorkOrders()` robi **jedno zapytanie na całą tablicę** planera, bez N+1.

### Świadome ograniczenie

Planer i baner mierzą **każde zlecenie osobno** — odpowiadają na „czy to zlecenie da się dziś uruchomić", nie „czy starczy na tydzień". Dwa zlecenia po 100 szt. przy stanie 100 oba wyjdą na zielono. Od pytania tygodniowego jest raport Net Requirements, który agreguje popyt. Rozdzieliłem to celowo — mieszanie tych semantyk w jednym wskaźniku myli.

---

## 2. Dane demo

Zestaw demo był jednodniową migawką z dużymi dziurami. Teraz:

- **Zgłoszenia operatorów** — 5, po jednym na każdy stan cyklu życia
- **Marszruty** — każdy wyrób ma szablon procesu (wcześniej tylko HEPA-13; pozostałe pokazywały „0 templates" mimo posiadanych zleceń). Snapshot na zleceniu idzie teraz przez `toSnapshot()`, więc niesie kroki **i** BOM — wcześniej ręcznie sklejany nagłówek nie niósł ani jednego, przez co operator nie miał czego wykonywać
- **BOM dla każdej marszruty** — 25 pozycji, w tym dwupoziomowy HEPA-13 z półproduktem (pakiet plisowany ma własną marszrutę i BOM)
- **Partie materiałowe** — 15, pokrywają wszystkie 6 statusów (w tym kwarantanna, odrzucona, przeterminowana obok żywego zamiennika)
- **Zmiany robocze** — nie było **żadnej**, przez co planer i shift monitor generowały syntetyczne okno. Teraz pokrycie całodobowe
- **Maintenance w planerze** — narzędzia, 3 harmonogramy cykliczne, 9 zdarzeń; zdarzenie „w toku" to druga strona zaseedowanego zgłoszenia o prasie węglowej
- **Shift monitor** — był całkowicie martwy. Teraz 43 zmiany na stanowisko wstecz przez 2 tygodnie: oś stanów, licznik pcs/min, nieopisane stopy do sklasyfikowania
- **Horyzont 2 tygodni** — zlecenia i maintenance w przód, historia wykonania wstecz

**Kierunki są rozdzielone celowo:** plan w przód, wykonanie wstecz. Shift monitor rysuje to, co maszyny faktycznie zrobiły — generowanie „produkcji" na przyszłe daty dałoby dane wprost fałszywe.

---

## Naprawione przy okazji

- **Seeder mógł wskrzeszać usunięte kroki marszruty** — zapisywał je przez `updateOrInsert()` z query buildera, który omija scope soft-delete. Dopasowanie trafiało w skasowany wiersz i aktualizowało go zamiast wstawić żywy. Warunek dostał `deleted_at IS NULL`.
- Dwa błędy ujawnione przez przejście shift monitora na wiele dni: zapis od najstarszej zmiany (`clear()` kasuje wszystko od danego okna wzwyż, więc szło od najnowszej wycierało już zapisaną historię) oraz zamykanie ostatniego stanu zakończonej zmiany.

## Weryfikacja

- **Gate: 2705 testów** zielonych
- **6 nowych testów** dla wykrywania braków: półprodukt po nazwie, rezerwacje nieliczone jako dostępne, usunięty materiał flagowany, zlecenia mierzone niezależnie
- **Zaktualizowany istniejący test**, który wprost asertował stare zachowanie (`assertFalse($required->has('SUBASSEMBLY-1100'))`), plus nowy test netowania: 12 z 20 na stanie → w dół eksploduje tylko 8 (24 zamiast 60, 120 zamiast 300)
- i18n en/pl parytet 5975/5975, zmiany czysto addytywne
- Wszystkie seedery idempotentne — zweryfikowane wielokrotnym uruchomieniem
- Wszystko sprawdzone klikalnie na czystym stacku Dockera