### PR TITLE
fix: seed the whole reference set on install + clear commonmark advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **A fresh install came up missing most of its reference data** — both install paths (the
+  container entrypoint and the web installer) seeded a hand-picked subset of `DatabaseSeeder`
+  rather than running it, so a new install had no scrap reasons, no downtime reasons, no
+  material types and no label templates. The operator's "report scrap" picker was an empty
+  dropdown out of the box. Both paths now run `DatabaseSeeder`; every seeder in it upserts,
+  so it stays safe to repeat on each container start.
+
+### Security
+- **Upgraded `league/commonmark` 2.8.3 → 2.10.1**, clearing ten advisories (several high) on
+  the copy pulled in through `laravel/framework`. OpenMES does not render Markdown itself, so
+  exposure was limited to Laravel's own mail templates — but `composer audit` is a merge gate
+  and it now reports clean.
+
 ### Added
 - **A shortage of a manufactured subassembly is now reported as such** — previously nothing
   said "not enough pleat packs to build this order". The net-requirements report exploded

--- a/backend/app/Http/Controllers/InstallController.php
+++ b/backend/app/Http/Controllers/InstallController.php
@@ -114,10 +114,9 @@ class InstallController extends Controller
                 ->with('error', 'Preconfigured database is not reachable. Check the server logs for details.');
         }
 
-        // Idempotent: `migrate` skips applied migrations, both seeders upsert.
+        // Idempotent: `migrate` skips applied migrations, every seeder upserts.
         Artisan::call('migrate', ['--force' => true]);
-        Artisan::call('db:seed', ['--class' => 'RolesAndPermissionsSeeder', '--force' => true]);
-        Artisan::call('db:seed', ['--class' => 'IssueTypesSeeder', '--force' => true]);
+        Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
 
         // Joining an existing main database (e.g. desktop client pointed at a
         // central server's DB): accounts already exist, so there is nothing to
@@ -334,8 +333,10 @@ class InstallController extends Controller
             return back()->withErrors(['migration' => 'Migration failed: '.$e->getMessage()]);
         }
 
-        Artisan::call('db:seed', ['--class' => 'RolesAndPermissionsSeeder', '--force' => true]);
-        Artisan::call('db:seed', ['--class' => 'IssueTypesSeeder', '--force' => true]);
+        // The whole reference set, not just roles and issue types — a fresh
+        // install otherwise starts with no scrap or downtime reasons, no
+        // material types and no label templates.
+        Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
 
         // The plant timezone picked in step 1, now that there is a table to put it
         // in. This is the copy the application actually reads — on Docker the

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -2833,16 +2833,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "9d489ab67a02960fd8ffe624d93f751daf95439e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/9d489ab67a02960fd8ffe624d93f751daf95439e",
+                "reference": "9d489ab67a02960fd8ffe624d93f751daf95439e",
                 "shasum": ""
             },
             "require": {
@@ -2879,7 +2879,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -2936,7 +2936,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-09-07T13:44:26+00:00"
         },
         {
             "name": "league/config",

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -59,10 +59,13 @@ if [ "$IS_PRIMARY" = "1" ]; then
     php artisan migrate --force
 
     # ── Seeders (idempotent) ─────────────────────────────────────────────────
+    # DatabaseSeeder, not a hand-picked subset: it already lists exactly the
+    # reference data a usable install needs, and every child upserts, so running
+    # it on each start is safe. Naming three of the eight here is what left a
+    # fresh install with no scrap reasons (the operator's "report scrap" picker
+    # was empty), no downtime reasons, no material types and no label templates.
     echo "[OpenMES] Running seeders..."
-    php artisan db:seed --class=RolesAndPermissionsSeeder --force
-    php artisan db:seed --class=IssueTypesSeeder --force
-    php artisan db:seed --class=LineStatusSeeder --force
+    php artisan db:seed --class=DatabaseSeeder --force
 
     # Reset the Spatie permission cache so the freshly-seeded roles/permissions
     # are authoritative. Without this an upgrade can keep serving a stale cached

--- a/backend/tests/Feature/Seeders/DatabaseSeederTest.php
+++ b/backend/tests/Feature/Seeders/DatabaseSeederTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\DowntimeReason;
+use App\Models\IssueType;
+use App\Models\LabelTemplate;
+use App\Models\LineStatus;
+use App\Models\MaterialType;
+use App\Models\ScrapReason;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The reference data a fresh install needs before anyone can use it.
+ *
+ * Regression guard: the installer used to run three hand-picked seeders instead
+ * of this one, so a new install came up with no scrap or downtime reasons, no
+ * material types and no label templates — the operator's "report scrap" picker
+ * was an empty dropdown. Both install paths now call DatabaseSeeder, and it runs
+ * on every container start, so it also has to be safe to repeat.
+ */
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array<string, int> */
+    private function counts(): array
+    {
+        return [
+            'roles' => Role::count(),
+            'issue_types' => IssueType::count(),
+            'line_statuses' => LineStatus::count(),
+            'material_types' => MaterialType::count(),
+            'downtime_reasons' => DowntimeReason::count(),
+            'scrap_reasons' => ScrapReason::count(),
+            'label_templates' => LabelTemplate::count(),
+        ];
+    }
+
+    public function test_it_seeds_every_reference_set_a_fresh_install_needs(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        foreach ($this->counts() as $what => $count) {
+            $this->assertGreaterThan(0, $count, "A fresh install must have {$what}.");
+        }
+    }
+
+    public function test_the_operator_facing_pickers_are_not_empty(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        // These two feed dropdowns an operator has to choose from to report
+        // scrap or classify a stop; empty means the flow cannot be completed.
+        $this->assertGreaterThan(0, ScrapReason::active()->count());
+        $this->assertGreaterThan(0, DowntimeReason::where('is_active', true)->count());
+    }
+
+    public function test_both_install_paths_actually_call_it(): void
+    {
+        // The bug was never in this seeder — it was that nothing invoked it.
+        // The Docker entrypoint is a shell script and the web installer shells
+        // out through Artisan, so neither is reachable from a normal test; the
+        // invariant worth pinning is simply that both still name it.
+        $entrypoint = file_get_contents(base_path('docker-entrypoint.sh'));
+        $installer = file_get_contents(app_path('Http/Controllers/InstallController.php'));
+
+        $this->assertStringContainsString(
+            'db:seed --class=DatabaseSeeder',
+            $entrypoint,
+            'The container entrypoint must seed the full reference set, not a hand-picked subset.',
+        );
+        $this->assertStringContainsString(
+            "'--class' => 'DatabaseSeeder'",
+            $installer,
+            'The web installer must seed the full reference set, not a hand-picked subset.',
+        );
+    }
+
+    public function test_running_it_again_changes_nothing(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $first = $this->counts();
+
+        // The container entrypoint runs this on every boot, so a repeat must not
+        // duplicate rows or fail on a unique index.
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame($first, $this->counts());
+    }
+}


### PR DESCRIPTION
Dwie poprawki przed release, obie wyszły z testów całego developa.

---

## 1. Świeża instalacja startowała bez większości danych referencyjnych

Oba ścieżki instalacji — entrypoint kontenera i instalator webowy — wołały **trzy z ośmiu** seederów wymienionych w `DatabaseSeeder`, zamiast uruchomić go w całości.

Skutek na czystej instalacji:

```
ScrapReason     = 0   ← operator zgłaszający braki miał PUSTĄ listę powodów
DowntimeReason  = 0   ← nie było czym sklasyfikować przestoju
MaterialType    = 0
LabelTemplate   = 0
```

Pierwsza pozycja to realny blocker przepływu: operatora nie da się przeprowadzić przez zgłoszenie braków, bo dropdown jest pusty.

### Poprawka

Obie ścieżki wołają teraz `DatabaseSeeder`. Każdy seeder w nim robi upsert (`firstOrCreate` / `updateOrCreate` / `updateOrInsert`), więc uruchamianie przy każdym starcie kontenera pozostaje bezpieczne — sprawdziłem to osobno.

### Weryfikacja na instalacji od zera

Postawiłem stack z wyczyszczonymi wolumenami. Wszystkie osiem seederów wystartowało:

```
RolesAndPermissionsSeeder ... DONE      ViewTemplateSeeder ......... DONE
IssueTypesSeeder ............ DONE      MaterialTypesSeeder ........ DONE
LineStatusSeeder ............ DONE      DowntimeReasonsSeeder ...... DONE
                                        ScrapReasonsSeeder ......... DONE
                                        LabelTemplatesSeeder ....... DONE
```

| | przed | po |
|---|---|---|
| ScrapReason | 0 | **5** |
| DowntimeReason | 0 | **10** |
| MaterialType | 0 | **4** |
| LabelTemplate | 0 | **4** |

Po restarcie kontenera **wszystkie liczniki bez zmian** — brak duplikatów, brak naruszeń unique.

---

## 2. `league/commonmark` 2.8.3 → 2.10.1

`composer audit` zgłaszał **dziesięć podatności, kilka HIGH**, na kopii wciąganej przechodnio przez `laravel/framework (^2.8.1)`.

OpenMES nigdzie nie renderuje Markdownu samodzielnie (`grep` po `Str::markdown`/CommonMark = zero trafień w core), więc ekspozycja ograniczała się do własnych szablonów mailowych Laravela. Ale `composer audit` jest bramką mergeową z checklisty w CLAUDE.md i wywalał się na każdej gałęzi.

Ograniczenie Laravela już dopuszczało 2.10.x, więc to podbicie samego lock-a — `composer.lock` zmienia się o 6 linii, żaden inny pakiet nie rusza.

```
composer audit  →  No security vulnerability advisories found.
```

---

## Testy

Nowy `DatabaseSeederTest` (4 przypadki):

- zestaw referencyjny jest kompletny po zaseedowaniu,
- **listy, z których wybiera operator, nie są puste** — to jest ten regres,
- **obie ścieżki instalacji faktycznie wołają `DatabaseSeeder`** — bo błąd nigdy nie leżał w samym seederze, tylko w tym, że nikt go nie uruchamiał; entrypoint to skrypt shellowy, a instalator woła Artisana, więc jedyny sensowny do przypięcia niezmiennik to fakt, że obie go nazywają,
- ponowne uruchomienie niczego nie zmienia.

**Gate: 2709 testów zielonych** (2704 + 5 nowych asercji), `composer audit` czysty.